### PR TITLE
Persist repository URL in project settings

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -4,46 +4,46 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.config.CodyProjectSettings
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
+class CodyAgentCodebase(private val underlying: CodyAgentServer, private val project: Project) {
 
-  // TODO: This should ideally be persisted as a project-wide setting. Down the road, it should also
-  // support a list of repository names instead of only a single codebase.
-  private var inferredCodebase: String = ""
-  private var explicitCodebase: String = ""
+  // TODO: Support list of repository names instead of just one.
+  private val application = ApplicationManager.getApplication()
+  private val settings = CodyProjectSettings.getInstance(project)
 
   init {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, null))
+    application.executeOnPooledThread {
+      onRepositoryNameChanged(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, null))
     }
   }
 
-  fun onNewExplicitCodebase(codebase: String) {
-    explicitCodebase = codebase
+  fun setUrl(url: String) {
+    settings.remoteUrl = url
     onPropagateConfiguration()
   }
 
-  fun currentCodebase(): String? = explicitCodebase.ifEmpty { inferredCodebase }.ifEmpty { null }
+  fun getUrl(): String? = settings.remoteUrl
 
   fun onFileOpened(project: Project, file: VirtualFile) {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, file))
+    application.executeOnPooledThread {
+      onRepositoryNameChanged(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, file))
+    }
+  }
+
+  private fun onRepositoryNameChanged(url: String?) {
+    application.invokeLater {
+      if (url != null) {
+        settings.remoteUrl = url
+        onPropagateConfiguration()
+      }
     }
   }
 
   private fun onPropagateConfiguration() {
     CodyToolWindowContent.getInstance(project).embeddingStatusView.updateEmbeddingStatus()
     underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
-  }
-
-  private fun onRepositoryName(repositoryName: String?) {
-    ApplicationManager.getApplication().invokeLater {
-      if (repositoryName != null && inferredCodebase != repositoryName) {
-        inferredCodebase = repositoryName
-        onPropagateConfiguration()
-      }
-    }
   }
 }

--- a/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -54,7 +54,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
 
   fun updateEmbeddingStatus() {
     val client = CodyAgent.getClient(project)
-    val repoName = client.codebase?.currentCodebase()
+    val repoName = client.codebase?.getUrl()
     if (repoName == null) {
       setEmbeddingStatus(NoGitRepositoryEmbeddingStatus())
     } else {

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -27,8 +27,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
   private val currentIndicator: AtomicReference<ProgressIndicator> = AtomicReference()
 
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
-    val gitURL =
-        ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+    val gitURL = ExtendableTextField(CodyAgent.getClient(project).codebase?.getUrl() ?: "", 40)
     val loadingLayerUI = LoadingLayerUI()
     val layeredGitURL = JLayer(gitURL, loadingLayerUI)
 
@@ -93,7 +92,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
     }
 
     override fun doOKAction() {
-      CodyAgent.getClient(project).codebase?.onNewExplicitCodebase(gitURL.text)
+      CodyAgent.getClient(project).codebase?.setUrl(gitURL.text)
       super.doOKAction()
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
@@ -13,6 +13,7 @@ import com.sourcegraph.find.Search
 @Service(Service.Level.PROJECT)
 data class CodyProjectSettings(
     var defaultBranchName: String = "main",
+    var remoteUrl: String? = null,
     var remoteUrlReplacements: String = "",
     var lastSearchQuery: String? = null,
     var lastSearchCaseSensitive: Boolean = false,
@@ -23,6 +24,7 @@ data class CodyProjectSettings(
 
   override fun loadState(state: CodyProjectSettings) {
     this.defaultBranchName = state.defaultBranchName
+    this.remoteUrl = state.remoteUrl
     this.remoteUrlReplacements = state.remoteUrlReplacements
     this.lastSearchQuery = state.lastSearchQuery
     this.lastSearchCaseSensitive = state.lastSearchCaseSensitive

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -43,7 +43,7 @@ object ConfigUtil {
             autocompleteAdvancedEmbeddings = UserLevelConfig.getAutocompleteAdvancedEmbeddings(),
             debug = isCodyDebugEnabled(),
             verboseDebug = isCodyVerboseDebugEnabled(),
-            codebase = codyAgentCodebase?.currentCodebase(),
+            codebase = codyAgentCodebase?.getUrl(),
         )
 
     UserLevelConfig.getAutocompleteProviderType()?.let {


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/56948

Additionally: I've removed the line stating that leaving the address empty would result in an inferred URL from the Git repository. This statement is not true: the dialog does not allow you to leave it blank.

## Test plan

- `./gradlew :runIde`
- Open project.
- (optional) Expect new value `<option name="remoteUrl" value="github.com/user/repo"/>` in `.idea/cody_project_settings.xml`.
- Open repository dialog. Change address and click OK.
- Restart IDE.
- Verify that the repository address remains the same as it was before the restart.