### PR TITLE
Add update channel setting

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.config
 
+import com.sourcegraph.cody.config.ui.UpdateChannel
 import java.awt.Color
 
 data class SettingsModel(
@@ -13,4 +14,5 @@ data class SettingsModel(
     var customAutocompleteColor: Color? = null,
     var blacklistedLanguageIds: List<String> = listOf(),
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
+    var channel: UpdateChannel = UpdateChannel.Stable
 )

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.updateSettings.impl.UpdateSettings
 import com.intellij.ui.ColorPanel
 import com.intellij.ui.JBColor
+import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
@@ -59,7 +60,9 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
       group("Plugin") {
         row {
           label("Update channel:")
-          comboBox(UpdateChannel.values().toList())
+          comboBox(
+                  UpdateChannel.values().toList(),
+                  SimpleListCellRenderer.create("") { it.presentableText })
               .bindItem(settingsModel::channel.toNullableProperty())
         }
       }

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/UpdateChannel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/UpdateChannel.kt
@@ -9,7 +9,7 @@ enum class UpdateChannel(val channelUrl: String?) : PresentableEnum {
   override fun getPresentableText(): String {
     return when (this) {
       Stable -> "Stable"
-      Alpha -> "Alpha"
+      Alpha -> "Nightly"
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/UpdateChannel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/UpdateChannel.kt
@@ -1,0 +1,15 @@
+package com.sourcegraph.cody.config.ui
+
+import com.intellij.util.ui.PresentableEnum
+
+enum class UpdateChannel(val channelUrl: String?) : PresentableEnum {
+  Stable(null as String?),
+  Alpha("https://plugins.jetbrains.com/plugins/alpha/9682");
+
+  override fun getPresentableText(): String {
+    return when (this) {
+      Stable -> "Stable"
+      Alpha -> "Alpha"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the update channel setting to make it easier to use the Alpha channel.

<img width="916" alt="image" src="https://github.com/sourcegraph/jetbrains/assets/19799111/fa0da0bb-e2c0-4714-abe3-f41caece9f8a">


## Test plan

### Manual

1. `runIde`
2. go to Settings / Plugins / gaer icon / Manage plugin repositories
3. verify there are no repositories
4. go to Settings / Tools / Sourcegraph & Cody / Cody
5. Switch Update channel to Alpha
6. go to Settings / Plugins / gaer icon / Manage plugin repositories
7. verify there is alpha repository added
8. go to Settings / Tools / Sourcegraph & Cody / Cody
9. Switch Update channel back to Stable
10. go to Settings / Plugins / gaer icon / Manage plugin repositories
11. verify there are no repositories

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
