### PR TITLE
Prevent auto-scroll in chat while reading previous messages

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/ChatScrollPane.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/ChatScrollPane.kt
@@ -1,42 +1,38 @@
 package com.sourcegraph.cody.ui
 
 import com.intellij.ui.components.JBScrollPane
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
-import java.util.concurrent.atomic.AtomicBoolean
+import com.intellij.ui.components.JBViewport
+import java.awt.Point
+import java.awt.Rectangle
 import javax.swing.BorderFactory
 import javax.swing.JPanel
-import javax.swing.JScrollBar
+import kotlin.math.max
 
-class ChatScrollPane(messagesPanel: JPanel?) :
+class ChatScrollPane(private val messagesPanel: JPanel) :
     JBScrollPane(messagesPanel, VERTICAL_SCROLLBAR_AS_NEEDED, HORIZONTAL_SCROLLBAR_NEVER) {
-  private val wasMouseWheelScrolled = AtomicBoolean(false)
-  private val wasScrollBarDragged = AtomicBoolean(false)
+
+  private var touchingBottom = false
 
   init {
-    setBorder(BorderFactory.createEmptyBorder())
-    // this hack allows us to guess if an adjustment event isn't caused by the user mouse wheel
-    // scrolling and drag scrolling;
-    // we need to do that, as AdjustmentEvent doesn't account for the mouse wheel/drag scroll,
-    // and we don't want to rob the user of those
-    addMouseWheelListener { wasMouseWheelScrolled.set(true) }
-    // Scroll all the way down after each message
-    val chatPanelVerticalScrollBar = getVerticalScrollBar()
-    chatPanelVerticalScrollBar.addMouseListener(
-        object : MouseAdapter() {
-          override fun mousePressed(e: MouseEvent) = wasScrollBarDragged.set(true)
-
-          override fun mouseReleased(e: MouseEvent) = wasScrollBarDragged.set(false)
-        })
-    chatPanelVerticalScrollBar.addAdjustmentListener {
-      (it.source as? JScrollBar)?.model?.let { brm ->
-        if (!brm.valueIsAdjusting &&
-            !wasMouseWheelScrolled.getAndSet(false) &&
-            !wasScrollBarDragged.getAndSet(false) &&
-            brm.value + brm.extent != brm.maximum) {
-          brm.value = brm.maximum
-        }
-      }
+    border = BorderFactory.createEmptyBorder()
+    verticalScrollBar.addAdjustmentListener { change ->
+      val distance = change.value - verticalScrollBar.maximum + verticalScrollBar.visibleAmount
+      touchingBottom = distance == 0
     }
+    setViewport(
+        object : JBViewport() {
+
+          override fun scrollRectToVisible(bounds: Rectangle?) {}
+
+          override fun setViewPosition(point: Point) {
+            if (touchingBottom) {
+              val maxHeight = max(0, messagesPanel.height - height)
+              super.setViewPosition(Point(0, maxHeight))
+            } else {
+              super.setViewPosition(point)
+            }
+          }
+        })
+    setViewportView(messagesPanel)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/56494

## Test plan

1. Run IDE
1. Send a chat message and wait for a response.
1. Expectation: The panel scrolls automatically to the bottom, and the message is visible.
1. Scroll up (use mouse scroll or drag the vertical scroll bar).
1. Send a chat message again.
1. Play with the scroll (mouse/drag) while tokens are generated.
1. Expectation: Visible messages do not stutter, and scrolling is smooth.
1. Scroll all the way down.
1. Send another message.
1. Expectation: The panel scrolls automatically.

## Demo

![Peek 2023-10-11 20-30](https://github.com/sourcegraph/jetbrains/assets/5013708/9d12ac17-066c-4737-81b6-d87aa083fff6)
