### PR TITLE
Fix chat/autocomplete for projects with space characters in the file path

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -20,7 +20,6 @@ import com.sourcegraph.config.ConfigUtil
 import java.io.File
 import java.io.IOException
 import java.io.PrintWriter
-import java.net.URI
 import java.nio.file.*
 import java.util.*
 import java.util.concurrent.CompletableFuture
@@ -72,7 +71,7 @@ class CodyAgent(private val project: Project) : Disposable {
                       ClientInfo(
                           name = "JetBrains",
                           version = ConfigUtil.getPluginVersion(),
-                          workspaceRootUri = URI("file://${ConfigUtil.getWorkspaceRoot(project)}"),
+                          workspaceRootUri = ConfigUtil.getWorkspaceRootPath(project).toUri(),
                           extensionConfiguration = ConfigUtil.getAgentConfiguration(project)))
                   .get()
           logger.info("connected to Cody agent " + info.name)

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -16,6 +16,8 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ServerAuthLoader
 import com.sourcegraph.cody.config.SourcegraphServerPath
 import com.sourcegraph.cody.config.SourcegraphServerPath.Companion.from
+import java.nio.file.Path
+import java.nio.file.Paths
 import java.util.*
 import java.util.stream.Collectors
 import org.jetbrains.annotations.Contract
@@ -110,6 +112,11 @@ object ConfigUtil {
 
   @JvmStatic
   fun getCustomAutocompleteColor(): Int? = CodyApplicationSettings.instance.customAutocompleteColor
+
+  @JvmStatic
+  fun getWorkspaceRootPath(project: Project): Path {
+    return Paths.get(getWorkspaceRoot(project))
+  }
 
   @JvmStatic
   fun getWorkspaceRoot(project: Project): String {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/57532

Previously, we manually constructed URIs from file paths, which could lead to a crash during agent initialization when the project path had a space character in it. This PR fixes the problem by using `Path.toUri` instead.

## Test plan

I added a test case to demonstrate that `nio.Path.toUri` doesn't crash on paths with space characters. I tried to use `BasePlatformTestCase` to create a `Project` with a space character in the `basePath` but I couldn't figure out how to create a new `Project`.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
