### PR TITLE
JetBrains: remove autocomplete embeddings setting 

### DIFF
--- a/src/main/java/com/sourcegraph/config/UserLevelConfig.java
+++ b/src/main/java/com/sourcegraph/config/UserLevelConfig.java
@@ -33,12 +33,6 @@ public class UserLevelConfig {
         .orElse(null);
   }
 
-  public static boolean getAutocompleteAdvancedEmbeddings() {
-    Properties properties = readProperties();
-    return Boolean.parseBoolean(
-        properties.getProperty("cody.autocomplete.advanced.embeddings", "true"));
-  }
-
   /**
    * Overrides the server endpoint used for generating autocomplete suggestions. This is only
    * supported with the `unstable-codegen` provider right now.

--- a/src/main/kotlin/com/sourcegraph/cody/agent/ExtensionConfiguration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/ExtensionConfiguration.kt
@@ -8,7 +8,6 @@ data class ExtensionConfiguration(
     var autocompleteAdvancedProvider: String? = null,
     var autocompleteAdvancedServerEndpoint: String? = null,
     var autocompleteAdvancedAccessToken: String? = null,
-    var autocompleteAdvancedEmbeddings: Boolean = false,
     var debug: Boolean? = false,
     var verboseDebug: Boolean? = false,
     var codebase: String? = null

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -42,7 +42,6 @@ object ConfigUtil {
             proxy = UserLevelConfig.getProxy(),
             autocompleteAdvancedServerEndpoint = UserLevelConfig.getAutocompleteServerEndpoint(),
             autocompleteAdvancedAccessToken = UserLevelConfig.getAutocompleteAccessToken(),
-            autocompleteAdvancedEmbeddings = UserLevelConfig.getAutocompleteAdvancedEmbeddings(),
             debug = isCodyDebugEnabled(),
             verboseDebug = isCodyVerboseDebugEnabled(),
             codebase = codyAgentCodebase?.getUrl(),


### PR DESCRIPTION
As of https://github.com/sourcegraph/cody/pull/1308 `cody.autocomplete.advanced.embeddings` is no longer a valid setting.  Removing from JetBrains extension.

## Test plan
`./gradlew :runIDE`
Verify chat and autocomplete work

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
