### PR TITLE
Revert "Persist repository URL in project settings (#6)"

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -4,46 +4,46 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.CodyToolWindowContent
-import com.sourcegraph.cody.config.CodyProjectSettings
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, private val project: Project) {
+class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
 
-  // TODO: Support list of repository names instead of just one.
-  private val application = ApplicationManager.getApplication()
-  private val settings = CodyProjectSettings.getInstance(project)
+  // TODO: This should ideally be persisted as a project-wide setting. Down the road, it should also
+  // support a list of repository names instead of only a single codebase.
+  private var inferredCodebase: String = ""
+  private var explicitCodebase: String = ""
 
   init {
-    application.executeOnPooledThread {
-      onRepositoryNameChanged(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, null))
+    ApplicationManager.getApplication().executeOnPooledThread {
+      onRepositoryName(RepoUtil.findRepositoryName(project, null))
     }
   }
 
-  fun setUrl(url: String) {
-    settings.remoteUrl = url
+  fun onNewExplicitCodebase(codebase: String) {
+    explicitCodebase = codebase
     onPropagateConfiguration()
   }
 
-  fun getUrl(): String? = settings.remoteUrl
+  fun currentCodebase(): String? = explicitCodebase.ifEmpty { inferredCodebase }.ifEmpty { null }
 
   fun onFileOpened(project: Project, file: VirtualFile) {
-    application.executeOnPooledThread {
-      onRepositoryNameChanged(settings.remoteUrl ?: RepoUtil.findRepositoryName(project, file))
-    }
-  }
-
-  private fun onRepositoryNameChanged(url: String?) {
-    application.invokeLater {
-      if (url != null) {
-        settings.remoteUrl = url
-        onPropagateConfiguration()
-      }
+    ApplicationManager.getApplication().executeOnPooledThread {
+      onRepositoryName(RepoUtil.findRepositoryName(project, file))
     }
   }
 
   private fun onPropagateConfiguration() {
     CodyToolWindowContent.getInstance(project).embeddingStatusView.updateEmbeddingStatus()
     underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
+  }
+
+  private fun onRepositoryName(repositoryName: String?) {
+    ApplicationManager.getApplication().invokeLater {
+      if (repositoryName != null && inferredCodebase != repositoryName) {
+        inferredCodebase = repositoryName
+        onPropagateConfiguration()
+      }
+    }
   }
 }

--- a/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -54,7 +54,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
 
   fun updateEmbeddingStatus() {
     val client = CodyAgent.getClient(project)
-    val repoName = client.codebase?.getUrl()
+    val repoName = client.codebase?.currentCodebase()
     if (repoName == null) {
       setEmbeddingStatus(NoGitRepositoryEmbeddingStatus())
     } else {

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -27,7 +27,8 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
   private val currentIndicator: AtomicReference<ProgressIndicator> = AtomicReference()
 
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
-    val gitURL = ExtendableTextField(CodyAgent.getClient(project).codebase?.getUrl() ?: "", 40)
+    val gitURL =
+        ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
     val loadingLayerUI = LoadingLayerUI()
     val layeredGitURL = JLayer(gitURL, loadingLayerUI)
 
@@ -92,7 +93,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
     }
 
     override fun doOKAction() {
-      CodyAgent.getClient(project).codebase?.setUrl(gitURL.text)
+      CodyAgent.getClient(project).codebase?.onNewExplicitCodebase(gitURL.text)
       super.doOKAction()
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
@@ -13,7 +13,6 @@ import com.sourcegraph.find.Search
 @Service(Service.Level.PROJECT)
 data class CodyProjectSettings(
     var defaultBranchName: String = "main",
-    var remoteUrl: String? = null,
     var remoteUrlReplacements: String = "",
     var lastSearchQuery: String? = null,
     var lastSearchCaseSensitive: Boolean = false,
@@ -24,7 +23,6 @@ data class CodyProjectSettings(
 
   override fun loadState(state: CodyProjectSettings) {
     this.defaultBranchName = state.defaultBranchName
-    this.remoteUrl = state.remoteUrl
     this.remoteUrlReplacements = state.remoteUrlReplacements
     this.lastSearchQuery = state.lastSearchQuery
     this.lastSearchCaseSensitive = state.lastSearchCaseSensitive

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -45,7 +45,7 @@ object ConfigUtil {
             autocompleteAdvancedEmbeddings = UserLevelConfig.getAutocompleteAdvancedEmbeddings(),
             debug = isCodyDebugEnabled(),
             verboseDebug = isCodyVerboseDebugEnabled(),
-            codebase = codyAgentCodebase?.getUrl(),
+            codebase = codyAgentCodebase?.currentCodebase(),
         )
 
     UserLevelConfig.getAutocompleteProviderType()?.let {


### PR DESCRIPTION
This reverts commit 14891e64eb192789df371dd43ae819a77aa22cd6.

Reverting because this commit introduced 
https://github.com/sourcegraph/jetbrains/issues/15
https://github.com/sourcegraph/jetbrains/issues/16

closes https://github.com/sourcegraph/jetbrains/issues/15
closes https://github.com/sourcegraph/jetbrains/issues/16

## Test plan
`./gradlew  :runIDE`

Open a single repo verify chat & autocomplete work
Check cody-agent-trace.json to make sure configuration change isn't send on every cursor movement

Open a folder with multiple repos:
Verify autocomplete & chat work
  - ensure repo changes when switching files between repos
  - ensure override of codebase settings works (set it to a 3rd repo and make sure it stays when changes files)
 
Check cody-agent-trace.json to make sure configuration change isn't send on every cursor movement

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
