### PR TITLE
Move update channel setting to Cody & Sourcegraph

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.config
 
-import com.sourcegraph.cody.config.ui.UpdateChannel
 import java.awt.Color
 
 data class SettingsModel(
@@ -14,5 +13,4 @@ data class SettingsModel(
     var customAutocompleteColor: Color? = null,
     var blacklistedLanguageIds: List<String> = listOf(),
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
-    var channel: UpdateChannel = UpdateChannel.Stable
 )

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -6,7 +6,10 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
+import com.intellij.openapi.updateSettings.impl.UpdateSettings
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.SimpleListCellRenderer
+import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
@@ -30,6 +33,7 @@ class AccountConfigurable(val project: Project) :
   private val accountsModel = CodyAccountListModel(project)
   private val activeAccountHolder = project.service<CodyProjectActiveAccountHolder>()
   private lateinit var dialogPanel: DialogPanel
+  var channel: UpdateChannel = findConfiguredChannel()
 
   override fun createPanel(): DialogPanel {
     dialogPanel = panel {
@@ -56,6 +60,16 @@ class AccountConfigurable(val project: Project) :
                   if (CodyAccountsHost.DATA_KEY.`is`(key)) accountsModel else null
                 }
               }
+        }
+      }
+
+      group("Plugin") {
+        row {
+          label("Update channel:")
+          comboBox(
+                  UpdateChannel.values().toList(),
+                  SimpleListCellRenderer.create("") { it.presentableText })
+              .bindItem({ channel }, { channel = it!! })
         }
       }
     }
@@ -93,5 +107,34 @@ class AccountConfigurable(val project: Project) :
     CodyAuthenticationManager.instance.setActiveAccount(project, activeAccount)
     accountsModel.activeAccount = activeAccount
     publisher.afterAction(context)
+
+    applyChannelConfiguration()
+  }
+
+  private fun applyChannelConfiguration() {
+    val configuredChannel = findConfiguredChannel()
+    val newChannel = channel
+
+    if (!configuredChannel.equals(newChannel)) {
+      if (!UpdateChannel.Stable.equals(configuredChannel)) {
+        UpdateSettings.getInstance().storedPluginHosts.remove(configuredChannel.channelUrl)
+      }
+
+      if (!UpdateChannel.Stable.equals(newChannel)) {
+        UpdateSettings.getInstance().storedPluginHosts.add(newChannel.channelUrl)
+      }
+    }
+  }
+
+  private fun findConfiguredChannel(): UpdateChannel {
+    var currentChannel = UpdateChannel.Stable
+    for (channel in UpdateChannel.values()) {
+      val url = channel.channelUrl
+      if (url != null && UpdateSettings.getInstance().storedPluginHosts.contains(url)) {
+        currentChannel = channel
+        break
+      }
+    }
+    return currentChannel
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -33,7 +33,7 @@ class AccountConfigurable(val project: Project) :
   private val accountsModel = CodyAccountListModel(project)
   private val activeAccountHolder = project.service<CodyProjectActiveAccountHolder>()
   private lateinit var dialogPanel: DialogPanel
-  var channel: UpdateChannel = findConfiguredChannel()
+  private var channel: UpdateChannel = findConfiguredChannel()
 
   override fun createPanel(): DialogPanel {
     dialogPanel = panel {

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -4,10 +4,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.openapi.updateSettings.impl.UpdateSettings
 import com.intellij.ui.ColorPanel
 import com.intellij.ui.JBColor
-import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
@@ -54,16 +52,6 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
           checkBox("Accept non-trusted certificates")
               .enabledIf(enableCodyCheckbox.selected)
               .bindSelected(settingsModel::shouldAcceptNonTrustedCertificatesAutomatically)
-        }
-      }
-
-      group("Plugin") {
-        row {
-          label("Update channel:")
-          comboBox(
-                  UpdateChannel.values().toList(),
-                  SimpleListCellRenderer.create("") { it.presentableText })
-              .bindItem(settingsModel::channel.toNullableProperty())
         }
       }
 
@@ -114,7 +102,6 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
     settingsModel.blacklistedLanguageIds = codyApplicationSettings.blacklistedLanguageIds
     settingsModel.shouldAcceptNonTrustedCertificatesAutomatically =
         codyApplicationSettings.shouldAcceptNonTrustedCertificatesAutomatically
-    settingsModel.channel = findConfiguredChannel()
     dialogPanel.reset()
   }
 
@@ -146,36 +133,8 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
     codyApplicationSettings.blacklistedLanguageIds = settingsModel.blacklistedLanguageIds
     codyApplicationSettings.shouldAcceptNonTrustedCertificatesAutomatically =
         settingsModel.shouldAcceptNonTrustedCertificatesAutomatically
-    applyChannelConfiguration()
 
     publisher.afterAction(context)
-  }
-
-  private fun applyChannelConfiguration() {
-    val configuredChannel = findConfiguredChannel()
-    val newChannel = settingsModel.channel
-
-    if (!configuredChannel.equals(newChannel)) {
-      if (!UpdateChannel.Stable.equals(configuredChannel)) {
-        UpdateSettings.getInstance().storedPluginHosts.remove(configuredChannel.channelUrl)
-      }
-
-      if (!UpdateChannel.Stable.equals(newChannel)) {
-        UpdateSettings.getInstance().storedPluginHosts.add(newChannel.channelUrl)
-      }
-    }
-  }
-
-  private fun findConfiguredChannel(): UpdateChannel {
-    var currentChannel = UpdateChannel.Stable
-    for (channel in UpdateChannel.values()) {
-      val url = channel.channelUrl
-      if (url != null && UpdateSettings.getInstance().storedPluginHosts.contains(url)) {
-        currentChannel = channel
-        break
-      }
-    }
-    return currentChannel
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/57369

https://github.com/sourcegraph/jetbrains/pull/9 has been prematurely merged.

This PR moves the update channel setting from Cody to Cody & Sourcegraph.

<img width="1011" alt="image" src="https://github.com/sourcegraph/jetbrains/assets/19799111/41e6fe2b-8caa-4bc5-8b63-acf55cc216a1">

## Test plan

### Manual

1. runIde
2. go to Settings / Plugins / gaer icon / Manage plugin repositories
3. verify there are no repositories
4. go to Settings / Tools / Sourcegraph & Cody
5. Switch Update channel to Nightly
6. go to Settings / Plugins / gaer icon / Manage plugin repositories
7. verify there is alpha repository added
8. go to Settings / Tools / Sourcegraph & Cody
9. Switch Update channel back to Stable
10. go to Settings / Plugins / gaer icon / Manage plugin repositories
11. verify there are no repositories
