### PR TITLE
Chat: add support to press up/down arrow keys to open previous messages

### DIFF
--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -1,0 +1,103 @@
+package com.sourcegraph.cody.chat
+
+import com.intellij.ui.components.JBTextArea
+import com.sourcegraph.config.ConfigUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class CodyChatMessageHistoryTest {
+    private lateinit var history: CodyChatMessageHistory;
+
+    @BeforeEach
+    fun setup() {
+        history = CodyChatMessageHistory(10);
+    }
+    @Test
+    fun `messageSent adds message to latest position in history`() {
+        val textArea = JBTextArea()
+        textArea.text = "test"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test")
+    }
+
+    @Test
+    fun `popUpperMessage pops message from upper stack`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        textArea.text = "test 2"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 2")
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+    }
+
+    @Test
+    fun `popLowerMessages pop message from lower stack`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        textArea.text = "test 2"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 2")
+
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+    }
+
+    @Test
+    fun `popUpperMessage stops at last message`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
+    }
+
+    @Test
+    fun `popLowerMessage stops at empty string`() {
+        val textArea = JBTextArea()
+        textArea.text = "test 1"
+        history.messageSent(textArea)
+        history.popUpperMessage(textArea)
+        history.popLowerMessage(textArea)
+
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+        history.popLowerMessage(textArea)
+        assertThat(textArea.text).isEmpty()
+    }
+
+    @Test
+    fun `popUpperMessage overrides oldest message when capacity exceeded`() {
+        val textArea = JBTextArea()
+        val testString = "test"
+        for (i in 1..10){
+            textArea.text = testString.plus(i)
+            history.messageSent(textArea)
+        }
+        textArea.text = "last test"
+        history.messageSent(textArea)
+
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("last test")
+
+        for (i in 1..11){
+            history.popUpperMessage(textArea)
+        }
+        assertThat(textArea.text).isEqualTo("test2")
+
+    }
+}

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -49,9 +49,11 @@ class CodyChatMessageHistoryTest {
 
         history.popUpperMessage(textArea)
         assertThat(textArea.text).isEqualTo("test 2")
+        history.popUpperMessage(textArea)
+        assertThat(textArea.text).isEqualTo("test 1")
 
         history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
+        assertThat(textArea.text).isEqualTo("test 2")
     }
 
     @Test
@@ -67,10 +69,11 @@ class CodyChatMessageHistoryTest {
     }
 
     @Test
-    fun `popLowerMessage stops at empty string`() {
+    fun `popLowerMessage stops at last message in stack`() {
         val textArea = JBTextArea()
         textArea.text = "test 1"
         history.messageSent(textArea)
+        textArea.text = ""
         history.popUpperMessage(textArea)
         history.popLowerMessage(textArea)
 

--- a/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
+++ b/client/jetbrains/src/test/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistoryTest.kt
@@ -1,106 +1,123 @@
 package com.sourcegraph.cody.chat
 
 import com.intellij.ui.components.JBTextArea
-import com.sourcegraph.config.ConfigUtil
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 class CodyChatMessageHistoryTest {
-    private lateinit var history: CodyChatMessageHistory;
+  private lateinit var history: CodyChatMessageHistory
 
-    @BeforeEach
-    fun setup() {
-        history = CodyChatMessageHistory(10);
+  @BeforeEach
+  fun setup() {
+    history = CodyChatMessageHistory(10)
+  }
+
+  @Test
+  fun `messageSent adds message to latest position in history`() {
+    val textArea = JBTextArea()
+    textArea.text = "test"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test")
+  }
+
+  @Test
+  fun `popUpperMessage pops message from upper stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = "test 2"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+  }
+
+  @Test
+  fun `popLowerMessages pop message from lower stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = "test 2"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 2")
+  }
+
+  @Test
+  fun `popUpperMessage stops at last message`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test 1")
+  }
+
+  @Test
+  fun `popLowerMessage stops at last message in stack`() {
+    val textArea = JBTextArea()
+    textArea.text = "test 1"
+    history.messageSent(textArea)
+    textArea.text = ""
+    history.popUpperMessage(textArea)
+    history.popLowerMessage(textArea)
+
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEmpty()
+    history.popLowerMessage(textArea)
+    assertThat(textArea.text).isEmpty()
+  }
+
+  @Test
+  fun `popUpperMessage overrides oldest message when capacity exceeded`() {
+    val textArea = JBTextArea()
+    val testString = "test"
+    for (i in 1..10) {
+      textArea.text = testString.plus(i)
+      history.messageSent(textArea)
     }
-    @Test
-    fun `messageSent adds message to latest position in history`() {
-        val textArea = JBTextArea()
-        textArea.text = "test"
-        history.messageSent(textArea)
+    textArea.text = "last test"
+    history.messageSent(textArea)
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("last test")
+
+    for (i in 1..11) {
+      history.popUpperMessage(textArea)
     }
+    assertThat(textArea.text).isEqualTo("test2")
+  }
 
-    @Test
-    fun `popUpperMessage pops message from upper stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = "test 2"
-        history.messageSent(textArea)
+  @Test
+  fun `popUpperMessage when history state reset`() {
+    val textArea = JBTextArea()
+    textArea.text = "test1"
+    history.messageSent(textArea)
+    textArea.text = "test2"
+    history.messageSent(textArea)
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test2")
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test1")
 
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-    }
+    textArea.text = ""
 
-    @Test
-    fun `popLowerMessages pop message from lower stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = "test 2"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 2")
-    }
-
-    @Test
-    fun `popUpperMessage stops at last message`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("test 1")
-    }
-
-    @Test
-    fun `popLowerMessage stops at last message in stack`() {
-        val textArea = JBTextArea()
-        textArea.text = "test 1"
-        history.messageSent(textArea)
-        textArea.text = ""
-        history.popUpperMessage(textArea)
-        history.popLowerMessage(textArea)
-
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
-        history.popLowerMessage(textArea)
-        assertThat(textArea.text).isEmpty()
-    }
-
-    @Test
-    fun `popUpperMessage overrides oldest message when capacity exceeded`() {
-        val textArea = JBTextArea()
-        val testString = "test"
-        for (i in 1..10){
-            textArea.text = testString.plus(i)
-            history.messageSent(textArea)
-        }
-        textArea.text = "last test"
-        history.messageSent(textArea)
-
-        history.popUpperMessage(textArea)
-        assertThat(textArea.text).isEqualTo("last test")
-
-        for (i in 1..11){
-            history.popUpperMessage(textArea)
-        }
-        assertThat(textArea.text).isEqualTo("test2")
-
-    }
+    history.popUpperMessage(textArea)
+    assertThat(textArea.text).isEqualTo("test2")
+  }
 }

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -130,14 +130,23 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            chatMessageHistory.popUpperMessage(promptInput);
+            if (promptInput.getCaretPosition() == 0) {
+              chatMessageHistory.popUpperMessage(promptInput);
+            } else {
+              promptInput.setCaretPosition(0);
+            }
           }
         };
     AnAction lowerMessageAction =
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            chatMessageHistory.popLowerMessage(promptInput);
+            int promptLastPosition = promptInput.getText().length();
+            if (promptInput.getCaretPosition() == promptLastPosition) {
+              chatMessageHistory.popLowerMessage(promptInput);
+            } else {
+              promptInput.setCaretPosition(promptLastPosition);
+            }
           }
         };
 

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -52,6 +52,8 @@ import com.sourcegraph.cody.ui.ChatScrollPane;
 import com.sourcegraph.cody.vscode.CancellationToken;
 import com.sourcegraph.telemetry.GraphQlLogger;
 import java.awt.*;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -93,6 +95,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   private CodyOnboardingGuidancePanel codyOnboardingGuidancePanel;
   private final @NotNull CodyChatMessageHistory chatMessageHistory =
       new CodyChatMessageHistory(CHAT_MESSAGE_HISTORY_CAPACITY);
+  private boolean isInHistoryMode = true;
 
   public CodyToolWindowContent(@NotNull Project project) {
     this.project = project;
@@ -131,11 +134,7 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            // When no text in prompt, pop from history.
-            if ((promptInput.getText().isEmpty()
-                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
-                && !chatMessageHistory.getUpperStack().isEmpty()
-                && promptInput.getCaretPosition() == 0) {
+            if (isInHistoryMode) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();
@@ -165,10 +164,7 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
-            // When no text in prompt, pop from history.
-            if ((promptInput.getText().isEmpty()
-                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
-                && promptInput.getCaretPosition() == promptLastPosition) {
+            if (isInHistoryMode) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();
@@ -178,10 +174,12 @@ public class CodyToolWindowContent implements UpdatableChat {
                 int lineCount = promptInput.getLineCount();
                 // When not on the last line, move caret to the same position in line below.
                 if (lineNumber + 1 < lineCount) {
-                  int maxNextLineOffset = promptInput.getLineEndOffset(lineNumber + 1);
+                  int endOfNextLine =
+                      (lineNumber + 1 == lineCount - 1)
+                          ? promptInput.getLineEndOffset(lineNumber + 1)
+                          : promptInput.getLineEndOffset(lineNumber + 1) - 1;
                   int positionInLine = caretPosition - promptInput.getLineStartOffset(lineNumber);
-                  int newCaretPosition =
-                      Math.min(maxNextLineOffset - 1, positionInLine + lineEndOffset);
+                  int newCaretPosition = Math.min(endOfNextLine, positionInLine + lineEndOffset);
                   promptInput.setCaretPosition(newCaretPosition);
                 }
                 // When on last line, move caret to the end of prompt.
@@ -199,12 +197,25 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            sendChatMessage(project);
+            if (!promptInput.getText().isEmpty()) {
+              sendChatMessage(project);
+            }
           }
         };
     sendMessageAction.registerCustomShortcutSet(DEFAULT_SUBMIT_ACTION_SHORTCUT, promptInput);
     upperMessageAction.registerCustomShortcutSet(POP_UPPER_MESSAGE_ACTION_SHORTCUT, promptInput);
     lowerMessageAction.registerCustomShortcutSet(POP_LOWER_MESSAGE_ACTION_SHORTCUT, promptInput);
+    promptInput.addKeyListener(
+        new KeyAdapter() {
+          @Override
+          public void keyReleased(KeyEvent e) {
+            int keyCode = e.getKeyCode();
+
+            if (keyCode != VK_UP && keyCode != VK_DOWN) {
+              isInHistoryMode = promptInput.getText().isEmpty();
+            }
+          }
+        });
     // Enable/disable the send button based on whether promptInput is empty
     promptInput
         .getDocument()

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -64,6 +64,7 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.plaf.ButtonUI;
+import javax.swing.text.BadLocationException;
 import org.jetbrains.annotations.NotNull;
 
 public class CodyToolWindowContent implements UpdatableChat {
@@ -130,12 +131,31 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
+            // When no text in prompt, pop from history.
             if (!chatMessageHistory.getUpperStack().isEmpty()
                 && (promptInput.getText().isEmpty()
                     || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
-              promptInput.setCaretPosition(0);
+              int caretPosition = promptInput.getCaretPosition();
+              try {
+                int lineNumber = promptInput.getLineOfOffset(caretPosition);
+                // When not on the first line, move caret to the same position in line above.
+                if (lineNumber > 0) {
+                  int maxPreviousLineOffset = promptInput.getLineEndOffset(lineNumber - 1);
+                  int positionInLine = caretPosition - promptInput.getLineStartOffset(lineNumber);
+                  int previousLineStart = promptInput.getLineStartOffset(lineNumber - 1);
+                  int newCaretPosition =
+                      Math.min(maxPreviousLineOffset - 1, previousLineStart + positionInLine);
+                  promptInput.setCaretPosition(newCaretPosition);
+                }
+                // When on the first line, move caret to the beginning of the line.
+                else {
+                  promptInput.setCaretPosition(0);
+                }
+              } catch (BadLocationException ex) {
+                throw new RuntimeException(ex);
+              }
             }
           }
         };
@@ -144,11 +164,31 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
+            // When no text in prompt, pop from history.
             if (promptInput.getText().isEmpty()
                 || promptInput.getText().equals(chatMessageHistory.getCurrentValue())) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
-              promptInput.setCaretPosition(promptLastPosition);
+              int caretPosition = promptInput.getCaretPosition();
+              try {
+                int lineNumber = promptInput.getLineOfOffset(caretPosition);
+                int lineEndOffset = promptInput.getLineEndOffset(lineNumber);
+                int lineCount = promptInput.getLineCount();
+                // When not on the last line, move caret to the same position in line below.
+                if (lineNumber + 1 < lineCount) {
+                  int maxNextLineOffset = promptInput.getLineEndOffset(lineNumber + 1);
+                  int positionInLine = caretPosition - promptInput.getLineStartOffset(lineNumber);
+                  int newCaretPosition =
+                      Math.min(maxNextLineOffset - 1, positionInLine + lineEndOffset);
+                  promptInput.setCaretPosition(newCaretPosition);
+                }
+                // When on last line, move caret to the end of prompt.
+                else {
+                  promptInput.setCaretPosition(promptLastPosition);
+                }
+              } catch (BadLocationException ex) {
+                throw new RuntimeException(ex);
+              }
             }
           }
         };

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -132,9 +132,10 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             // When no text in prompt, pop from history.
-            if (!chatMessageHistory.getUpperStack().isEmpty()
-                && (promptInput.getText().isEmpty()
-                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))) {
+            if ((promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
+                && !chatMessageHistory.getUpperStack().isEmpty()
+                && promptInput.getCaretPosition() == 0) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();
@@ -165,8 +166,9 @@ public class CodyToolWindowContent implements UpdatableChat {
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
             // When no text in prompt, pop from history.
-            if (promptInput.getText().isEmpty()
-                || promptInput.getText().equals(chatMessageHistory.getCurrentValue())) {
+            if ((promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))
+                && promptInput.getCaretPosition() == promptLastPosition) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
               int caretPosition = promptInput.getCaretPosition();

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody;
 
 import static com.intellij.ui.SimpleTextAttributes.STYLE_PLAIN;
-import static java.awt.event.KeyEvent.VK_ENTER;
+import static java.awt.event.KeyEvent.*;
 import static javax.swing.KeyStroke.getKeyStroke;
 
 import com.intellij.icons.AllIcons;
@@ -41,6 +41,7 @@ import com.sourcegraph.cody.chat.CodyOnboardingGuidancePanel;
 import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
+import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
@@ -74,6 +75,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   public static final String SING_IN_WITH_SOURCEGRAPH_PANEL = "singInWithSourcegraphPanel";
   private static final int CHAT_TAB_INDEX = 0;
   private static final int RECIPES_TAB_INDEX = 1;
+  private static final int CHAT_MESSAGE_HISTORY_CAPACITY = 100;
   private final @NotNull CardLayout allContentLayout = new CardLayout();
   private final @NotNull JPanel allContentPanel = new JPanel(allContentLayout);
   private final @NotNull JBTabbedPane tabbedPane = new JBTabbedPane();
@@ -88,6 +90,8 @@ public class CodyToolWindowContent implements UpdatableChat {
   public final EmbeddingStatusView embeddingStatusView;
   private boolean isChatVisible = false;
   private CodyOnboardingGuidancePanel codyOnboardingGuidancePanel;
+  private final @NotNull CodyChatMessageHistory chatMessageHistory =
+      new CodyChatMessageHistory(CHAT_MESSAGE_HISTORY_CAPACITY);
 
   public CodyToolWindowContent(@NotNull Project project) {
     this.project = project;
@@ -115,7 +119,28 @@ public class CodyToolWindowContent implements UpdatableChat {
     promptInput = autoGrowingTextArea.getTextArea();
     /* Submit on enter */
     KeyboardShortcut JUST_ENTER = new KeyboardShortcut(getKeyStroke(VK_ENTER, 0), null);
+    KeyboardShortcut UP = new KeyboardShortcut(getKeyStroke(VK_UP, 0), null);
+    KeyboardShortcut DOWN = new KeyboardShortcut(getKeyStroke(VK_DOWN, 0), null);
+
     ShortcutSet DEFAULT_SUBMIT_ACTION_SHORTCUT = new CustomShortcutSet(JUST_ENTER);
+    ShortcutSet POP_UPPER_MESSAGE_ACTION_SHORTCUT = new CustomShortcutSet(UP);
+    ShortcutSet POP_LOWER_MESSAGE_ACTION_SHORTCUT = new CustomShortcutSet(DOWN);
+
+    AnAction upperMessageAction =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            chatMessageHistory.popUpperMessage(promptInput);
+          }
+        };
+    AnAction lowerMessageAction =
+        new DumbAwareAction() {
+          @Override
+          public void actionPerformed(@NotNull AnActionEvent e) {
+            chatMessageHistory.popLowerMessage(promptInput);
+          }
+        };
+
     AnAction sendMessageAction =
         new DumbAwareAction() {
           @Override
@@ -124,7 +149,8 @@ public class CodyToolWindowContent implements UpdatableChat {
           }
         };
     sendMessageAction.registerCustomShortcutSet(DEFAULT_SUBMIT_ACTION_SHORTCUT, promptInput);
-
+    upperMessageAction.registerCustomShortcutSet(POP_UPPER_MESSAGE_ACTION_SHORTCUT, promptInput);
+    lowerMessageAction.registerCustomShortcutSet(POP_LOWER_MESSAGE_ACTION_SHORTCUT, promptInput);
     // Enable/disable the send button based on whether promptInput is empty
     promptInput
         .getDocument()
@@ -438,6 +464,7 @@ public class CodyToolWindowContent implements UpdatableChat {
               addWelcomeMessage();
               messagesPanel.revalidate();
               messagesPanel.repaint();
+              chatMessageHistory.clearHistory();
               CodyAgent.getInitializedServer(project).thenAccept(CodyAgentServer::transcriptReset);
             });
   }
@@ -456,6 +483,7 @@ public class CodyToolWindowContent implements UpdatableChat {
   @RequiresEdt
   private void sendChatMessage(@NotNull Project project) {
     String text = promptInput.getText();
+    chatMessageHistory.messageSent(promptInput);
     sendMessage(project, text, "chat-question");
     promptInput.setText("");
   }

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -33,6 +33,7 @@ import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentManager;
 import com.sourcegraph.cody.agent.CodyAgentServer;
 import com.sourcegraph.cody.agent.protocol.RecipeInfo;
+import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.api.Speaker;
 import com.sourcegraph.cody.chat.Chat;
 import com.sourcegraph.cody.chat.ChatMessage;
@@ -41,7 +42,6 @@ import com.sourcegraph.cody.chat.CodyOnboardingGuidancePanel;
 import com.sourcegraph.cody.chat.ContextFilesMessage;
 import com.sourcegraph.cody.chat.MessagePanel;
 import com.sourcegraph.cody.chat.SignInWithSourcegraphPanel;
-import com.sourcegraph.cody.chat.*;
 import com.sourcegraph.cody.config.CodyAccount;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.config.CodyAuthenticationManager;
@@ -130,7 +130,9 @@ public class CodyToolWindowContent implements UpdatableChat {
         new DumbAwareAction() {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
-            if (promptInput.getCaretPosition() == 0) {
+            if (!chatMessageHistory.getUpperStack().isEmpty()
+                && (promptInput.getText().isEmpty()
+                    || promptInput.getText().equals(chatMessageHistory.getCurrentValue()))) {
               chatMessageHistory.popUpperMessage(promptInput);
             } else {
               promptInput.setCaretPosition(0);
@@ -142,7 +144,8 @@ public class CodyToolWindowContent implements UpdatableChat {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             int promptLastPosition = promptInput.getText().length();
-            if (promptInput.getCaretPosition() == promptLastPosition) {
+            if (promptInput.getText().isEmpty()
+                || promptInput.getText().equals(chatMessageHistory.getCurrentValue())) {
               chatMessageHistory.popLowerMessage(promptInput);
             } else {
               promptInput.setCaretPosition(promptLastPosition);

--- a/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -1,0 +1,55 @@
+package com.sourcegraph.cody.chat
+
+import com.intellij.ui.components.JBTextArea
+import java.util.*
+
+class CodyChatMessageHistory(
+    private val capacity: Int
+) {
+    private var upperStack: Stack<String> = Stack<String>()
+    private var lowerStack: Stack<String> = Stack<String>()
+    private var currentValue: String = ""
+
+    fun popUpperMessage(promptInput: JBTextArea) {
+        if (upperStack.isNotEmpty()) {
+            val pop = upperStack.pop()
+            lowerStack.push(currentValue)
+            promptInput.text = pop
+            currentValue = pop
+        }
+    }
+
+    fun popLowerMessage(promptInput: JBTextArea) {
+        if (lowerStack.isNotEmpty()) {
+            val pop = lowerStack.pop()
+            upperStack.push(currentValue)
+            promptInput.text = pop
+            currentValue = pop
+        }
+    }
+
+    /**
+     * When new message is sent it is pushing all messages
+     *  from lower stack to upper stack and at the end pushes new message
+     */
+    fun messageSent(promptInput: JBTextArea) {
+        if (currentValue.isNotEmpty()) {
+            upperStack.push(currentValue)
+        }
+        while (lowerStack.isNotEmpty()) {
+            val pop: String = lowerStack.pop()
+            if (pop.isNotEmpty()) upperStack.push(pop)
+        }
+        currentValue = ""
+        upperStack.push(promptInput.text)
+        if (upperStack.size > capacity) {
+            upperStack.removeFirst()
+        }
+    }
+
+    fun clearHistory() {
+        upperStack.clear()
+        lowerStack.clear()
+        currentValue = ""
+    }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -13,7 +13,7 @@ class CodyChatMessageHistory(
     fun popUpperMessage(promptInput: JBTextArea) {
         if (upperStack.isNotEmpty()) {
             val pop = upperStack.pop()
-            lowerStack.push(currentValue)
+            lowerStack.push(promptInput.text)
             promptInput.text = pop
             currentValue = pop
         }
@@ -22,7 +22,7 @@ class CodyChatMessageHistory(
     fun popLowerMessage(promptInput: JBTextArea) {
         if (lowerStack.isNotEmpty()) {
             val pop = lowerStack.pop()
-            upperStack.push(currentValue)
+            upperStack.push(promptInput.text)
             promptInput.text = pop
             currentValue = pop
         }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -3,53 +3,63 @@ package com.sourcegraph.cody.chat
 import com.intellij.ui.components.JBTextArea
 import java.util.*
 
-class CodyChatMessageHistory(
-    private val capacity: Int
-) {
-    private var upperStack: Stack<String> = Stack<String>()
-    private var lowerStack: Stack<String> = Stack<String>()
-    private var currentValue: String = ""
+class CodyChatMessageHistory(private val capacity: Int) {
+  var currentValue: String = ""
+  var upperStack: Stack<String> = Stack<String>()
+  private var lowerStack: Stack<String> = Stack<String>()
 
-    fun popUpperMessage(promptInput: JBTextArea) {
-        if (upperStack.isNotEmpty()) {
-            val pop = upperStack.pop()
-            lowerStack.push(promptInput.text)
-            promptInput.text = pop
-            currentValue = pop
-        }
+  fun popUpperMessage(promptInput: JBTextArea) {
+    resetHistoryIfPromptCleared(promptInput)
+    if (upperStack.isNotEmpty()) {
+      val pop = upperStack.pop()
+      lowerStack.push(promptInput.text)
+      promptInput.text = pop
+      currentValue = pop
     }
+  }
 
-    fun popLowerMessage(promptInput: JBTextArea) {
-        if (lowerStack.isNotEmpty()) {
-            val pop = lowerStack.pop()
-            upperStack.push(promptInput.text)
-            promptInput.text = pop
-            currentValue = pop
-        }
+  fun popLowerMessage(promptInput: JBTextArea) {
+    resetHistoryIfPromptCleared(promptInput)
+    if (lowerStack.isNotEmpty()) {
+      val pop = lowerStack.pop()
+      upperStack.push(promptInput.text)
+      promptInput.text = pop
+      currentValue = pop
     }
+  }
 
-    /**
-     * When new message is sent it is pushing all messages
-     *  from lower stack to upper stack and at the end pushes new message
-     */
-    fun messageSent(promptInput: JBTextArea) {
-        if (currentValue.isNotEmpty()) {
-            upperStack.push(currentValue)
-        }
-        while (lowerStack.isNotEmpty()) {
-            val pop: String = lowerStack.pop()
-            if (pop.isNotEmpty()) upperStack.push(pop)
-        }
-        currentValue = ""
-        upperStack.push(promptInput.text)
-        if (upperStack.size > capacity) {
-            upperStack.removeFirst()
-        }
+  /**
+   * When new message is sent it is pushing all messages from lower stack to upper stack and at the
+   * end pushes new message
+   */
+  fun messageSent(promptInput: JBTextArea) {
+    resetHistory()
+    upperStack.push(promptInput.text)
+    if (upperStack.size > capacity) {
+      upperStack.removeFirst()
     }
+  }
 
-    fun clearHistory() {
-        upperStack.clear()
-        lowerStack.clear()
-        currentValue = ""
+  fun clearHistory() {
+    upperStack.clear()
+    lowerStack.clear()
+    currentValue = ""
+  }
+
+  private fun resetHistory() {
+    if (currentValue.isNotEmpty()) {
+      upperStack.push(currentValue)
     }
+    while (lowerStack.isNotEmpty()) {
+      val pop: String = lowerStack.pop()
+      if (pop.isNotEmpty()) upperStack.push(pop)
+    }
+    currentValue = ""
+  }
+
+  private fun resetHistoryIfPromptCleared(promptInput: JBTextArea) {
+    if (promptInput.text.isEmpty() && currentValue.isNotEmpty()) {
+      resetHistory()
+    }
+  }
 }


### PR DESCRIPTION
It fixes https://github.com/sourcegraph/sourcegraph/issues/54933

Previously, you had to copy-paste a previous message if you want to send it again with some changes. This PR fixes the problem by adding up/down arrow shortcuts to load the input field with messages from your chat history. By default, up/down work just like normal. This feature can only be activated when the input field is empty.

## Test plan
* Open new cody chat window
* Send message 1
* Send message 2
* Press ⬆️, message 2 should appear in the prompt
* Press ⬆️, message 1 should appear in the prompt
* Press ⬇️, message 2 should again appear in the prompt
* Modify message 2 and send
* Press ⬆️, modified message 2 should appear
