### PR TITLE
Persist codebase URL after closing IDE (#6)

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -4,32 +4,33 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.config.CodyProjectSettings
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
+class CodyAgentCodebase(private val underlying: CodyAgentServer, private val project: Project) {
 
-  // TODO: This should ideally be persisted as a project-wide setting. Down the road, it should also
-  // support a list of repository names instead of only a single codebase.
-  private var inferredCodebase: String = ""
-  private var explicitCodebase: String = ""
+  // TODO: Support list of repository names instead of just one.
+  private val application = ApplicationManager.getApplication()
+  private val settings = CodyProjectSettings.getInstance(project)
+  private var inferredUrl: String? = null
 
   init {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, null))
+    application.executeOnPooledThread {
+      onRepositoryNameChange(RepoUtil.findRepositoryName(project, null))
     }
   }
 
-  fun onNewExplicitCodebase(codebase: String) {
-    explicitCodebase = codebase
+  fun setUrl(url: String) {
+    settings.remoteUrl = url
     onPropagateConfiguration()
   }
 
-  fun currentCodebase(): String? = explicitCodebase.ifEmpty { inferredCodebase }.ifEmpty { null }
+  fun getUrl(): String? = settings.remoteUrl ?: inferredUrl
 
   fun onFileOpened(project: Project, file: VirtualFile) {
-    ApplicationManager.getApplication().executeOnPooledThread {
-      onRepositoryName(RepoUtil.findRepositoryName(project, file))
+    application.executeOnPooledThread {
+      onRepositoryNameChange(RepoUtil.findRepositoryName(project, file))
     }
   }
 
@@ -38,10 +39,10 @@ class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Pr
     underlying.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
   }
 
-  private fun onRepositoryName(repositoryName: String?) {
-    ApplicationManager.getApplication().invokeLater {
-      if (repositoryName != null && inferredCodebase != repositoryName) {
-        inferredCodebase = repositoryName
+  private fun onRepositoryNameChange(repositoryName: String?) {
+    application.invokeLater {
+      if (repositoryName != null && inferredUrl != repositoryName) {
+        inferredUrl = repositoryName
         onPropagateConfiguration()
       }
     }

--- a/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/src/main/java/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -54,7 +54,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
 
   fun updateEmbeddingStatus() {
     val client = CodyAgent.getClient(project)
-    val repoName = client.codebase?.currentCodebase()
+    val repoName = client.codebase?.getUrl()
     if (repoName == null) {
       setEmbeddingStatus(NoGitRepositoryEmbeddingStatus())
     } else {

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/EditCodebaseContextAction.kt
@@ -27,8 +27,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
   private val currentIndicator: AtomicReference<ProgressIndicator> = AtomicReference()
 
   private inner class EditCodebaseDialog : DialogWrapper(null, true) {
-    val gitURL =
-        ExtendableTextField(CodyAgent.getClient(project).codebase?.currentCodebase() ?: "", 40)
+    val gitURL = ExtendableTextField(CodyAgent.getClient(project).codebase?.getUrl() ?: "", 40)
     val loadingLayerUI = LoadingLayerUI()
     val layeredGitURL = JLayer(gitURL, loadingLayerUI)
 
@@ -93,7 +92,7 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
     }
 
     override fun doOKAction() {
-      CodyAgent.getClient(project).codebase?.onNewExplicitCodebase(gitURL.text)
+      CodyAgent.getClient(project).codebase?.setUrl(gitURL.text)
       super.doOKAction()
     }
 
@@ -105,10 +104,6 @@ class EditCodebaseContextAction(val project: Project) : AbstractAction("Cody Con
             }
             .rowComment("Example: github.com/sourcegraph/cody")
         row { text("The URL will be used to retrieve the code context from the Cody API.") }
-        row {
-          text(
-              "If left empty, Cody will automatically infer the URL from your project's Git metadata.")
-        }
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyProjectSettings.kt
@@ -13,6 +13,7 @@ import com.sourcegraph.find.Search
 @Service(Service.Level.PROJECT)
 data class CodyProjectSettings(
     var defaultBranchName: String = "main",
+    var remoteUrl: String? = null,
     var remoteUrlReplacements: String = "",
     var lastSearchQuery: String? = null,
     var lastSearchCaseSensitive: Boolean = false,
@@ -23,6 +24,7 @@ data class CodyProjectSettings(
 
   override fun loadState(state: CodyProjectSettings) {
     this.defaultBranchName = state.defaultBranchName
+    this.remoteUrl = state.remoteUrl
     this.remoteUrlReplacements = state.remoteUrlReplacements
     this.lastSearchQuery = state.lastSearchQuery
     this.lastSearchCaseSensitive = state.lastSearchCaseSensitive

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -44,7 +44,7 @@ object ConfigUtil {
             autocompleteAdvancedAccessToken = UserLevelConfig.getAutocompleteAccessToken(),
             debug = isCodyDebugEnabled(),
             verboseDebug = isCodyVerboseDebugEnabled(),
-            codebase = codyAgentCodebase?.currentCodebase(),
+            codebase = codyAgentCodebase?.getUrl(),
         )
 
     UserLevelConfig.getAutocompleteProviderType()?.let {


### PR DESCRIPTION
Persist codebase URL after closing IDE (#6)

Fixes https://github.com/sourcegraph/sourcegraph/issues/56948

Remote URL is now stored in project settings.

Additional note: I've removed the line stating that leaving the address
empty would result in an inferred URL from the Git repository. This statement
is not true: the dialog does not allow you to leave it blank.

## Test plan

* `./gradlew :runIde` and open project.
* Open Context Selection dialog. Change URL and click OK.
* Restart IDE.
* Make sure repository address remains the same as it was before the restart.
* Make sure status bar is properly displayed after 2nd time you open the project.
* Make sure configuration change isn't send on every cursor movement (this should be visible in logs).
* Make sure status bar is properly displayed after opening large project (when indexing takes time).
