### PR TITLE
Support macos-arm64 with CI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
       - run: |
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
-      - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
+      - run: ./gradlew "-PldidSign=true" "-PpluginVersion=$RELEASE_VERSION" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
       - name: Publish nightly version
         if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
         run: |
           echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
-          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
+          ./gradlew "-PldidSign=true" "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,18 @@ jobs:
           cache: "gradle"
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.1.0
+      - run: ./scripts/install-ldid.sh
       - run: yarn global add pnpm@8.6.7
       - run: |
-          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)-nightly" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
       - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+      - name: Publish nightly version
+        if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
+        run: |
+          echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
+          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,7 +238,9 @@ tasks {
       commandLine("pnpm", "run", "build-agent-binaries")
       environment("AGENT_EXECUTABLE_TARGET_DIRECTORY", buildCodyDir.toString())
     }
-    // Run ldid if on Linux
+    // If running on Linux in CI, run ldid2 -S on the macos-arm64 binary so that it can be run on
+    // Apple M1 computers. This is required to prevent the following issue
+    // https://github.com/vercel/pkg/issues/2004
     if (System.getenv().containsKey("CI") &&
         System.getProperty("os.name").toLowerCase().contains("linux")) {
       exec { commandLine("ldid2", "-S", buildCodyDir.resolve("agent-macos-arm64").toString()) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
+val isLdidSign = properties("ldidSign") == "true"
 val isForceBuild = properties("forceBuild") == "true"
 val isForceAgentBuild =
     isForceBuild ||
@@ -241,8 +242,7 @@ tasks {
     // If running on Linux in CI, run ldid2 -S on the macos-arm64 binary so that it can be run on
     // Apple M1 computers. This is required to prevent the following issue
     // https://github.com/vercel/pkg/issues/2004
-    if (System.getenv().containsKey("CI") &&
-        System.getProperty("os.name").toLowerCase().contains("linux")) {
+    if (isLdidSign) {
       exec { commandLine("ldid2", "-S", buildCodyDir.resolve("agent-macos-arm64").toString()) }
     }
     return buildCodyDir

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -238,6 +238,11 @@ tasks {
       commandLine("pnpm", "run", "build-agent-binaries")
       environment("AGENT_EXECUTABLE_TARGET_DIRECTORY", buildCodyDir.toString())
     }
+    // Run ldid if on Linux
+    if (System.getenv().containsKey("CI") &&
+        System.getProperty("os.name").toLowerCase().contains("linux")) {
+      exec { commandLine("ldid2", "-S", buildCodyDir.resolve("agent-macos-arm64").toString()) }
+    }
     return buildCodyDir
   }
 

--- a/scripts/install-ldid.sh
+++ b/scripts/install-ldid.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Script to install `ldid2` on Linux computers to codesign the macos-arm64 binary for the agent.
+
 set -eux
 
 # Check if ldid is installed
@@ -12,6 +15,3 @@ unzip ldid.zip
 cd ldid-master
 ./make.sh
 cp ldid2 /usr/local/bin/
-
-
-

--- a/scripts/install-ldid.sh
+++ b/scripts/install-ldid.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eux
+
+# Check if ldid is installed
+if command -v ldid &>/dev/null; then
+  echo "ldid is already installed."
+  exit 0
+fi
+
+curl -Lo ldid.zip https://github.com/xerub/ldid/archive/refs/heads/master.zip
+unzip ldid.zip
+cd ldid-master
+./make.sh
+cp ldid2 /usr/local/bin/
+
+
+

--- a/scripts/push-git-tag-for-next-release.sh
+++ b/scripts/push-git-tag-for-next-release.sh
@@ -3,10 +3,34 @@
 # No arguments needed, the version is automatically computed.
 set -eux
 
+# Check the number of arguments
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 [--stable | --nightly]"
+  exit 1
+fi
+
+NIGHTLY_SUFFIX=""
+# Check the argument and take appropriate action
+if [ "$1" == "--stable" ]; then
+  # shellcheck disable=SC2162
+  read -p "Confirm that you want to run the stable release (y/n): " choice
+  if [ "$choice" == "y" ]; then
+    echo "Running stable release..."
+  else
+    echo "Aborted."
+    exit 1
+  fi
+elif [ "$1" == "--nightly" ]; then
+  NIGHTLY_SUFFIX="-nightly"
+else
+  echo "Invalid argument. Usage: $0 [--stable | --nightly]"
+  exit 1
+fi
+
 SCRIPT_DIR="$(dirname "$0")"
-SCRIPT_DIR="$(readlink -f $SCRIPT_DIR)"
+SCRIPT_DIR="$(readlink -f "$SCRIPT_DIR")"
 NEXT_VERSION="$(bash "$SCRIPT_DIR/next-release.sh")"
 bash "$SCRIPT_DIR/verify-release.sh"
-TAG="v$NEXT_VERSION"
-echo $TAG
-git tag -fa "$TAG" -m $TAG && git push -f origin $TAG
+TAG="v$NEXT_VERSION$NIGHTLY_SUFFIX"
+echo "$TAG"
+git tag -fa "$TAG" -m "$TAG" && git push -f origin "$TAG"

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -218,7 +218,7 @@ class CodyAgent(private val project: Project) : Disposable {
       val os = if (SystemInfoRt.isMac) "macos" else if (SystemInfoRt.isWindows) "win" else "linux"
       // Only use x86 for macOS because of this issue here https://github.com/vercel/pkg/issues/2004
       // TLDR; we're not able to run macos-arm64 binaries when they're created on ubuntu-latest
-      val arch = if (CpuArch.isArm64() && !SystemInfoRt.isMac) "arm64" else "x64"
+      val arch = if (CpuArch.isArm64()) "arm64" else "x64"
       return "agent-" + os + "-" + arch + binarySuffix()
     }
 


### PR DESCRIPTION
Previously, we ran the x86 binary on Apple M1 computers because the arm64 binary required code signing to run correctly on macOS computers. This PR fixes the problem by using `ldid2` to sign the macos-arms64 binary.


## Test plan

Run a nightly build and confirm it works as expected on macOS.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
