### PR TITLE
Fix bug in release automation

### DIFF
--- a/scripts/version-from-git-tag.sh
+++ b/scripts/version-from-git-tag.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eu
-VERSION=$(git describe --tags | sed s/^v//)
+VERSION="$(git describe --tags | sed 's/^v//' | sed 's/-nightly$//')"
 if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   echo "Version $VERSION does not match semver pattern MAJOR.MINOR.PATCH where each part is a number"
   echo "To fix this problem, make sure you are running this script with a non-dirty work tree and that HEAD points to a commit that has an associated git tag using the format vMAJOR.MINOR.PATCH"


### PR DESCRIPTION
The release job failed because it didn't recognize the new `MAJOR.MINOR.PATCH-nightly` format.


## Test plan
n/a
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
