### PR TITLE
Stop using Gradle cache for sourcegraph+cody clones

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -163,7 +163,7 @@ fun unzip(input: File, output: File, excludeMatcher: PathMatcher? = null) {
 }
 
 val githubArchiveCache =
-    Paths.get(System.getProperty("user.home"), ".gradle", "caches", "sourcegraph").toFile()
+    Paths.get(System.getProperty("user.home"), ".sourcegraph", "caches", "jetbrains").toFile()
 
 tasks {
   val codeSearchCommit = "9d86a4f7d183e980acfe5d6b6468f06aaa0d8acf"


### PR DESCRIPTION
Previously, we did shallow git clones of sourcegraph/sourcegraph and sourcegraph/cody to the Gradle cache. This was problematic because it was taking a very long time to create the cache in CI, defeating the point of caching. This PR moves the shallow clones to another directory so that they are not cached, which hopefully speeds up the caching step in CI (which is taking 5-7 minutes before this PR)


## Test plan

Merge the PR and see CI become faster
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
