### PR TITLE
Handle updated access token format from RFC 837

### DIFF
--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -7,6 +7,8 @@ public class AuthorizationUtil {
     return accessToken.isEmpty()
         || accessToken.length() == 40
         || (accessToken.startsWith("sgp_") && accessToken.length() == 44)
-        || (accessToken.startsWith("sgp_") && (accessToken.length() == 61 || accessToken.length() == 62)); // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
+        // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
+        || (accessToken.startsWith("sgp_") && accessToken.length() == 61)
+        || (accessToken.startsWith("sgph_") && accessToken.length() == 62);
   }
 }

--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -6,6 +6,7 @@ public class AuthorizationUtil {
   public static boolean isValidAccessToken(@NotNull String accessToken) {
     return accessToken.isEmpty()
         || accessToken.length() == 40
-        || (accessToken.startsWith("sgp_") && accessToken.length() == 44);
+        || (accessToken.startsWith("sgp_") && accessToken.length() == 44)
+        || (accessToken.startsWith("sgp_") && ( accessToken.length() == 61) || accessToken.length() == 62)); // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
   }
 }

--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -7,6 +7,6 @@ public class AuthorizationUtil {
     return accessToken.isEmpty()
         || accessToken.length() == 40
         || (accessToken.startsWith("sgp_") && accessToken.length() == 44)
-        || (accessToken.startsWith("sgp_") && ( accessToken.length() == 61) || accessToken.length() == 62)); // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
+        || (accessToken.startsWith("sgp_") && (accessToken.length() == 61 || accessToken.length() == 62)); // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
   }
 }


### PR DESCRIPTION
As part of [RFC 837](https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno/edit#heading=h.a31kbqeib9od) we will be updating the access token format.

This PR updates the JetBrains plugin's token validator to handle this new format. I've specified 61 or 62 characters as we haven't yet determined whether we can keep the `sgp_` prefix or will have to switch to `sgph_` - this will depend on Github when we join their secret scanning program. We can clean this up in a future release.

Example tokens:
- `sgp_abcdef0123456789_1234567890123456789012345678901234567890`
- `sgph_abcdef0123456789_1234567890123456789012345678901234567890`

Related to https://github.com/sourcegraph/sourcegraph/pull/56772.

## Questions for reviewers

- Is this only called the first time a token is configured/edited, or every time a Cody request is made?
- Do we have a way of determining when all extension users have upgraded to a version that contains this change?

## Test plan

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
