### PR TITLE
Add a hint on trigger when no account signed in

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -160,6 +160,7 @@ class CodyAutocompleteManager {
     if (isTriggeredExplicitly &&
         CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
       HintManager.getInstance().showErrorHint(editor, "Cody: No account signed-in")
+      return
     }
     cancelCurrentJob(project)
     val cancellationToken = CancellationToken()

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -159,7 +159,7 @@ class CodyAutocompleteManager {
     }
     if (isTriggeredExplicitly &&
         CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
-      HintManager.getInstance().showErrorHint(editor, "Cody: No account signed-in")
+      HintManager.getInstance().showErrorHint(editor, "Cody: Sign in to use autocomplete")
       return
     }
     cancelCurrentJob(project)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.autocomplete
 
+import com.intellij.codeInsight.hint.HintManager
 import com.intellij.codeInsight.lookup.LookupManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.CommandProcessor
@@ -22,6 +23,7 @@ import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteBlockElementRend
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteElementRenderer
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteSingleLineRenderer
 import com.sourcegraph.cody.autocomplete.render.InlayModelUtil.getAllInlaysForEditor
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatus
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService.Companion.resetApplication
@@ -154,6 +156,10 @@ class CodyAutocompleteManager {
     val autoCompleteDocumentContext = textDocument.getAutocompleteContext(offset)
     if (isTriggeredImplicitly && !autoCompleteDocumentContext.isCompletionTriggerValid()) {
       return
+    }
+    if (isTriggeredExplicitly &&
+        CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
+      HintManager.getInstance().showErrorHint(editor, "Cody: No account signed-in")
     }
     cancelCurrentJob(project)
     val cancellationToken = CancellationToken()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/56050.

When the trigger is explicit but there is no account let's provide a visual error hint.

## Test plan

1. Remove all authentication settings
2. Trigger autocomplete
3. a visible hint