### PR TITLE
Fix the automatic repository detection for ssh remotes with port numbers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "68281675fd0731c0b2d30f61b85bb84dea165242" // todo
+  val codyCommit = "8a61ffc8a55631350a31276b39f38e003007a3d2"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "68281675fd0731c0b2d30f61b85bb84dea165242"
+  val codyCommit = "68281675fd0731c0b2d30f61b85bb84dea165242" // todo
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -44,6 +44,9 @@ public interface CodyAgentServer {
   @JsonRequest("graphql/getRepoId")
   CompletableFuture<@Nullable String> getRepoId(GetRepoID repoName);
 
+  @JsonRequest("convertGitCloneURLToCodebaseName")
+  CompletableFuture<@Nullable String> convertGitCloneURLToCodebaseName(String cloneURL);
+
   // Notifications
   @JsonNotification("initialized")
   void initialized();

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -45,7 +45,7 @@ public interface CodyAgentServer {
   CompletableFuture<@Nullable String> getRepoId(GetRepoID repoName);
 
   @JsonRequest("git/codebaseName")
-  CompletableFuture<@Nullable String> convertGitCloneURLToCodebaseName(String cloneURL);
+  CompletableFuture<@Nullable String> convertGitCloneURLToCodebaseName(CloneURL cloneURL);
 
   // Notifications
   @JsonNotification("initialized")

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentServer.java
@@ -44,7 +44,7 @@ public interface CodyAgentServer {
   @JsonRequest("graphql/getRepoId")
   CompletableFuture<@Nullable String> getRepoId(GetRepoID repoName);
 
-  @JsonRequest("convertGitCloneURLToCodebaseName")
+  @JsonRequest("git/codebaseName")
   CompletableFuture<@Nullable String> convertGitCloneURLToCodebaseName(String cloneURL);
 
   // Notifications

--- a/src/main/java/com/sourcegraph/cody/agent/protocol/CloneURL.java
+++ b/src/main/java/com/sourcegraph/cody/agent/protocol/CloneURL.java
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.agent.protocol;
+
+public class CloneURL {
+  public final String url;
+
+  public CloneURL(String url) {
+    this.url = url;
+  }
+}

--- a/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -147,9 +147,21 @@ public class RepoUtil {
     VCSType vcsType = getVcsType(project, file);
 
     if (vcsType == VCSType.GIT && repository != null) {
+      String cloneURL;
+      try {
+        cloneURL = GitUtil.getRemoteRepoUrl((GitRepository) repository, project);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
       return CodyAgent.withServer(
           project,
-          server -> server.convertGitCloneURLToCodebaseName(repository.getPresentableUrl()));
+          server -> {
+            System.out.println("[debug] cloneURL="+ cloneURL);
+            return server.convertGitCloneURLToCodebaseName(cloneURL).thenApply(result -> {
+              System.out.println("[debug] result="+ result);
+              return result;
+            });
+          });
     }
 
     if (vcsType == VCSType.PERFORCE) {

--- a/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcsUtil.VcsUtil;
+import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.config.CodyProjectSettings;
 import com.sourcegraph.common.ErrorNotification;
 import git4idea.GitVcs;
@@ -14,6 +15,7 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.idea.perforce.perforce.PerforceAuthenticationException;
@@ -47,7 +49,7 @@ public class RepoUtil {
         relativePath = relativePath.substring(relativePath.indexOf("/") + 1);
       }
 
-      remoteUrl = getRemoteRepoUrl(project, file);
+      remoteUrl = getRemoteRepoUrl(project, file).join(); // todo
       remoteUrl = doReplacements(codyProjectSettings, remoteUrl);
 
       // If the current branch doesn't exist on the remote or if the remote
@@ -85,11 +87,10 @@ public class RepoUtil {
     if (fileFromTheRepository == null) {
       return null;
     }
-    try {
-      return RepoUtil.getRemoteRepoUrlWithoutScheme(project, fileFromTheRepository);
-    } catch (Exception e) {
-      return RepoUtil.getSimpleRepositoryName(project, fileFromTheRepository);
-    }
+
+    return RepoUtil.getRemoteRepoUrlWithoutScheme(project, fileFromTheRepository)
+        .exceptionally(e -> RepoUtil.getSimpleRepositoryName(project, fileFromTheRepository))
+        .join(); // todo
   }
 
   @Nullable
@@ -122,39 +123,51 @@ public class RepoUtil {
 
   // Returned format: github.com/sourcegraph/sourcegraph
   // Must be called from non-EDT context
-  private static @NotNull String getRemoteRepoUrlWithoutScheme(
-      @NotNull Project project, @NotNull VirtualFile file) throws Exception {
-    String remoteUrl = getRemoteRepoUrl(project, file);
-    String repoName;
-    try {
-      URL url = new URL(remoteUrl);
-      repoName = url.getHost() + url.getPath();
-    } catch (MalformedURLException e) {
-      repoName = remoteUrl.substring(remoteUrl.indexOf('@') + 1).replaceFirst(":", "/");
-    }
-    return repoName.replaceFirst(".git$", "");
+  private static @NotNull CompletableFuture<String> getRemoteRepoUrlWithoutScheme(
+      @NotNull Project project, @NotNull VirtualFile file) {
+    return getRemoteRepoUrl(project, file)
+        .thenApply(
+            remoteUrl -> {
+              String repoName;
+              try {
+                URL url = new URL(remoteUrl);
+                repoName = url.getHost() + url.getPath();
+              } catch (MalformedURLException e) {
+                repoName = remoteUrl.substring(remoteUrl.indexOf('@') + 1).replaceFirst(":", "/");
+              }
+              return repoName.replaceFirst(".git$", "");
+            });
   }
 
   // Returned format: git@github.com:sourcegraph/sourcegraph.git
   // Must be called from non-EDT context
-  public static @NotNull String getRemoteRepoUrl(
-      @NotNull Project project, @NotNull VirtualFile file) throws Exception {
+  public static @NotNull CompletableFuture<String> getRemoteRepoUrl(
+      @NotNull Project project, @NotNull VirtualFile file) {
     Repository repository = VcsRepositoryManager.getInstance(project).getRepositoryForFile(file);
     VCSType vcsType = getVcsType(project, file);
 
     if (vcsType == VCSType.GIT && repository != null) {
-      return GitUtil.getRemoteRepoUrl((GitRepository) repository, project);
+      return CodyAgent.withServer(
+          project,
+          server -> server.convertGitCloneURLToCodebaseName(repository.getPresentableUrl()));
     }
 
     if (vcsType == VCSType.PERFORCE) {
-      return PerforceUtil.getRemoteRepoUrl(project, file);
+      try {
+        return CompletableFuture.completedFuture(PerforceUtil.getRemoteRepoUrl(project, file));
+      } catch (Exception e) {
+        return CompletableFuture.failedFuture(e);
+      }
     }
 
     if (repository == null) {
-      throw new Exception("Could not find repository for file " + file.getPath());
+      return CompletableFuture.failedFuture(
+          new Exception("Could not find repository for file " + file.getPath()));
     }
 
-    throw new Exception("Unsupported VCS: " + repository.getVcs().getName());
+    // completable future error
+    return CompletableFuture.failedFuture(
+        new Exception("Unsupported VCS: " + repository.getVcs().getName()));
   }
 
   /** Returns the repository root directory for any path within a repository. */

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -74,36 +74,37 @@ public class OpenRevisionAction extends DumbAwareAction {
     ApplicationManager.getApplication()
         .executeOnPooledThread(
             () -> {
-              String remoteUrl;
-              try {
-                remoteUrl = RepoUtil.getRemoteRepoUrl(project, context.getRepoRoot());
-              } catch (Exception e) {
-                throw new RuntimeException(e);
-              }
-
-              String url;
-              try {
-                url =
-                    URLBuilder.buildCommitUrl(
-                        ConfigUtil.getServerPath(project).getUrl(),
-                        context.getRevisionNumber(),
-                        remoteUrl,
-                        productName,
-                        productVersion);
-              } catch (IllegalArgumentException e) {
-                logger.warn(
-                    "Unable to build commit view URI for url "
-                        + ConfigUtil.getServerPath(project).getUrl()
-                        + ", revision "
-                        + context.getRevisionNumber()
-                        + ", product "
-                        + productName
-                        + ", version "
-                        + productVersion,
-                    e);
-                return;
-              }
-              BrowserOpener.openInBrowser(project, url);
+              RepoUtil.getRemoteRepoUrl(project, context.getRepoRoot())
+                  .thenAccept(
+                      remoteUrl -> {
+                        String url;
+                        try {
+                          url =
+                              URLBuilder.buildCommitUrl(
+                                  ConfigUtil.getServerPath(project).getUrl(),
+                                  context.getRevisionNumber(),
+                                  remoteUrl,
+                                  productName,
+                                  productVersion);
+                        } catch (IllegalArgumentException e) {
+                          logger.warn(
+                              "Unable to build commit view URI for url "
+                                  + ConfigUtil.getServerPath(project).getUrl()
+                                  + ", revision "
+                                  + context.getRevisionNumber()
+                                  + ", product "
+                                  + productName
+                                  + ", version "
+                                  + productVersion,
+                              e);
+                          return;
+                        }
+                        BrowserOpener.openInBrowser(project, url);
+                      })
+                  .exceptionally(
+                      e -> {
+                        throw new RuntimeException(e);
+                      });
             });
   }
 

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -74,37 +74,36 @@ public class OpenRevisionAction extends DumbAwareAction {
     ApplicationManager.getApplication()
         .executeOnPooledThread(
             () -> {
-              RepoUtil.getRemoteRepoUrl(project, context.getRepoRoot())
-                  .thenAccept(
-                      remoteUrl -> {
-                        String url;
-                        try {
-                          url =
-                              URLBuilder.buildCommitUrl(
-                                  ConfigUtil.getServerPath(project).getUrl(),
-                                  context.getRevisionNumber(),
-                                  remoteUrl,
-                                  productName,
-                                  productVersion);
-                        } catch (IllegalArgumentException e) {
-                          logger.warn(
-                              "Unable to build commit view URI for url "
-                                  + ConfigUtil.getServerPath(project).getUrl()
-                                  + ", revision "
-                                  + context.getRevisionNumber()
-                                  + ", product "
-                                  + productName
-                                  + ", version "
-                                  + productVersion,
-                              e);
-                          return;
-                        }
-                        BrowserOpener.openInBrowser(project, url);
-                      })
-                  .exceptionally(
-                      e -> {
-                        throw new RuntimeException(e);
-                      });
+              String remoteUrl;
+              try {
+                remoteUrl = RepoUtil.getRemoteRepoUrl(project, context.getRepoRoot());
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+
+              String url;
+              try {
+                url =
+                    URLBuilder.buildCommitUrl(
+                        ConfigUtil.getServerPath(project).getUrl(),
+                        context.getRevisionNumber(),
+                        remoteUrl,
+                        productName,
+                        productVersion);
+              } catch (IllegalArgumentException e) {
+                logger.warn(
+                    "Unable to build commit view URI for url "
+                        + ConfigUtil.getServerPath(project).getUrl()
+                        + ", revision "
+                        + context.getRevisionNumber()
+                        + ", product "
+                        + productName
+                        + ", version "
+                        + productVersion,
+                    e);
+                return;
+              }
+              BrowserOpener.openInBrowser(project, url);
             });
   }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/56929. 

Before merging this one we need changes to the agent:
https://github.com/sourcegraph/cody/pull/1425

- [x] once your cody PR is merged, you will need to bump up the commit hash on the jetbrains side

## Test plan
- [x] Test it manually against the reported url:
```
test('converts GitHub SSH URL with the port number', () => {
        expect(convertGitCloneURLToCodebaseName('ssh://git@gitlab-my-company.net:20022/path/repo.git')).toEqual(
            'gitlab-my-company.net/path/repo'
        )
    })
```

- [x] and do this:
> when bumping up the cody commit hash, it's worth doing manual tests for chat/autocomplete/onboarding