### PR TITLE
Allow to specify cody directory for use instead of the committed version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,17 +21,18 @@ using the `jetbrains-ide` & `team/integrations` labels.
     - https://plugins.jetbrains.com/plugin/8527-google-java-format
     - https://plugins.jetbrains.com/plugin/14912-ktfmt
 
-| What                                                          | Command                                                                  |
-|---------------------------------------------------------------|--------------------------------------------------------------------------|
-| Run the plugin locally                                        | `./gradlew :runIDE`                                                      |
-| Run the plugin locally with fresh build of Cody               | `./gradlew -PforceAgentBuild=true :runIDE`                               |
-| Run the plugin locally with fresh build of Code Search assets | `./gradlew -PforceCodeSearchBuild=true :runIDE`                          |
-| Build Code Search assets (separate terminal)                  | `pnpm build`                                                             |
-| Continuously re-build Code Search assets (separate terminal)  | `pnpm watch`                                                             |
-| Code Search "Find with Sourcegraph" window                    | `pnpm standalone && open http://localhost:3000/`                         |
-| Build deployable plugin                                       | `./gradlew buildPlugin` (artifact is generated in `build/distributions`) |
-| Reformat Java and Kotlin sources                              | `./gradlew spotlessApply`                                                |
-| Debug agent JSON-RPC communication                            | `tail -f build/sourcegraph/cody-agent-trace.json`                        |
+| What                                                             | Command                                                                  |
+|------------------------------------------------------------------|--------------------------------------------------------------------------|
+| Run the plugin locally                                           | `./gradlew :runIDE`                                                      |
+| Run the plugin locally with fresh build of Cody                  | `./gradlew -PforceAgentBuild=true :runIDE`                               |
+| Run the plugin locally with fresh build of a local clone of Cody | `CODY_DIR=<path_to_cody> ./gradlew -PforceAgentBuild=true :runIDE`       |
+| Run the plugin locally with fresh build of Code Search assets    | `./gradlew -PforceCodeSearchBuild=true :runIDE`                          |
+| Build Code Search assets (separate terminal)                     | `pnpm build`                                                             |
+| Continuously re-build Code Search assets (separate terminal)     | `pnpm watch`                                                             |
+| Code Search "Find with Sourcegraph" window                       | `pnpm standalone && open http://localhost:3000/`                         |
+| Build deployable plugin                                          | `./gradlew buildPlugin` (artifact is generated in `build/distributions`) |
+| Reformat Java and Kotlin sources                                 | `./gradlew spotlessApply`                                                |
+| Debug agent JSON-RPC communication                               | `tail -f build/sourcegraph/cody-agent-trace.json`                        |
 
 ## Using Nightly channel releases
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,6 +213,11 @@ tasks {
     return destination
   }
   fun unzipCody(): File {
+    val fromEnvironmentVariable = System.getenv("CODY_DIR")
+    if (!fromEnvironmentVariable.isNullOrEmpty()) {
+      return Paths.get(fromEnvironmentVariable.replace("~", System.getProperty("user.home")))
+          .toFile()
+    }
     val zipFile = downloadCody()
     val destination = githubArchiveCache.resolve("cody").resolve("cody-$codyCommit")
     unzip(zipFile, destination.parentFile)
@@ -224,10 +229,7 @@ tasks {
       println("Cached $buildCodyDir")
       return buildCodyDir
     }
-    val codyDirEnv: String? =
-        System.getenv("CODY_DIR")?.replace("~", System.getProperty("user.home"))
-    val codyDir: File =
-        if (codyDirEnv.isNullOrEmpty()) unzipCody() else Paths.get(codyDirEnv).normalize().toFile()
+    val codyDir = unzipCody()
     println("Using cody from codyDir=$codyDir")
     exec {
       workingDir(codyDir)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -215,8 +215,14 @@ tasks {
   fun unzipCody(): File {
     val fromEnvironmentVariable = System.getenv("CODY_DIR")
     if (!fromEnvironmentVariable.isNullOrEmpty()) {
-      return Paths.get(fromEnvironmentVariable.replace("~", System.getProperty("user.home")))
-          .toFile()
+      // "~" works fine from the terminal, however it breaks IntelliJ's run configurations
+      val pathString =
+          if (fromEnvironmentVariable.startsWith("~")) {
+            System.getProperty("user.home") + fromEnvironmentVariable.substring(1)
+          } else {
+            fromEnvironmentVariable
+          }
+      return Paths.get(pathString).toFile()
     }
     val zipFile = downloadCody()
     val destination = githubArchiveCache.resolve("cody").resolve("cody-$codyCommit")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,7 +224,11 @@ tasks {
       println("Cached $buildCodyDir")
       return buildCodyDir
     }
-    val codyDir = unzipCody()
+    val codyDirEnv: String? =
+        System.getenv("CODY_DIR")?.replace("~", System.getProperty("user.home"))
+    val codyDir: File =
+        if (codyDirEnv.isNullOrEmpty()) unzipCody() else Paths.get(codyDirEnv).normalize().toFile()
+    println("Using cody from codyDir=$codyDir")
     exec {
       workingDir(codyDir)
       commandLine("pnpm", "install", "--frozen-lockfile")


### PR DESCRIPTION


I have two run configurations, for Cody from commit:
![image](https://github.com/sourcegraph/jetbrains/assets/19799111/e7596a95-4967-418a-af35-22aa533a8472)


And for the local clone of Cody:
![image](https://github.com/sourcegraph/jetbrains/assets/19799111/4c84ecf7-b98d-4f0f-ad37-565b0f503cf1)
