### PR TITLE
Simplify access token matching and add docs URL

### DIFF
--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AuthorizationUtil {
   public static boolean isValidAccessToken(@NotNull String accessToken) {
-    // Sourcegraph access token formats: see https://docs.sourcegraph.com/dev/security/secret-formats
+    // Sourcegraph access token formats: https://docs.sourcegraph.com/dev/security/secret-formats
     return accessToken.isEmpty()
         || accessToken.length() == 40
         || accessToken.startsWith("sgp_");

--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -4,11 +4,9 @@ import org.jetbrains.annotations.NotNull;
 
 public class AuthorizationUtil {
   public static boolean isValidAccessToken(@NotNull String accessToken) {
+    // Sourcegraph access token formats: see https://docs.sourcegraph.com/dev/security/secret-formats
     return accessToken.isEmpty()
         || accessToken.length() == 40
-        || (accessToken.startsWith("sgp_") && accessToken.length() == 44)
-        // See https://docs.google.com/document/d/1aC4gHB8Q5lurwVhc8SCxznR0blNJMKo7yIkpP7WShno
-        || (accessToken.startsWith("sgp_") && accessToken.length() == 61)
-        || (accessToken.startsWith("sgph_") && accessToken.length() == 62);
+        || accessToken.startsWith("sgp_");
   }
 }

--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -5,8 +5,6 @@ import org.jetbrains.annotations.NotNull;
 public class AuthorizationUtil {
   public static boolean isValidAccessToken(@NotNull String accessToken) {
     // Sourcegraph access token formats: https://docs.sourcegraph.com/dev/security/secret-formats
-    return accessToken.isEmpty()
-        || accessToken.length() == 40
-        || accessToken.startsWith("sgp_");
+    return accessToken.isEmpty() || accessToken.length() == 40 || accessToken.startsWith("sgp_");
   }
 }

--- a/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
+++ b/src/main/java/com/sourcegraph/common/AuthorizationUtil.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class AuthorizationUtil {
   public static boolean isValidAccessToken(@NotNull String accessToken) {
-    // Sourcegraph access token formats: https://docs.sourcegraph.com/dev/security/secret-formats
+    // Sourcegraph access token formats: https://docs.sourcegraph.com/dev/security/secret_formats
     return accessToken.isEmpty() || accessToken.length() == 40 || accessToken.startsWith("sgp_");
   }
 }


### PR DESCRIPTION
Simplify token matching format, as the previous length-based validation missed an edge case. Also remove `sgph_` prefix as we're going ahead with `sgp_`.

~URL in comment is pending https://github.com/sourcegraph/sourcegraph/pull/57722 merging.~

## Test plan

- CI

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
