### PR TITLE
Fix rendering of html tags in the chat

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowContent.java
@@ -23,6 +23,7 @@ import com.intellij.util.concurrency.annotations.RequiresEdt;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.StatusText;
 import com.intellij.util.ui.UIUtil;
+import com.intellij.xml.util.XmlStringUtil;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentManager;
 import com.sourcegraph.cody.agent.CodyAgentServer;
@@ -519,7 +520,8 @@ public class CodyToolWindowContent implements UpdatableChat {
 
     startMessageProcessing();
 
-    ChatMessage humanMessage = new ChatMessage(Speaker.HUMAN, message, message);
+    String displayText = XmlStringUtil.escapeString(message);
+    ChatMessage humanMessage = new ChatMessage(Speaker.HUMAN, message, displayText);
     addMessageToChat(humanMessage);
     activateChatTab();
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/30.

I guess there is still an area for improvement - the chat could keep whitespaces. 
However, now the html tags are handled properly 🚀 

Demo:

https://github.com/sourcegraph/jetbrains/assets/19799111/3de7ebba-34d0-4b40-8fd9-b3b5c1e2ac2a



