### PR TITLE
Fix version numbering script

### DIFF
--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -15,8 +15,9 @@ if ! command -v gdate &>/dev/null; then
 fi
 
 
-MAJOR_MINOR=$(gh release list --repo sourcegraph/sourcegraph --limit 1 --exclude-drafts --exclude-pre-releases | awk '{ print $2 }' | tail -n 1 | cut -d. -f1 -f2)
-LAST_RELEASE_TIMESTAMP=$(gh release list --repo sourcegraph/sourcegraph --limit 1 --exclude-drafts --exclude-pre-releases | awk '{ print $5 }')
+LAST_MAJOR_MINOR_ZERO_RELEASE=$(gh release list --repo sourcegraph/sourcegraph --limit 20 --exclude-drafts --exclude-pre-releases | awk '$3 ~ /v[0-9]+\.[0-9]+\.0$/ { print $3, $4; exit }')
+MAJOR_MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f1 -f2)
+LAST_RELEASE_TIMESTAMP=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $2 }')
 
 # Current year
 MILLIS_START_YEAR="$(gdate -d "$LAST_RELEASE_TIMESTAMP" +%s%3N)"


### PR DESCRIPTION
Previously, the patch number was computed based on the release timestamp of the last Sourcegraph release. This was problematic because it meant we reset the patch number for every new patch release of Sourcegraph. This PR fixes the problem by making the patch number be based on the release timestamp of the latest MAJOR.MINOR.0 release.


## Test plan
```
# This PR
❯ ./scripts/next-release.sh
5.2.3528
# On main
❯ ./scripts/next-release.sh
5.2.841
```

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
