### PR TITLE
Fix Apple M1 issue for CI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
           distribution: "temurin"
           java-version: 11
           cache: "gradle"
+      # See note about QEMU and binfmt requirement here https://github.com/vercel/pkg#targets
+      - name: Set up QEMU
+         id: qemu
+         uses: docker/setup-qemu-action@v1
+         with:
+           image: tonistiigi/binfmt:latest
+           platforms: all
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.1.0
       - run: ./scripts/install-ldid.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -247,13 +247,13 @@ tasks {
       commandLine("pnpm", "run", "build-agent-binaries")
       environment("AGENT_EXECUTABLE_TARGET_DIRECTORY", buildCodyDir.toString())
     }
-    // If running on Linux in CI, run ldid2 -S on the macos-arm64 binary so that it can be run on
+    // If running on Linux in CI, run ldid -S on the macos-arm64 binary so that it can be run on
     // Apple M1 computers. This is required to prevent the following issue
     // https://github.com/vercel/pkg/issues/2004
     if (isLdidSign) {
       val arm64Binary = buildCodyDir.resolve("agent-macos-arm64").toString()
-      println("Signing ldid2 -S $arm64Binary")
-      exec { commandLine("ldid2", "-S", arm64Binary) }
+      println("Signing ldid -S $arm64Binary")
+      exec { commandLine("ldid", "-S", arm64Binary) }
     }
     return buildCodyDir
   }

--- a/scripts/install-ldid.sh
+++ b/scripts/install-ldid.sh
@@ -14,4 +14,4 @@ curl -Lo ldid.zip https://github.com/xerub/ldid/archive/refs/heads/master.zip
 unzip ldid.zip
 cd ldid-master
 ./make.sh
-cp ldid2 /usr/local/bin/
+cp ldid /usr/local/bin/


### PR DESCRIPTION
The CI release workflow was missing a dependency on QEMU and binfmt to correctly sign the agent-macos-arm64 binary.

Massive kudos to @burmudar for the help with this! https://github.com/sourcegraph/cody/pull/1474

Towards https://github.com/sourcegraph/jetbrains/issues/52

## Test plan

Merge this PR, cut a new nightly release and manually verify that it works on Apple M1.
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
