### PR TITLE
Add `testIntegration` task with Autocompletion Tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,40 @@ This workflow is not automated yet. Our goal is to publish stable releases by pr
 manually tested. What we're missing is a script to download the zip file of a nightly release, correct the version
 to be non-nightly and then upload it to the JetBrains Marketplace.
 
+## Testing
+
+### Unit tests
+
+```shell
+./gradlew test
+```
+    
+### Integration tests
+
+```shell
+./gradlew testIntegration
+```
+
+Integration tests require an environmental variable with valid `SRC_ACCESS_TOKEN`. Otherwise, they will not start.
+
+### UI tests
+
+UI tests are based on [intellij-ui-test-robot](https://github.com/JetBrains/intellij-ui-test-robot).
+
+First, launch the IDE:
+
+```shell
+./gradlew runIdeForUiTests
+```
+
+Next, wait until the IDE is launched. When everything is ready to use: 
+
+```shell
+./gradlew testUI
+```
+
+During the tests, mouse move and keyboard clicking will be simulated, so it is important not to interfere.
+
 ## Enabling web view debugging
 
 Parts of this extension rely on the [JCEF](https://plugins.jetbrains.com/docs/intellij/jcef.html) web view features

--- a/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
@@ -1,17 +1,37 @@
 package com.sourcegraph.cody.auth
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.config.CodyAccount
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.getFirstAccountOrNull
 import com.sourcegraph.cody.initialization.Activity
 
 class SelectOneOfTheAccountsAsActive : Activity {
+
+  private val logger = Logger.getInstance(SelectOneOfTheAccountsAsActive::class.java)
+
   override fun runActivity(project: Project) {
-    val codyAuthenticationManager = CodyAuthenticationManager.instance
-    if (codyAuthenticationManager.getActiveAccount(project) == null) {
-      val newActiveAccount = codyAuthenticationManager.getAccounts().getFirstAccountOrNull()
-      codyAuthenticationManager.setActiveAccount(project, newActiveAccount)
+    val manager = CodyAuthenticationManager.instance
+    activateTestAccountIfAvailable(project, manager)
+    activateAnyAccount(project, manager)
+  }
+
+  private fun activateTestAccountIfAvailable(project: Project, manager: CodyAuthenticationManager) {
+    val testToken = System.getenv("SRC_ACCESS_TOKEN")
+    if (testToken != null) {
+      val testAccount = CodyAccount("test", "Test User")
+      manager.updateAccountToken(testAccount, testToken)
+      manager.setActiveAccount(project, testAccount)
+      logger.warn("Test account with external SRC_ACCESS_TOKEN selected as active")
+    }
+  }
+
+  private fun activateAnyAccount(project: Project, manager: CodyAuthenticationManager) {
+    if (manager.getActiveAccount(project) == null) {
+      val newActiveAccount = manager.getAccounts().getFirstAccountOrNull()
+      manager.setActiveAccount(project, newActiveAccount)
       val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
       codyToolWindowContent.refreshPanelsVisibility()
     }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -57,6 +57,7 @@ import java.util.stream.Collectors
 class CodyAutocompleteManager {
   private val logger = Logger.getInstance(CodyAutocompleteManager::class.java)
   private val currentJob = AtomicReference(CancellationToken())
+  private var isAsync = true
   var currentAutocompleteTelemetry: AutocompleteTelemetry? = null
 
   /**
@@ -168,6 +169,7 @@ class CodyAutocompleteManager {
     val autocompleteRequest =
         triggerAutocompleteAsync(
             project, editor, offset, textDocument, triggerKind, cancellationToken)
+    if (!isAsync) autocompleteRequest.join()
     cancellationToken.onCancellationRequested { autocompleteRequest.cancel(true) }
   }
 
@@ -330,6 +332,10 @@ class CodyAutocompleteManager {
   private fun cancelCurrentJob(project: Project?) {
     currentJob.get().abort()
     resetApplication(project!!)
+  }
+
+  fun disableAsyncAutocomplete() {
+    isAsync = false
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/config/ServerAuth.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ServerAuth.kt
@@ -1,25 +1,25 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.project.Project
-import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.config.ConfigUtil.DOTCOM_URL
 
 data class ServerAuth(
     val instanceUrl: String,
-    val accessToken: String,
-    val customRequestHeaders: String
+    val accessToken: String = "",
+    val customRequestHeaders: String = ""
 )
 
 object ServerAuthLoader {
 
   @JvmStatic
   fun loadServerAuth(project: Project): ServerAuth {
-    val codyAuthenticationManager = CodyAuthenticationManager.instance
-    val defaultAccount = codyAuthenticationManager.getActiveAccount(project)
+    val authManager = CodyAuthenticationManager.instance
+    val defaultAccount = authManager.getActiveAccount(project)
     if (defaultAccount != null) {
-      val accessToken = codyAuthenticationManager.getTokenForAccount(defaultAccount) ?: ""
+      val token = authManager.getTokenForAccount(defaultAccount) ?: ""
       return ServerAuth(
-          defaultAccount.server.url, accessToken, defaultAccount.server.customRequestHeaders)
+          defaultAccount.server.url, token, defaultAccount.server.customRequestHeaders)
     }
-    return ServerAuth(ConfigUtil.DOTCOM_URL, "", "")
+    return ServerAuth(DOTCOM_URL)
   }
 }

--- a/src/testIntegration/kotlin/com/sourcegraph/cody/autocomplete/action/TriggerAutocompleteActionTest.kt
+++ b/src/testIntegration/kotlin/com/sourcegraph/cody/autocomplete/action/TriggerAutocompleteActionTest.kt
@@ -1,0 +1,18 @@
+package com.sourcegraph.cody.autocomplete.action
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
+
+class TriggerAutocompleteActionTest : BasePlatformTestCase() {
+
+  fun `test autocomplete`() {
+    CodyAutocompleteManager.instance.disableAsyncAutocomplete()
+    myFixture.configureByText("script.py", "print(\"Hello <caret>")
+    myFixture.testAction(TriggerAutocompleteAction())
+
+    val telemetry = CodyAutocompleteManager.instance.currentAutocompleteTelemetry!!.params()!!
+    assertEquals(telemetry.type, "inline")
+    assertEquals(telemetry.languageId, "python")
+    assertEquals(telemetry.lineCount, 1)
+  }
+}

--- a/src/testUI/kotlin/ui/ChatTest.kt
+++ b/src/testUI/kotlin/ui/ChatTest.kt
@@ -1,0 +1,34 @@
+package ui
+
+import com.intellij.remoterobot.RemoteRobot
+import com.intellij.remoterobot.fixtures.ContainerFixture
+import com.intellij.remoterobot.search.locators.byXpath
+import com.intellij.remoterobot.utils.keyboard
+import com.intellij.remoterobot.utils.waitFor
+import junit.framework.TestCase
+
+class ChatTest : TestCase() {
+
+    fun `test send chat message and wait for response`() {
+        val robot = RemoteRobot("http://127.0.0.1:8082")
+        val toolbar = robot.find<ContainerFixture>(byXpath("//div[@tooltiptext='Cody']"))
+        toolbar.click()
+        println()
+        val toolbarChat = robot.find<ContainerFixture>(byXpath("//div[@class='TabContainer']/div[@text='Chat']"))
+        toolbarChat.click()
+        val textArea = robot.find<ContainerFixture>(byXpath("//div[@class='RoundedJBTextArea']"))
+        textArea.click()
+        textArea.keyboard {
+            enterText("Hello, Cody!")
+        }
+        val button = robot.find<ContainerFixture>(byXpath("//div[@text='Send']"))
+        button.click()
+        robot.apply {
+            waitFor {
+                val messages = robot.findAll<ContainerFixture>(byXpath("//div[@class='MessagePanel']"))
+                messages.size > 2
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Add `testIntegration` task with Autocompletion Tests

Fixes https://github.com/sourcegraph/sourcegraph/issues/57976

Added `testIntegration` task with dedicated source set. If `SRC_ACCESS_TOKEN` is missing, these tests will fail.

Running integration testing is optional for developers.

### Test plan

* Add `SRC_ACCESS_TOKEN` environment variable with valid token.
* Run `./gradlew testIntegration`.
* Verify: `TriggerAutocompleteActionTest` passes.
