### PR TITLE
Upgrade to latest Cody

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "8a61ffc8a55631350a31276b39f38e003007a3d2"
+  val codyCommit = "fc38e03899bdd95cafa17e36986e6bfdc4ea5075"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")


### PR DESCRIPTION
Specifically, we need to pull in this PR here to fix an error https://github.com/sourcegraph/cody/pull/1473

Towards https://github.com/sourcegraph/jetbrains/issues/61

## Test plan

Start `runIde` and actively trigger autocomplete. It should not error.

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
