### PR TITLE
Update next-release.sh to make it work on Linux

### DIFF
--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -7,21 +7,38 @@
 # https://docs.google.com/document/d/11cw-7dAp93JmasITNSNCtx31xrQsNB1L2OoxVE6zrTc/edit#bookmark=id.ufwe0bqp83z1
 set -eu
 
-if ! command -v gdate &>/dev/null; then
-  echo "command not found: gdate"
-  echo "The command gdate is required to compute the next version number"
-  echo "To fix this problem, run:\n  brew install coreutils"
+if [[ "$(uname)" == "Darwin" ]]; then
+  if ! command -v gdate &>/dev/null; then
+    echo "Command not found: gdate"
+    echo "The command gdate is required to compute the next version number"
+    echo "To fix this problem, run:\n  brew install coreutils"
+    exit 1
+  fi
+  date_program() {
+    gdate "$@"
+  }
+else
+  if ! command -v date &>/dev/null; then
+    echo "Command not found: date"
+    exit 1
+  fi
+  date_program() {
+    date "$@"
+  }
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo "Command not found: gh"
   exit 1
 fi
 
-
 LAST_MAJOR_MINOR_ZERO_RELEASE=$(gh release list --repo sourcegraph/sourcegraph --limit 20 --exclude-drafts --exclude-pre-releases | awk '$3 ~ /v[0-9]+\.[0-9]+\.0$/ { print $3, $4; exit }')
-MAJOR_MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f1 -f2)
+MAJOR_MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f1,2)
 LAST_RELEASE_TIMESTAMP=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $2 }')
 
 # Current year
-MILLIS_START_YEAR="$(gdate -d "$LAST_RELEASE_TIMESTAMP" +%s%3N)"
-MILLIS_NOW="$(gdate +%s%3N)"
+MILLIS_START_YEAR="$(date_program -d "$LAST_RELEASE_TIMESTAMP" +%s%3N)"
+MILLIS_NOW="$(date_program +%s%3N)"
 BUILDNUM_MILLIS="$(($MILLIS_NOW - $MILLIS_START_YEAR))"
 MILLIS_IN_ONE_MINUTE=60000
 MINUTES_IN_ONE_YEAR=525600 # assuming 365 days


### PR DESCRIPTION
Changes in script:
* Choose between `gdate` and `date`
* Verify `gdate` or `date` is installed
* Verify `gh` is installed
* Update `cut` usage (not sure why, but -fX fields as separate arguments are unsupported on Linux)

### Test Plan

* Run `./next.release.sh` on macOS or Linux
* Expect output similar to `5.2.4100`