### PR TITLE
Bump hardcoded version to prevent issues with version recognition by IDE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=5.2.1715-nightly
+pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.1


### PR DESCRIPTION
Motivation:
* We don't want to manually update this value on every release
* If version from properties is older, the IDE want's us to update to latest public stable version during local testing, which is incorrect
* For example: The "What's New" content is taken from public stable instead of local build and content will automatically change after restart