### PR TITLE
Fix Cody status on missing accesses token

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
@@ -43,7 +43,9 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
           val service =
               ApplicationManager.getApplication().getService(CodyAccountManager::class.java)
           val token =
-              CodyAuthenticationManager.instance.getActiveAccount(project)?.let(service::findCredentials)
+              CodyAuthenticationManager.instance
+                  .getActiveAccount(project)
+                  ?.let(service::findCredentials)
           status =
               if (!ConfigUtil.isCodyEnabled()) {
                 CodyAutocompleteStatus.CodyDisabled

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.config.CodyAccountManager
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.config.ConfigUtil
 import javax.annotation.concurrent.GuardedBy
@@ -39,6 +40,10 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
         synchronized(this) {
           val oldStatus = status
           ApplicationManager.getApplication()
+          val service =
+              ApplicationManager.getApplication().getService(CodyAccountManager::class.java)
+          val token =
+              CodyAuthenticationManager.instance.getActiveAccount(project)?.let(service::findCredentials)
           status =
               if (!ConfigUtil.isCodyEnabled()) {
                 CodyAutocompleteStatus.CodyDisabled
@@ -46,7 +51,7 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
                 CodyAutocompleteStatus.AutocompleteDisabled
               } else if (!CodyAgent.isConnected(project)) {
                 CodyAutocompleteStatus.CodyAgentNotRunning
-              } else if (CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
+              } else if (token == null) {
                 CodyAutocompleteStatus.CodyNotSignedIn
               } else {
                 CodyAutocompleteStatus.Ready


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/57373.

### Demo

https://github.com/sourcegraph/jetbrains/assets/19799111/6764fb2e-8532-4397-8ff6-4164effce284



## Test plan
1. Manual:
    1. modify the code so that `com.sourcegraph.cody.auth.AccountManagerBase#findCredentials` returns `null`
    2. `runIde`