### PR TITLE
Configure :runIde to depend on :buildCody

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -212,6 +212,7 @@ tasks {
     download(url, destination)
     return destination
   }
+
   fun unzipCody(): File {
     val fromEnvironmentVariable = System.getenv("CODY_DIR")
     if (!fromEnvironmentVariable.isNullOrEmpty()) {
@@ -229,6 +230,7 @@ tasks {
     unzip(zipFile, destination.parentFile)
     return destination
   }
+
   val buildCodyDir = buildDir.resolve("sourcegraph").resolve("agent")
   fun buildCody(): File {
     if (!isForceAgentBuild && (buildCodyDir.listFiles()?.size ?: 0) > 0) {
@@ -300,7 +302,7 @@ tasks {
   }
 
   buildPlugin {
-    buildCody()
+    dependsOn(project.tasks.getByPath("buildCody"))
     from(
         fileTree(buildCodyDir) { include("*") },
     ) {
@@ -311,7 +313,7 @@ tasks {
       // Assert that agent binaries are included in the plugin
       val pluginPath = buildPlugin.get().outputs.files.first()
       ZipFile(pluginPath).use { zip ->
-        fun assertExists(name: String): Unit {
+        fun assertExists(name: String) {
           val path = "Sourcegraph/agent/$name"
           if (zip.getEntry(path) == null) {
             throw Error("Agent binary '$path' not found in plugin zip $pluginPath")
@@ -327,6 +329,7 @@ tasks {
   }
 
   runIde {
+    dependsOn(project.tasks.getByPath("buildCody"))
     jvmArgs("-Djdk.module.illegalAccess.silent=true")
     systemProperty("cody-agent.trace-path", "$buildDir/sourcegraph/cody-agent-trace.json")
     systemProperty("cody-agent.directory", buildCodyDir.parent)


### PR DESCRIPTION
Previously, `gradle -PforceBuild :runIde` wouldn't rebuild cody agent, as the task was never in its graph. 

<details><summary>Task graph before</summary>

```
> Task :tiTree
:runIde                                                                (org.jetbrains.intellij.tasks.RunIdeTask)
+--- :initializeIntelliJPlugin                                         (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
`--- :prepareSandbox                                                   (org.jetbrains.intellij.tasks.PrepareSandboxTask)
     +--- :initializeIntelliJPlugin                                    (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     +--- :instrumentedJar                                             (org.jetbrains.intellij.tasks.InstrumentedJarTask)
     |    +--- :initializeIntelliJPlugin                               (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |    `--- :instrumentCode                                         (org.jetbrains.intellij.tasks.InstrumentCodeTask)
     |         +--- :classes                                           (org.gradle.api.DefaultTask)
     |         |    +--- :compileJava                                  (org.gradle.api.tasks.compile.JavaCompile)
     |         |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
     |         |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |         |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
     |         |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |         |    `--- :processResources                             (org.gradle.language.jvm.tasks.ProcessResources)
     |         |         `--- :buildCodeSearch                         (org.gradle.api.DefaultTask)
     |         `--- :initializeIntelliJPlugin                          (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     `--- :jar                                                         (org.gradle.api.tasks.bundling.Jar)
          +--- :classes                                                (org.gradle.api.DefaultTask)
          |    +--- :compileJava                                       (org.gradle.api.tasks.compile.JavaCompile)
          |    |    +--- :compileKotlin                                (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |    `--- :verifyPluginConfiguration                    (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |         +--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    `--- :processResources                                  (org.gradle.language.jvm.tasks.ProcessResources)
          |         +--- :buildCodeSearch                              (org.gradle.api.DefaultTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          +--- :compileJava                                            (org.gradle.api.tasks.compile.JavaCompile)
          |    +--- :compileKotlin                                     (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    |    `--- :verifyPluginConfiguration                    (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |         +--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    `--- :verifyPluginConfiguration                         (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |         +--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          +--- :compileKotlin                                          (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    `--- :verifyPluginConfiguration                         (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |         +--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          `--- :instrumentCode                                         (org.jetbrains.intellij.tasks.InstrumentCodeTask)
               +--- :classes                                           (org.gradle.api.DefaultTask)
               |    +--- :compileJava                                  (org.gradle.api.tasks.compile.JavaCompile)
               |    |    +--- :compileKotlin                           (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
               |    |    |    `--- :verifyPluginConfiguration          (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
               |    |    |         +--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |    |         `--- :patchPluginXml                (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |    |    |              `--- :initializeIntelliJPlugin (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
               |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    `--- :processResources                             (org.gradle.language.jvm.tasks.ProcessResources)
               |         +--- :buildCodeSearch                         (org.gradle.api.DefaultTask)
               |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               +--- :initializeIntelliJPlugin                          (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               `--- :classpathIndexCleanup (finalizer)                 (org.jetbrains.intellij.tasks.ClasspathIndexCleanupTask)
                    `--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
```

</details> 


<details><summary>Task graph after</summary>

```
> Task :tiTree
:runIde                                                                (org.jetbrains.intellij.tasks.RunIdeTask)
+--- :buildCody                                                        (org.gradle.api.DefaultTask)
+--- :initializeIntelliJPlugin                                         (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
`--- :prepareSandbox                                                   (org.jetbrains.intellij.tasks.PrepareSandboxTask)
     +--- :initializeIntelliJPlugin                                    (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     +--- :instrumentedJar                                             (org.jetbrains.intellij.tasks.InstrumentedJarTask)
     |    +--- :initializeIntelliJPlugin                               (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |    `--- :instrumentCode                                         (org.jetbrains.intellij.tasks.InstrumentCodeTask)
     |         +--- :classes                                           (org.gradle.api.DefaultTask)
     |         |    +--- :compileJava                                  (org.gradle.api.tasks.compile.JavaCompile)
     |         |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
     |         |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |         |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
     |         |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     |         |    `--- :processResources                             (org.gradle.language.jvm.tasks.ProcessResources)
     |         |         `--- :buildCodeSearch                         (org.gradle.api.DefaultTask)
     |         `--- :initializeIntelliJPlugin                          (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
     `--- :jar                                                         (org.gradle.api.tasks.bundling.Jar)
          +--- :classes                                                (org.gradle.api.DefaultTask)
          |    +--- :compileJava                                       (org.gradle.api.tasks.compile.JavaCompile)
          |    |    +--- :compileKotlin                                (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |    `--- :verifyPluginConfiguration                    (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |         +--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    `--- :processResources                                  (org.gradle.language.jvm.tasks.ProcessResources)
          |         +--- :buildCodeSearch                              (org.gradle.api.DefaultTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          +--- :compileJava                                            (org.gradle.api.tasks.compile.JavaCompile)
          |    +--- :compileKotlin                                     (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    |    `--- :verifyPluginConfiguration                    (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |    |         +--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |    |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |    `--- :verifyPluginConfiguration                         (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |         +--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          +--- :compileKotlin                                          (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
          |    `--- :verifyPluginConfiguration                         (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
          |         +--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          |         `--- :patchPluginXml                               (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
          |              `--- :initializeIntelliJPlugin                (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
          `--- :instrumentCode                                         (org.jetbrains.intellij.tasks.InstrumentCodeTask)
               +--- :classes                                           (org.gradle.api.DefaultTask)
               |    +--- :compileJava                                  (org.gradle.api.tasks.compile.JavaCompile)
               |    |    +--- :compileKotlin                           (org.jetbrains.kotlin.gradle.tasks.KotlinCompile)
               |    |    |    `--- :verifyPluginConfiguration          (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
               |    |    |         +--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |    |         `--- :patchPluginXml                (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |    |    |              `--- :initializeIntelliJPlugin (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |    `--- :verifyPluginConfiguration               (org.jetbrains.intellij.tasks.VerifyPluginConfigurationTask)
               |    |         +--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    |         `--- :patchPluginXml                     (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |    |              `--- :initializeIntelliJPlugin      (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               |    `--- :processResources                             (org.gradle.language.jvm.tasks.ProcessResources)
               |         +--- :buildCodeSearch                         (org.gradle.api.DefaultTask)
               |         `--- :patchPluginXml                          (org.jetbrains.intellij.tasks.PatchPluginXmlTask)
               |              `--- :initializeIntelliJPlugin           (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               +--- :initializeIntelliJPlugin                          (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)
               `--- :classpathIndexCleanup (finalizer)                 (org.jetbrains.intellij.tasks.ClasspathIndexCleanupTask)
                    `--- :initializeIntelliJPlugin                     (org.jetbrains.intellij.tasks.InitializeIntelliJPluginTask)

```

</details> 

## Test plan

Viewed task graph with org.barfuin.gradle.taskinfo and saw `:runIde` building Cody in gradle output
