### PR TITLE
Handle race between querying for VCS repositories and them being loaded by IntelliJ

### DIFF
--- a/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -4,7 +4,7 @@ import com.intellij.dvcs.repo.Repository;
 import com.intellij.dvcs.repo.VcsRepositoryManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl;
+import com.intellij.openapi.vcs.ProjectLevelVcsManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcsUtil.VcsUtil;
 import com.sourcegraph.cody.agent.CodyAgent;
@@ -226,7 +226,7 @@ public class RepoUtil {
   private static Optional<VirtualFile> getRootFileFromFirstGitRepository(@NotNull Project project) {
     // https://intellij-support.jetbrains.com/hc/en-us/community/posts/206105769/comments/206091565
     Object lock = new Object();
-    ProjectLevelVcsManagerImpl.getInstanceImpl(project)
+    ProjectLevelVcsManager.getInstance(project)
         .runAfterInitialization(
             () -> {
               synchronized (lock) {

--- a/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -4,6 +4,7 @@ import com.intellij.dvcs.repo.Repository;
 import com.intellij.dvcs.repo.VcsRepositoryManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vcs.impl.ProjectLevelVcsManagerImpl;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.vcsUtil.VcsUtil;
 import com.sourcegraph.cody.agent.CodyAgent;
@@ -223,11 +224,22 @@ public class RepoUtil {
   }
 
   private static Optional<VirtualFile> getRootFileFromFirstGitRepository(@NotNull Project project) {
+    // https://intellij-support.jetbrains.com/hc/en-us/community/posts/206105769/comments/206091565
+    Object lock = new Object();
+    ProjectLevelVcsManagerImpl.getInstanceImpl(project)
+        .runAfterInitialization(
+            () -> {
+              synchronized (lock) {
+                lock.notify();
+              }
+            });
+    synchronized (lock) {
+      try {
+        lock.wait();
+      } catch (InterruptedException ignored) {
+      }
+    }
     Optional<Repository> firstFoundRepository =
-        // NOTE(olafurpg): getRepositories() returns an empty stream in most cases. I made multiple
-        // failed attempts to infer the repository from a project. Ideally, we should just persist
-        // the codebase per project so that we only have to wait until the user has opened a file
-        // once for any given project.
         VcsRepositoryManager.getInstance(project).getRepositories().stream()
             .filter(it -> it.getVcs().getName().equals(GitVcs.NAME))
             .findFirst();


### PR DESCRIPTION
See: https://intellij-support.jetbrains.com/hc/en-us/community/posts/115000667650-Ensure-initialization-of-GitRepositoryManager-before-doing-plugin-operation and https://intellij-support.jetbrains.com/hc/en-us/community/posts/206105769-Get-project-git-repositories-in-a-project-component

## Test plan

TODO

<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
