### PR TITLE
Minor RepoAvailableEmbeddingStatus types changes

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/RepoAvailableEmbeddingStatus.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RepoAvailableEmbeddingStatus.kt
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.context
 
-abstract class RepoAvailableEmbeddingStatus protected constructor(fullRepositoryName: String) :
-    EmbeddingStatus {
+sealed class RepoAvailableEmbeddingStatus(fullRepositoryName: String) : EmbeddingStatus {
   private val simpleRepositoryName: String
 
   init {

--- a/src/main/kotlin/com/sourcegraph/cody/context/RepositoryIndexedEmbeddingStatus.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RepositoryIndexedEmbeddingStatus.kt
@@ -4,11 +4,8 @@ import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.Icons
 import javax.swing.Icon
 
-class RepositoryIndexedEmbeddingStatus(repoName: String?) :
-    RepoAvailableEmbeddingStatus(repoName!!) {
-  override fun getIcon(): Icon? {
-    return Icons.Repository.Indexed
-  }
+class RepositoryIndexedEmbeddingStatus(repoName: String) : RepoAvailableEmbeddingStatus(repoName) {
+  override fun getIcon(): Icon = Icons.Repository.Indexed
 
   override fun getTooltip(project: Project): String {
     return "Repository is indexed"

--- a/src/main/kotlin/com/sourcegraph/cody/context/RepositoryMissingEmbeddingStatus.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RepositoryMissingEmbeddingStatus.kt
@@ -7,9 +7,7 @@ import javax.swing.Icon
 class RepositoryMissingEmbeddingStatus(val repoName: String) :
     RepoAvailableEmbeddingStatus(repoName) {
 
-  override fun getIcon(): Icon? {
-    return Icons.Repository.NoEmbedding
-  }
+  override fun getIcon(): Icon = Icons.Repository.NoEmbedding
 
   override fun getTooltip(project: Project): String {
     return "Repository $repoName is not indexed and has no embeddings"

--- a/src/main/kotlin/com/sourcegraph/cody/context/RepositoryNotFoundOnSourcegraphInstance.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RepositoryNotFoundOnSourcegraphInstance.kt
@@ -12,10 +12,10 @@ class RepositoryNotFoundOnSourcegraphInstance(private val repoName: String) :
 
   override fun getTooltip(project: Project): String {
     val activeAccountType = CodyAuthenticationManager.instance.getActiveAccountType(project)
-    if (activeAccountType == AccountType.DOTCOM) {
-      return "$repoName not found on Sourcegraph.com. Support for private repos coming soon"
+    return if (activeAccountType == AccountType.DOTCOM) {
+      "$repoName not found on Sourcegraph.com. Support for private repos coming soon"
     } else {
-      return "Repository $repoName was not found on this Sourcegraph instance"
+      "Repository $repoName was not found on this Sourcegraph instance"
     }
   }
 }


### PR DESCRIPTION
Minor drive-by changes to `RepoAvailableEmbeddingStatus` types:
- change to sealed class to remove need for protected constructor
- change constructor param on `RepositoryIndexedEmbeddingStatus` from `String?` to `String` given immediate null-assertion afterwards

## Test plan

N/A type-system change