### PR TITLE
Fixing lookup manager autocomplete when no input from the user

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -296,8 +296,10 @@ class CodyAutocompleteManager {
       val lastCommonSuffixCharacterPosition =
           findLastCommonSuffixElementPosition(
               originalText.substring(0, caretPositionInLine), lookupString)
-      insertTextFirstLine =
-          insertTextFirstLine.removeRange(lastCommonSuffixCharacterPosition, caretPositionInLine)
+      if (lastCommonSuffixCharacterPosition > 0) {
+        insertTextFirstLine =
+            insertTextFirstLine.removeRange(lastCommonSuffixCharacterPosition, caretPositionInLine)
+      }
 
       // For each autocomplete item, remove common part with already inserted part of the lookup
       // element.


### PR DESCRIPTION
It fixes an issue with lookup manager autocompletion, which doesn't trigger autocompletion for lookup elements without user input common part e.g.
1. In empty line user press `ctrl + space`
2. Lookup manager is triggered
3. No autocompletions for lookup manager suggestions are presented

## Test plan
1. In empty line press `ctrl + space` 
2. Loop through lookup manager suggestions
3. Observe cody autocompletions

https://github.com/sourcegraph/jetbrains/assets/9321940/41b78b36-edd8-495b-9a34-fdbd4616b898

<!-- All pull requests REQUIRE a test plan: https://

docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
