### PR TITLE
Fix passing value of CompletionEvent's  'multiline' instead of 'multilineMode' for telemetry data

### DIFF
--- a/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -70,7 +70,7 @@ public class GraphQlLogger {
       updatedEventParameters.addProperty("source", params.getSource());
       updatedEventParameters.addProperty("charCount", params.getCharCount());
       updatedEventParameters.addProperty("lineCount", params.getLineCount());
-      updatedEventParameters.addProperty("multilineMode", params.getMultiline());
+      updatedEventParameters.addProperty("multilineMode", params.getMultilineMode());
       updatedEventParameters.addProperty("providerIdentifier", params.getProviderIdentifier());
     }
     return updatedEventParameters;


### PR DESCRIPTION


## Test plan

I looked :eye: at the field :eyes: 