### PR TITLE
Improve Send button & Chat user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,3 @@ If you have any questions, feedback, or bug report, we appreciate if you [open a
   - Mac: Go to `IntelliJ IDEA | Preferences` (or use <kbd>⌘,</kbd>)
 - Click `Plugins` in the left-hand pane, then the `Installed` tab at the top
 - Find `Sourcegraph` → Right click → `Uninstall` (or uncheck to disable)
-
-## Version History
-
-See [`CHANGELOG.md`](https://github.com/sourcegraph/jetbrains/blob/main/CHANGELOG.md).


### PR DESCRIPTION
- Fix the send button enable/disable state - now it is always disabled when there is no text in the prompt 
- Add placeholder text to the prompt 
- Fix chat history after sending the prompt with "Send" button

## Test plan
- play with prompt text area, send some messages, play with chat history
- all should work as expected in the case of sending with enter keyboard button and "Send" ui button