### PR TITLE
Disable "Send" button when a response is being generated

### DIFF
--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -12,6 +12,7 @@ import java.awt.BorderLayout
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import javax.swing.BorderFactory
+import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.KeyStroke
 import javax.swing.event.DocumentEvent
@@ -20,7 +21,8 @@ import javax.swing.text.DefaultEditorKit
 class PromptPanel(
     chatMessageHistory: CodyChatMessageHistory,
     onSendMessageAction: () -> Unit,
-    onTextChangedSetButtonEnabled: (Boolean) -> Unit
+    sendButton: JButton,
+    isGenerating: () -> Boolean
 ) : JPanel(BorderLayout()) {
 
   private val autoGrowingTextArea = AutoGrowingTextArea(3, 9, this)
@@ -55,7 +57,7 @@ class PromptPanel(
     val sendMessageAction: AnAction =
         object : DumbAwareAction() {
           override fun actionPerformed(e: AnActionEvent) {
-            if (textArea.getText().isNotEmpty()) {
+            if (sendButton.isEnabled) {
               onSendMessageAction()
               isInHistoryMode = true
             }
@@ -73,12 +75,11 @@ class PromptPanel(
             }
           }
         })
-    // Enable/disable the send button based on whether promptInput is empty
     textArea.document.addDocumentListener(
         object : DocumentAdapter() {
           override fun textChanged(e: DocumentEvent) {
-            // extract method instead of passing sendActionPanel
-            onTextChangedSetButtonEnabled(textArea.getText().isNotEmpty())
+            val empty = textArea.getText().isEmpty()
+            sendButton.isEnabled = !empty && !isGenerating()
           }
         })
     add(autoGrowingTextArea.scrollPane, BorderLayout.CENTER)

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -354,8 +354,8 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
   @RequiresEdt
   private fun sendChatMessage() {
-    val text = promptPanel.textArea.getText()
-    chatMessageHistory.messageSent(promptPanel.textArea)
+    val text = promptPanel.textArea.text
+    chatMessageHistory.messageSent(text)
     sendMessage(project, text, "chat-question")
     promptPanel.reset()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -80,7 +80,8 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
         PromptPanel(
             chatMessageHistory,
             ::sendChatMessage,
-            onTextChangedSetButtonEnabled = { v -> sendButton.isEnabled = v })
+            sendButton,
+            isGenerating = stopGeneratingButton::isVisible)
 
     val stopGeneratingButtonPanel = JPanel(FlowLayout(FlowLayout.CENTER, 0, 5))
     val controlsPanel = ControlsPanel(promptPanel, sendButton)
@@ -325,6 +326,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     ApplicationManager.getApplication().invokeLater {
       stopGeneratingButton.isVisible = false
       ensureBlinkingCursorIsNotDisplayed()
+      sendButton.isEnabled = promptPanel.textArea.text.isNotBlank()
     }
   }
 
@@ -359,14 +361,10 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     chatMessageHistory.messageSent(promptPanel.textArea)
     sendMessage(project, text, "chat-question")
     promptPanel.reset()
-    sendButton.isEnabled = false
   }
 
   @RequiresEdt
   private fun sendMessage(project: Project, message: String, recipeId: String) {
-    if (!sendButton.isEnabled) {
-      return
-    }
     startMessageProcessing()
     val displayText = XmlStringUtil.escapeString(message)
     val humanMessage = ChatMessage(Speaker.HUMAN, message, displayText)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -5,11 +5,11 @@ import java.util.*
 
 class CodyChatMessageHistory(private val capacity: Int) {
   var currentValue: String = ""
-  var upperStack: Stack<String> = Stack<String>()
+  private var upperStack: Stack<String> = Stack<String>()
   private var lowerStack: Stack<String> = Stack<String>()
 
   fun popUpperMessage(promptInput: JBTextArea) {
-    resetHistoryIfPromptCleared(promptInput)
+    resetHistoryIfPromptCleared(promptInput.text)
     if (upperStack.isNotEmpty()) {
       val pop = upperStack.pop()
       lowerStack.push(promptInput.text)
@@ -19,7 +19,7 @@ class CodyChatMessageHistory(private val capacity: Int) {
   }
 
   fun popLowerMessage(promptInput: JBTextArea) {
-    resetHistoryIfPromptCleared(promptInput)
+    resetHistoryIfPromptCleared(promptInput.text)
     if (lowerStack.isNotEmpty()) {
       val pop = lowerStack.pop()
       upperStack.push(promptInput.text)
@@ -32,9 +32,9 @@ class CodyChatMessageHistory(private val capacity: Int) {
    * When new message is sent it is pushing all messages from lower stack to upper stack and at the
    * end pushes new message
    */
-  fun messageSent(promptInput: JBTextArea) {
+  fun messageSent(text: String) {
     resetHistory()
-    upperStack.push(promptInput.text)
+    upperStack.push(text)
     if (upperStack.size > capacity) {
       upperStack.removeFirst()
     }
@@ -57,8 +57,8 @@ class CodyChatMessageHistory(private val capacity: Int) {
     currentValue = ""
   }
 
-  private fun resetHistoryIfPromptCleared(promptInput: JBTextArea) {
-    if (promptInput.text.isEmpty() && currentValue.isNotEmpty()) {
+  private fun resetHistoryIfPromptCleared(text: String) {
+    if (text.isEmpty() && currentValue.isNotEmpty()) {
       resetHistory()
     }
   }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/127.

In the scope of this PR:
- The "Send" button is correctly disabled when a response is generated
- A minor cleanup 

## Test plan
- play with message sending, use the Enter keyboard button and the "Send" button