### PR TITLE
Increasing autocompletion trigger sensitivity

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/AutocompleteParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/AutocompleteParams.kt
@@ -1,15 +1,13 @@
 package com.sourcegraph.cody.agent.protocol
 
-import com.google.gson.annotations.SerializedName
-
-enum class AutocompleteTriggerKind {
-  @SerializedName("Automatic") AUTOMATIC,
-  @SerializedName("Invoke") INVOKE,
+enum class AutocompleteTriggerKind(val value: String) {
+  AUTOMATIC("Automatic"),
+  INVOKE("Invoke"),
 }
 
 data class AutocompleteParams(
     val filePath: String,
     val position: Position,
-    val triggerKind: AutocompleteTriggerKind? = AutocompleteTriggerKind.AUTOMATIC,
+    val triggerKind: String? = AutocompleteTriggerKind.AUTOMATIC.value,
     val selectedCompletionInfo: SelectedCompletionInfo? = null
 )


### PR DESCRIPTION
It fixes [JetBrains: automatically trigger autocomplete in specific location#57366](https://github.com/sourcegraph/sourcegraph/issues/57366) and fixes problem with incorrect serialization of `triggerKind` parameter, sent to the agent + fixing range calculation for lookup manager autocompletion.


## Test plan

* Autocompletion is automatically triggered for this example: 
```
interface DoInteractionRequest {
    chatId: string
    prompt: string
    systemPrompt: string
}

interface Fuzz {
    string: () => string
}

const z: Fuzz = {} as any

const interactionRequest: DoInteractionRequest = {
    chatId_CURSOR_
    prompt: z.string(),
    systemPrompt: z.string(),
}
```

https://github.com/sourcegraph/jetbrains/assets/9321940/9f475127-ada6-4e0b-811d-69cc178f12c5

* Lookup manager autocompletions are correctly triggered

https://github.com/sourcegraph/jetbrains/assets/9321940/2bec91b3-cac5-470e-abee-9b2dc335c282



<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
