### PR TITLE
Fix text wrapping and messages 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "72ac489e6dd8a2a70e89a43b3f2c9ac01a2b659f"
+  val codyCommit = "2a4eb3587c9d83d3b58b9a5e9a162bb4ea17b047"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -115,7 +115,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
   @RequiresEdt
   fun refreshRecipes() {
     recipesPanel.removeAll()
-    recipesPanel.emptyText.text = "Loading recipes..."
+    recipesPanel.emptyText.text = "Loading commands..."
     recipesPanel.revalidate()
     recipesPanel.repaint()
     val server = getServer(project)
@@ -131,7 +131,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
           } // Update on EDT
         }
       } catch (e: Exception) {
-        logger.warn("Error fetching recipes from agent", e)
+        logger.warn("Error fetching commands from agent", e)
         // Update on EDT
         ApplicationManager.getApplication().invokeLater { setRecipesPanelError() }
       }
@@ -141,8 +141,9 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
   @RequiresEdt
   private fun setRecipesPanelError() {
     val emptyText = recipesPanel.emptyText
-    emptyText.text =
-        "Error fetching recipes. Check your connection. If the problem persists, please contact support."
+    emptyText.clear()
+    emptyText.appendLine("Error fetching commands. Check your connection.")
+    emptyText.appendLine("If the problem persists, please contact support.")
     emptyText.appendLine(
         "Retry",
         SimpleTextAttributes(


### PR DESCRIPTION
An important cody commit update included!
(https://github.com/sourcegraph/cody/pull/2014)


## Test plan
- `runIde`
- verify autocomplete works
- verify chat works
- verify commands work; the error text should be wrapped 
