### PR TITLE
Improve the handling of RateLimitError

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "2a4eb3587c9d83d3b58b9a5e9a162bb4ea17b047"
+  val codyCommit = "29e84d968a5eec6b87bedb1658a80a6578bfe86e"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -9,9 +9,6 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.RateLimitError
 import com.sourcegraph.common.BrowserOpener.openInBrowser
-import java.time.Duration
-import java.time.OffsetDateTime
-import org.apache.commons.lang3.time.DurationFormatUtils
 
 class UpgradeToCodyProNotification private constructor(content: String) :
     Notification("Sourcegraph errors", "Sourcegraph", content, NotificationType.WARNING),
@@ -39,16 +36,8 @@ class UpgradeToCodyProNotification private constructor(content: String) :
 
   companion object {
     fun create(rateLimitError: RateLimitError): UpgradeToCodyProNotification {
-      val quotaString = rateLimitError.limit?.let { " ${rateLimitError.limit}" } ?: ""
-      val currentDateTime = OffsetDateTime.now()
-      val resetString =
-          rateLimitError.retryAfter
-              ?.let { Duration.between(currentDateTime, it) }
-              ?.let { DurationFormatUtils.formatDurationWords(it.toMillis(), true, true) }
-              ?.let { " Usage will reset in $it." }
-              ?: ""
       return UpgradeToCodyProNotification(
-          "You've used all${quotaString} autocompletion suggestions.${resetString}")
+          "You've used all${rateLimitError.quotaString()} autocompletion suggestions.${rateLimitError.resetString()}")
     }
 
     var isFirstRLEOnAutomaticAutocompletionsShown: Boolean = false


### PR DESCRIPTION
In the scope of this PR:
- codyCommit bumped 
- RateLimitError class enhanced with  `upgradeIsAvailable` and messages
- RateLimitError related messaging has been improved

## Test plan
1. `runIde`
2. test `autocompletion`
3. test `chat`
4. play with the accounts that have the limits exceeded 