### PR TITLE
Add "Upgrade" option to RLE notifications

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -337,6 +337,7 @@ tasks {
     systemProperty(
         "cody.autocomplete.enableFormatting",
         project.property("cody.autocomplete.enableFormatting") ?: "true")
+    systemProperty("cody.isGa", "true")
   }
 
   runPluginVerifier {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "29e84d968a5eec6b87bedb1658a80a6578bfe86e"
+  val codyCommit = "edd8e27d2eec2e415d730cf3de96db4dad1cf38d"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/RateLimitError.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/RateLimitError.kt
@@ -15,7 +15,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 data class RateLimitError(
     val upgradeIsAvailable: Boolean,
     val limit: Int?,
-    val retryAfter: OffsetDateTime?,
+    val retryAfterDate: OffsetDateTime?,
     val userMessage: String,
     val retryMessage: String?
 ) {
@@ -23,7 +23,7 @@ data class RateLimitError(
 
   fun resetString() =
       retryMessage?.prependIndent(" ")
-          ?: retryAfter
+          ?: retryAfterDate
               ?.let { Duration.between(OffsetDateTime.now(), it) }
               ?.let { duration ->
                 if (duration.isNegative) {
@@ -54,12 +54,13 @@ data class RateLimitError(
         val jsonObject = json.asJsonObject
         val errorObject = jsonObject["error"].asJsonObject
         val limit = errorObject["limit"]?.asInt
-        val retryAfter = errorObject["retryAfter"]?.asString?.let(::parseOffsetDateTime)
+        val retryAfterDate = errorObject["retryAfterDate"]?.asString?.let(::parseOffsetDateTime)
         val upgradeIsAvailable = errorObject["upgradeIsAvailable"]?.asBoolean
         val userMessage = errorObject["userMessage"]?.asString
         val retryMessage = errorObject["retryMessage"]?.asString
 
-        return RateLimitError(upgradeIsAvailable!!, limit, retryAfter, userMessage!!, retryMessage)
+        return RateLimitError(
+            upgradeIsAvailable!!, limit, retryAfterDate, userMessage!!, retryMessage)
       }
 
       private fun parseOffsetDateTime(dateTimeString: String): OffsetDateTime {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -241,7 +241,7 @@ class CodyAutocompleteManager {
             }
           } else if (result != null) {
             UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = false
-            UpgradeToCodyProNotification.autocompleteRateLimitError = false
+            UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
             processAutocompleteResult(editor, offset, triggerKind, result, cancellationToken)
           }
           null
@@ -260,7 +260,7 @@ class CodyAutocompleteManager {
       val errorCode = error.toErrorCode()
       if (errorCode == ErrorCode.RateLimitError) {
         val rateLimitError = error.toRateLimitError()
-        UpgradeToCodyProNotification.autocompleteRateLimitError = true
+        UpgradeToCodyProNotification.autocompleteRateLimitError.set(rateLimitError)
         UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = true
         UpgradeToCodyProNotification.create(rateLimitError).notify(project)
       }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -74,8 +74,8 @@ class Chat {
     if (throwable is ResponseErrorException) {
       val errorCode = throwable.toErrorCode()
       if (errorCode == ErrorCode.RateLimitError) {
-        RateLimitStateManager.reportForChat(project)
         val rateLimitError = throwable.toRateLimitError()
+        RateLimitStateManager.reportForChat(project, rateLimitError)
 
         // TODO(mikolaj):
         // RFC 872 mentions `feature flag cody-pro: true`

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -76,10 +76,23 @@ class Chat {
       if (errorCode == ErrorCode.RateLimitError) {
         RateLimitStateManager.reportForChat(project)
         val rateLimitError = throwable.toRateLimitError()
+        // TODO(mikolaj):
+        // RFC 872 mentions `feature flag cody-pro: true`
+        // the flag should be a factor in whether to show the upgrade option
+        val upgradeLink =
+            when {
+              rateLimitError.upgradeIsAvailable ->
+                  " <a href=\"https://sourcegraph.com/cody/subscription\">Upgrade</a>&nbsp;&nbsp;&nbsp;&nbsp;"
+              else -> ""
+            }
+
         val text =
             "<b>Request failed:</b> You've used all${rateLimitError.quotaString()} chat messages and commands." +
                 " The allowed number of request per day is limited at the moment to ensure the service stays functional.${rateLimitError.resetString()}" +
-                "<br><a href=\"https://docs.sourcegraph.com/cody/core-concepts/cody-gateway#rate-limits-and-quotas\">Learn more.</a>"
+                "<br>" +
+                upgradeLink +
+                "<a href=\"https://sourcegraph.com/cody/manage\">Check usage</a>&nbsp;&nbsp;&nbsp;&nbsp;" +
+                "<a href=\"https://docs.sourcegraph.com/cody/core-concepts/cody-gateway#rate-limits-and-quotas\">Learn more</a>"
         val chatMessage = ChatMessage(Speaker.ASSISTANT, text, null)
         chat.addMessageToChat(chatMessage)
         chat.finishMessageProcessing()

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -9,6 +9,8 @@ import com.intellij.util.containers.orNull
 import com.sourcegraph.cody.auth.ui.AccountsListModel
 import com.sourcegraph.cody.auth.ui.AccountsListModelBase
 import com.sourcegraph.cody.localapp.LocalAppManager
+import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import com.sourcegraph.common.UpgradeToCodyProNotification
 import javax.swing.JComponent
 
 class CodyAccountListModel(private val project: Project) :
@@ -78,6 +80,9 @@ class CodyAccountListModel(private val project: Project) :
     accountsListModel.add(account)
     newCredentials[account] = token
     notifyCredentialsChanged(account)
+    UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+    UpgradeToCodyProNotification.chatRateLimitError.set(null)
+    CodyAutocompleteStatusService.resetApplication(project)
   }
 
   override fun isAccountUnique(login: String, server: SourcegraphServerPath): Boolean =

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
@@ -3,6 +3,8 @@ package com.sourcegraph.cody.config
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 
 class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHost {
@@ -22,6 +24,9 @@ class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHo
       val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
       codyToolWindowContent.refreshPanelsVisibility()
       codyToolWindowContent.embeddingStatusView.updateEmbeddingStatus()
+      UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+      UpgradeToCodyProNotification.chatRateLimitError.set(null)
+      CodyAutocompleteStatusService.resetApplication(project)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/RateLimitStateManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/RateLimitStateManager.kt
@@ -1,21 +1,22 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.protocol.RateLimitError
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
 import com.sourcegraph.common.UpgradeToCodyProNotification
 
 object RateLimitStateManager {
 
   fun invalidateForChat(project: Project) {
-    if (UpgradeToCodyProNotification.chatRateLimitError) {
-      UpgradeToCodyProNotification.chatRateLimitError = false
+    if (UpgradeToCodyProNotification.chatRateLimitError.get() != null) {
+      UpgradeToCodyProNotification.chatRateLimitError.set(null)
       CodyAutocompleteStatusService.resetApplication(project)
     }
   }
 
-  fun reportForChat(project: Project) {
-    if (!UpgradeToCodyProNotification.chatRateLimitError) {
-      UpgradeToCodyProNotification.chatRateLimitError = true
+  fun reportForChat(project: Project, rateLimitError: RateLimitError) {
+    if (UpgradeToCodyProNotification.chatRateLimitError.get() == null) {
+      UpgradeToCodyProNotification.chatRateLimitError.set(rateLimitError)
       CodyAutocompleteStatusService.resetApplication(project)
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyAutocompleteStatusService.kt
@@ -56,8 +56,8 @@ class CodyAutocompleteStatusService : CodyAutocompleteStatusListener, Disposable
                 CodyAutocompleteStatus.CodyAgentNotRunning
               } else if (token == null) {
                 CodyAutocompleteStatus.CodyNotSignedIn
-              } else if (UpgradeToCodyProNotification.autocompleteRateLimitError ||
-                  UpgradeToCodyProNotification.chatRateLimitError) {
+              } else if (UpgradeToCodyProNotification.autocompleteRateLimitError.get() != null ||
+                  UpgradeToCodyProNotification.chatRateLimitError.get() != null) {
                 CodyAutocompleteStatus.RateLimitError
               } else {
                 CodyAutocompleteStatus.Ready

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -34,27 +34,52 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
     }
   }
 
-  private fun deriveWarningAction() =
-      if (UpgradeToCodyProNotification.autocompleteRateLimitError &&
-          UpgradeToCodyProNotification.chatRateLimitError) {
+  private fun deriveWarningAction(): RateLimitErrorWarningAction? {
+    val autocompleteRLE = UpgradeToCodyProNotification.autocompleteRateLimitError.get()
+    val chatRLE = UpgradeToCodyProNotification.chatRateLimitError.get()
+
+    // TODO(mikolaj):
+    // RFC 872 mentions `feature flag cody-pro: true`
+    // the flag should be a factor in whether to show the upgrade option
+    val isGa = java.lang.Boolean.getBoolean("cody.isGa")
+    val shouldShowUpgradeOption =
+        isGa && autocompleteRLE?.upgradeIsAvailable ?: chatRLE?.upgradeIsAvailable ?: false
+
+    val suggestionOrExplanation =
+        if (shouldShowUpgradeOption)
+            "Upgrade to Cody Pro for unlimited autocompletes, chats, and commands."
+        else
+            " The allowed number of request per day is limited at the moment to ensure the service stays functional."
+
+    return when {
+      autocompleteRLE != null && chatRLE != null -> {
         RateLimitErrorWarningAction(
-            "<html><b>Warning:</b> Chat and Autocomplete Limit Reached...</html>",
-            "You've used all chat messages and commands, and autocompletion suggestions. The allowed number of request per day is limited at the moment to ensure the service stays functional.",
-            "Chat and Autocomplete Limit Reached",
-        )
-      } else if (UpgradeToCodyProNotification.autocompleteRateLimitError) {
+            "<html><b>Warning:</b> Autocomplete and Chat and Commands Limit Reached...</html>",
+                "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions, " +
+                "and all${chatRLE.limit?.let { " $it" }} chat messages and commands for the month. " +
+                suggestionOrExplanation,
+            "You've used up your autocompletes, chat and commands for the month",
+            shouldShowUpgradeOption)
+      }
+      autocompleteRLE != null -> {
         RateLimitErrorWarningAction(
             "<html><b>Warning:</b> Autocomplete Limit Reached...</html>",
-            "You've used all autocompletion suggestions. The allowed number of request per day is limited at the moment to ensure the service stays functional.",
-            "Autocomplete Limit Reached",
-        )
-      } else if (UpgradeToCodyProNotification.chatRateLimitError) {
+                "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions for the month. " +
+                suggestionOrExplanation,
+            "You've used up your autocompletes for the month",
+            shouldShowUpgradeOption)
+      }
+      chatRLE != null -> {
         RateLimitErrorWarningAction(
-            "<html><b>Warning:</b> Chat Limit Reached...</html>",
-            "You've used all chat messages and commands. The allowed number of request per day is limited at the moment to ensure the service stays functional.",
-            "Chat Limit Reached",
-        )
-      } else {
+            "<html><b>Warning:</b> Chat and Commands Limit Reached...</html>",
+                "You've used all${chatRLE.limit?.let { " $it" }} chat messages and commands for the month. " +
+                suggestionOrExplanation,
+            "You've used up your chat and commands for the month",
+            shouldShowUpgradeOption)
+      }
+      else -> {
         null
       }
+    }
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -55,7 +55,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
       autocompleteRLE != null && chatRLE != null -> {
         RateLimitErrorWarningAction(
             "<html><b>Warning:</b> Autocomplete and Chat and Commands Limit Reached...</html>",
-                "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions, " +
+            "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions, " +
                 "and all${chatRLE.limit?.let { " $it" }} chat messages and commands for the month. " +
                 suggestionOrExplanation,
             "You've used up your autocompletes, chat and commands for the month",
@@ -64,7 +64,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
       autocompleteRLE != null -> {
         RateLimitErrorWarningAction(
             "<html><b>Warning:</b> Autocomplete Limit Reached...</html>",
-                "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions for the month. " +
+            "You've used all${autocompleteRLE.limit?.let { " $it" }} autocomplete suggestions for the month. " +
                 suggestionOrExplanation,
             "You've used up your autocompletes for the month",
             shouldShowUpgradeOption)
@@ -72,7 +72,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
       chatRLE != null -> {
         RateLimitErrorWarningAction(
             "<html><b>Warning:</b> Chat and Commands Limit Reached...</html>",
-                "You've used all${chatRLE.limit?.let { " $it" }} chat messages and commands for the month. " +
+            "You've used all${chatRLE.limit?.let { " $it" }} chat messages and commands for the month. " +
                 suggestionOrExplanation,
             "You've used up your chat and commands for the month",
             shouldShowUpgradeOption)

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
@@ -29,7 +29,7 @@ class RateLimitErrorWarningAction(
             dialogTitle,
             actions,
             /* defaultOptionIndex= */ 0,
-                Icons.CodyLogo)
+            Icons.CodyLogo)
 
     if (shouldShowUpgradeOption && result == 0) {
       BrowserOpener.openInBrowser(e.project, "https://sourcegraph.com/cody/subscription")

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
@@ -3,22 +3,37 @@ package com.sourcegraph.cody.statusbar
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.ui.Messages
+import com.sourcegraph.cody.Icons
+import com.sourcegraph.common.BrowserOpener
 import com.sourcegraph.config.ConfigUtil
 
 class RateLimitErrorWarningAction(
     actionText: String,
     private val dialogMessage: String,
-    private val dialogTitle: String
+    private val dialogTitle: String,
+    private val shouldShowUpgradeOption: Boolean
 ) : DumbAwareAction(actionText) {
   override fun actionPerformed(e: AnActionEvent) {
 
-    Messages.showDialog(
-        e.project,
-        dialogMessage,
-        dialogTitle,
-        arrayOf("Ok"),
-        /* defaultOptionIndex= */ 0,
-        Messages.getWarningIcon())
+    val actions =
+        if (shouldShowUpgradeOption) {
+          arrayOf("Upgrade", "Ok")
+        } else {
+          arrayOf("Ok")
+        }
+
+    val result =
+        Messages.showDialog(
+            e.project,
+            dialogMessage,
+            dialogTitle,
+            actions,
+            /* defaultOptionIndex= */ 0,
+                Icons.CodyLogo)
+
+    if (shouldShowUpgradeOption && result == 0) {
+      BrowserOpener.openInBrowser(e.project, "https://sourcegraph.com/cody/subscription")
+    }
   }
 
   override fun update(e: AnActionEvent) {

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
@@ -17,7 +17,7 @@ class RateLimitErrorWarningAction(
 
     val actions =
         if (shouldShowUpgradeOption) {
-          arrayOf("Upgrade", "Ok")
+          arrayOf("Close", "Upgrade")
         } else {
           arrayOf("Ok")
         }
@@ -28,10 +28,10 @@ class RateLimitErrorWarningAction(
             dialogMessage,
             dialogTitle,
             actions,
-            /* defaultOptionIndex= */ 0,
+            /* defaultOptionIndex= */ 1,
             Icons.CodyLogo)
 
-    if (shouldShowUpgradeOption && result == 0) {
+    if (result == 1) {
       BrowserOpener.openInBrowser(e.project, "https://sourcegraph.com/cody/subscription")
     }
   }

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -31,13 +31,13 @@ private constructor(content: String, shouldShowUpgradeOption: Boolean) :
                       "https://docs.sourcegraph.com/cody/core-concepts/cody-gateway#rate-limits-and-quotas"
                 }
             openInBrowser(anActionEvent.project, learnMoreLink)
-            expire()
+            hideBalloon()
           }
         }
     val dismissAction: AnAction =
         object : DumbAwareAction("Dismiss") {
           override fun actionPerformed(anActionEvent: AnActionEvent) {
-            expire()
+            hideBalloon()
           }
         }
 
@@ -46,7 +46,7 @@ private constructor(content: String, shouldShowUpgradeOption: Boolean) :
           object : DumbAwareAction("Upgrade") {
             override fun actionPerformed(anActionEvent: AnActionEvent) {
               openInBrowser(anActionEvent.project, "https://sourcegraph.com/cody/subscription")
-              expire()
+              hideBalloon()
             }
           }
       addAction(upgradeAction)

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.RateLimitError
 import com.sourcegraph.common.BrowserOpener.openInBrowser
+import java.util.concurrent.atomic.AtomicReference
 
 class UpgradeToCodyProNotification
 private constructor(content: String, shouldShowUpgradeOption: Boolean) :
@@ -77,7 +78,7 @@ private constructor(content: String, shouldShowUpgradeOption: Boolean) :
     }
 
     var isFirstRLEOnAutomaticAutocompletionsShown: Boolean = false
-    var autocompleteRateLimitError: Boolean = false
-    var chatRateLimitError: Boolean = false
+    var autocompleteRateLimitError: AtomicReference<RateLimitError?> = AtomicReference(null)
+    var chatRateLimitError: AtomicReference<RateLimitError?> = AtomicReference(null)
   }
 }


### PR DESCRIPTION
## Overview
1. This PR adds `systemProperty("cody.isGa", "true")` to `build.gradle`. We may need to set it to false before the next stable release.
2. Messages related to the RateLimitError have been adjusted in the chat, notifications & status warning dialogs.
3. `Upgrade` option added when applicable 

## Test plan
- play with rate limit exceeded accounts

## Enable `cody.isGa=true` for testing
1. Install the plugin with these changes 
2. Go to `Help` -> `Edit Custom VM options....`
3. Add `-Dcody.isGa=true`
4. Restart IntelliJ (you can `File` -> `Invalidate Caches...` -> `Invalidate and restart`)