### PR TITLE
Increase getInitializedServer timeout in CodyFileEditorListener

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -25,6 +25,9 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
     }
 
     CodyAgent.getInitializedServer(source.getProject())
+        // The timeout has been increased from 3 to 12.
+        // This more like workaround than a fix to:
+        // https://github.com/sourcegraph/jetbrains/issues/169
         .completeOnTimeout(null, 12, TimeUnit.SECONDS)
         .thenAccept(
             server -> {

--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -25,7 +25,7 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
     }
 
     CodyAgent.getInitializedServer(source.getProject())
-        .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+        .completeOnTimeout(null, 12, TimeUnit.SECONDS)
         .thenAccept(
             server -> {
               if (server == null) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/169.

## Test plan
- see the related issue for full context
- `runIde` and check if the chat works properly when there is a file opened in the editor on startup
- check sourcegraph links too