### PR TITLE
Fix duplicated subscription tab

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -15,6 +15,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.EmptyIcon
+import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.auth.ui.customAccountsPanel
 import com.sourcegraph.cody.config.*
 import com.sourcegraph.cody.config.notification.AccountSettingChangeActionNotifier
@@ -123,6 +124,7 @@ class AccountConfigurable(val project: Project) :
     UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
     UpgradeToCodyProNotification.chatRateLimitError.set(null)
     CodyAutocompleteStatusService.resetApplication(project)
+    CodyToolWindowContent.getInstance(project).refreshSubscriptionTab()
   }
 
   private fun applyChannelConfiguration() {


### PR DESCRIPTION
It fixes: #196 

## Test plan
It's hard to reproduce, it happened for me couple of times when I was running `runIde` command and unfolded cody tab before indexing finished. 
<!-- All pull requests REQUIRE a test plan: https://docs.sourcegraph.com/dev/background-information/testing_principles 

Why does it matter? 

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers. 
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure 
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component: 
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests" 
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs: 
  - "previewed locally" 
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI" 
  - "locally tested" 
-->
