### PR TITLE
Update codyCommit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "e789043dbd6225db6236b69d420a5ec0d809893c"
+  val codyCommit = "8ffe0d93448e33072a29e2a780e4a35a6d5a869c"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/jetbrains/issues/191.

New commits to the agent:
```
Handle connection close events with no prior errors or messages (#2391)
Hide LLM dropdown for enterprise users (#2393)
Chat: Honor enterprise token limits (#2395)
Update "Start New Chat" button label casing (#2385)
set more conservative limit for gpt-3.5-turbo to stay under window limit (#2386)
VS Code: Release 1.0.0 (#2377)
Update Marketplace README with new gifs, free/pro info, and NLS (#2357)
HACK: Work around rate limiting errors by parsing the SSE message and reverse-engineering the headers (#2375)
chat: display CTA to create new chat when context limit reached (#2374)
Chat: Re-add /edit and /doc commands (#2373)
Autocomplete: format completions on accept (#2327)
Update rate limit error messages for Cody Pro users (#2364)
Chat: use the correct user tier in the upsell event (#2372)
set context window limit by model (#2371)
Chat: send `openLLMDropdown:clicked` only on dropdown open (#2370)
docs: update dev docs to include `pnpm build` (#2369)
Embeddings: Display accurate percent done; do not toast continued embeddings failure (#2368)
Fix code smell icon (#2367)
Chat: Add Mixtral as a chat model (#2307)
VSCode: Roll cody-engine to v5.2.12792 (#2359)
docs: update docs to new url (#2283)
VSCode: Fix local embeddings e2e test to specifically check that *embeddings* are indexed (#2358)
chat: use search context by default (#2325)
Agent: enable source maps in `pnpm agent` (#2334)
change nls label to beta (#2351)
VS Code: Release 0.18.6 (#2349)
Remove mention of Free/Pro from marketplace (#2347)
Chat: Fix settings menu not opening on click (#2346)
Chat Context: Provide relative path as current file (#2344)
Chat: Fix chat panel titles (#2345)
Update the marketplace readme to match product features (#2280)
Agent: skip file system tests on Windows for now (#2341)
Agent: add test case to accept autocomplete (#2337)
Edit: Update the changelog with a bunch of missed fixes from the last release (#2340)
Custom Commands: Filter out insert and edit commands from chat input (#2339)
Chat: Fix cody icon font usage (#2336)
Agent: implement `vscode.workspace.fs` (#1716)
Autocomplete: remove stop sequences for dynamuc multliline completions (#2326)
Autocomplete: log raw error in the development env (#2323)
Autocomplete: fix invalid position (#2324)
Agent: enable source maps in tests (#2333)
Remove complete command from CLI (#2332)
update pr-auditor token (#2321)
Autocomplete: remove `scminput` from the autocomplete languages setting default value (#2322)
Chore: Skip flaky agent chat cancellation test (#2320)
Update walkthrough to match product features (#2279)
Clean up VS Code Extension Settings (#2278)
VSCode: Make embeddings errors visible, resume indexing on restart (#2265)
Add V2 telemetry to remaining Cody events (#2060)
Chat: Fix reset recipe (#2313)
Autocomplete: Don't show loading spinner when rate limited (#2314)
Fix rate limit number being displayed (#2312)
Chore: Remove some GHA `ifs` that didn't work (#2299)
VS Code: Release 0.18.5 (#2308)
Commands: Include /test (#2305)
telemetry-v2: fix splitSafeMetadata to generate acceptable type (#2273)
Edit: Fix doc command jumping unnecessarily (#2296)
Edit: Flush diffs on apply (#2304)
Edit: Fix malformed comments from doc command with selection (#2290)
Chat: Update welcome message (#2298)
Chat: Add tooltip to disabled chat model selector (#2294)
Edit: Do not scroll into view on complete (#2297)
Fix keyDown:Paste:clicked events (#2293)
remove rg-based local keyword context fetcher (#2295)
Simple chat: Bring back chat telemetry (#2291)
Settings: Remove the "Simple Chat Context" setting (#2286)
Update rate limit error wording for Cody Pro users (#2287)
Chat: Remove Chat Suggestions setting that no longer works (#2284)
Settings: Relabel "symf Context" as "Search Context" (#2285)
Chat: Add support for cody.chat.preInstruction in the new preamble (#2255)
use context.globalStorageUri for symf indexes (#2271)
Add cody-pro-jetbrains feature flag (#2274)
Chat: Edit button to rename history chats (#1818)
VS Code: Release 0.18.4 (#2268)
Do not await `showSetupNotification` (#2267)
VS Code: Release 0.18.3 (#2262)
Autocomplete: Add Experimental hot streak mode (#2118)
Disable gzip compression for SSE streams (#2251)
Only search relative paths when @-mentioning files in chat (#2241)
JetBrains: Fix missing context files in the chat response (#2211)
Chat: Update chat icon and transcript gradient (#2254)
Add a Chat Settings button in Chat panels (#2117)
Replace "Sign Out" with an account dialog (#2233)
VSCode: Local Embeddings should pick up initial access token (#2247)
VSCode: Fix local embeddings status for non-git workspaces, git repos w/out remotes (#2235)
Fix pre-release version numbers not being correctly detected (#2240)
Handle context file searching using forward slashes on Windows (#2215)
VS Code: Release 0.18.2 (#2234)
Update CHANGELOG.md (#2232)
Mark Upgrade/Usage links as dot-com only (#2219)
Update CHANGELOG.md (#2226)
plg: display errors when autocomplete rate limits trigger (#2135)
Search: Only show search instructions on hover or focus (#2212)
Fix "Release Notes" label & link for pre-releases in sidebar (#2210)
send sigkill to symf when extension exits (#2225)
Adding endpoint for fetching feature flag (#2204)
Fix symf index dir on Windows (#2207)
symf: support cancelling index (#2202)
Don't duplicate @-filenames when pressing tab if the whole string has been typed (#2218)
Allow dotfiles to be included in context files list (#2209)
Reset feature flags when switching through logins (#2182)
Add rate limit upgrade for code edits (#2201)
Fix cursor blink issue and ensure proper chat initialization synchronization (#2193)
VSCode: Do not parse Windows file paths as URIs (#2197)
VSCode: Send `embeddings/initialize` to the local embeddings controller (#2183)
Chat: Improve Pro upgrade CTA styles (#2175)
Update intro chat message to be clear about coding questions (#2187)
VS Code: Release 0.18.1 (#2177)
Autocomplete: Remove top_k when using temperature (#2178)
fix: chat show up in tree view on submit (#2171)
Fix rate limit messages for short time spans (#2152)
ensure error message makes it through to chat view (#2176)
Enable symf-based context for chat (cody.experimental.symfContext) (#2166)
Add missing changelogs (#2174)
Chat: Improve slash command heading padding (#2173)
chore: Bump up macOS e2e runner instance size (#2145)
chat: fix abort (#2159)
chat: always include selection in enhanced context (#2144)
VS Code: Release 0.18.0 (#2111)
support custom commands in simple chat (#2153)
Chat: update embeddings and codebase identifiers (#2130)
chore: Speed up at-file-selection e2e test (#2146)
update enhance context display copy (#2086)
Fix isRateLimitError (#2151)
chore: Simplify new-history-ui e2e test to deflake (#2147)
Chat: Update message input placeholder to mention slash commands (#2142)
Chat: Reduce size of chats list blank copy (#2137)
Search: Style and UX improvements to the search panel (#2138)
Chat: Fix message input overlapping with enhanced context button (#2141)
enable cody.experimental.simpleChatContext by default (#2120)
feat: display error in webview for simple chat (#2132)
Chat: Speed up chat panel debounce w/ trigger on leading edge too (#2126)
Link to new Cody feedback URL (#2113)
Chat: Fix infinite loop when searching for symbols (#2114)
fix: invert notification toggle logic (#2122)
chore(deps): update dependency stylelint to ^15.11.0 (#2119)
change: enable new chat and search UIs by default (#2079)
```

## Test plan
- test everything possible