### PR TITLE
Eliminate long operations on EDT

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -24,27 +25,32 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
       return;
     }
 
-    CodyAgent.getInitializedServer(source.getProject())
-        // The timeout has been increased from 3 to 12.
-        // This more like workaround than a fix to:
-        // https://github.com/sourcegraph/jetbrains/issues/169
-        .completeOnTimeout(null, 12, TimeUnit.SECONDS)
-        .thenAccept(
-            server -> {
-              if (server == null) {
-                return;
-              }
-              if (!CodyAgent.isConnected(source.getProject())) {
-                return;
-              }
+    ApplicationManager.getApplication()
+        .executeOnPooledThread(
+            () -> {
+              CodyAgent.getInitializedServer(source.getProject())
+                  // The timeout has been increased from 3 to 12.
+                  // This more like workaround than a fix to:
+                  // https://github.com/sourcegraph/jetbrains/issues/169
+                  .completeOnTimeout(null, 12, TimeUnit.SECONDS)
+                  .thenAccept(
+                      server -> {
+                        if (server == null) {
+                          return;
+                        }
+                        if (!CodyAgent.isConnected(source.getProject())) {
+                          return;
+                        }
 
-              server.textDocumentDidOpen(new TextDocument(file.getPath(), document.getText()));
+                        server.textDocumentDidOpen(
+                            new TextDocument(file.getPath(), document.getText()));
 
-              CodyAgentClient client = CodyAgent.getClient(source.getProject());
-              if (client.codebase == null) {
-                return;
-              }
-              client.codebase.onFileOpened(source.getProject(), file);
+                        CodyAgentClient client = CodyAgent.getClient(source.getProject());
+                        if (client.codebase == null) {
+                          return;
+                        }
+                        client.codebase.onFileOpened(source.getProject(), file);
+                      });
             });
   }
 


### PR DESCRIPTION
## Test plan
- runIde
- test ide start up time (should be faster now)
- verify components (commands, sub tab) load

You can mock the initialization issue with:
```kotlin
@JvmStatic
    fun getInitializedServer(project: Project): CompletableFuture<CodyAgentServer> {
      return project.service<CodyAgent>().initialized.apply {
        println("initialized start")
        Thread.sleep(5000)
        println("initialized stop")
        this
      }
    }
```

Before some calls were definitely blocking the UI.