### PR TITLE
Update codyCommit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "8ffe0d93448e33072a29e2a780e4a35a6d5a869c"
+  val codyCommit = "a7123c2fbaa94c2209c98a593f92812edfd9ccf9"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")


### PR DESCRIPTION
This one includes a fix https://github.com/sourcegraph/cody/pull/2418 and fixes https://github.com/sourcegraph/jetbrains/issues/203.

## Commits since the last update

```
Add missing handlers to vscode-shim (#2418)
Chat: honor cody.codebase setting (#2415)
VS Code: Release 1.0.1 (#2397)
Handle connection close events with no prior errors or messages (#2391)
Hide LLM dropdown for enterprise users (#2393)
Chat: Honor enterprise token limits (#2395)
```

## Test plan 
- test everything 