### PR TITLE
Update selected file label on the ide start up & fix slow operation on selectionChanged

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.config.CodyProjectSettings
+import com.sourcegraph.common.ProjectFileUtils
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
@@ -31,6 +32,13 @@ class CodyAgentCodebase(private val underlying: CodyAgentServer, private val pro
   fun onFileOpened(project: Project, file: VirtualFile) {
     application.executeOnPooledThread {
       onRepositoryNameChange(RepoUtil.findRepositoryName(project, file))
+      application.runReadAction {
+        val openedFileName = file.name
+        val relativeFilePath: String? = ProjectFileUtils.getRelativePathToProjectRoot(project, file)
+        CodyToolWindowContent.getInstance(project)
+            .embeddingStatusView
+            .setOpenedFileName(openedFileName, relativeFilePath)
+      }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/context/CurrentlyOpenFileListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/CurrentlyOpenFileListener.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.context
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.project.Project
@@ -10,12 +11,15 @@ class CurrentlyOpenFileListener(
     private val embeddingStatusView: EmbeddingStatusView
 ) : FileEditorManagerListener {
   override fun selectionChanged(event: FileEditorManagerEvent) {
-    val newFile = event.newFile
-    val openedFileName = newFile?.name ?: ""
-    var relativeFilePath: String? = null
-    if (newFile != null) {
-      relativeFilePath = ProjectFileUtils.getRelativePathToProjectRoot(project, newFile)
+    ApplicationManager.getApplication().runReadAction {
+      val newFile = event.newFile
+      val openedFileName = newFile?.name ?: ""
+      var relativeFilePath: String? = null
+
+      if (newFile != null) {
+        relativeFilePath = ProjectFileUtils.getRelativePathToProjectRoot(project, newFile)
+      }
+      embeddingStatusView.setOpenedFileName(openedFileName, relativeFilePath)
     }
-    embeddingStatusView.setOpenedFileName(openedFileName, relativeFilePath)
   }
 }


### PR DESCRIPTION

The first attempt has been reverted here: https://github.com/sourcegraph/jetbrains/pull/215.

`runIde` was fine - the issue appeared in a newer version of intellij. now it should be fixed. 

now, now slow operation error should appear on start up

## Test plan 
- runIde
- play with files (open a file, have a file opened at start up)
- test against 2023.3