### PR TITLE
Agent: move from recipes to the new chat UI

### DIFF
--- a/.tool-version
+++ b/.tool-version
@@ -1,0 +1,1 @@
+java adoptopenjdk-11.0.21+9

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,6 +239,10 @@ tasks {
     }
     val codyDir = unzipCody()
     println("Using cody from codyDir=$codyDir")
+    if (System.getenv("CODY_DIR") != null) {
+      // Use `pnpm agent` instead
+      return buildCodyDir
+    }
     exec {
       workingDir(codyDir)
       commandLine("pnpm", "install", "--frozen-lockfile")
@@ -372,6 +376,7 @@ tasks {
     // Specify pre-release label to publish the plugin in a custom Release Channel automatically.
     // Read more:
     // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+
     channels.set(
         listOf(
             properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -3,12 +3,23 @@ package com.sourcegraph.cody.agent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.jcef.JBCefApp;
 import com.sourcegraph.cody.agent.protocol.ChatMessage;
 import com.sourcegraph.cody.agent.protocol.DebugMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import com.sourcegraph.find.FindPopupDialog;
+import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
+import com.sourcegraph.find.browser.SourcegraphJBCefBrowser;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,5 +73,35 @@ public class CodyAgentClient {
   @JsonNotification("debug/message")
   public void debugMessage(DebugMessage msg) {
     logger.warn(String.format("%s: %s", msg.getChannel(), msg.getMessage()));
+  }
+
+  // Webviews
+  @JsonRequest("webview/create")
+  public CompletableFuture<Void> webviewCreate(WebviewCreateParams params) {
+    logger.error("webview/create This request should not happen if you are using chat/new.");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @JsonNotification("webview/postMessage")
+  public void webviewPostMessage(WebviewPostMessageParams params) {
+    if (onChatUpdateMessageInProgress != null
+        && params.getMessage().getType().equals("transcript")) {
+      if (Boolean.FALSE.equals(params.getMessage().isMessageInProgress())) {
+        onFinishedProcessing.run();
+      } else if (params.getMessage().getMessages() != null
+          && !params.getMessage().getMessages().isEmpty()) {
+        ApplicationManager.getApplication()
+            .invokeLater(
+                () ->
+                    onChatUpdateMessageInProgress.accept(
+                        Objects.requireNonNull(params.getMessage().getMessages())
+                            .get(params.getMessage().getMessages().size() - 1)));
+
+      } else {
+        logger.warn("webview/postMessage: no messages in transcript");
+      }
+    } else {
+      logger.warn(String.format("webview/postMessage %s: %s", params.getId(), params.getMessage()));
+    }
   }
 }

--- a/src/main/java/com/sourcegraph/cody/agent/CommandExecuteParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CommandExecuteParams.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.agent
+
+data class CommandExecuteParams(val command: String, val args: List<String>)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewCreateParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewCreateParams.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.agent
+
+data class WebviewCreateParams(val id: String)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -1,0 +1,36 @@
+package com.sourcegraph.cody.agent
+
+import com.sourcegraph.cody.agent.protocol.ChatError
+import com.sourcegraph.cody.agent.protocol.ChatMessage
+import com.sourcegraph.cody.agent.protocol.ContextFile
+
+/**
+ * A message sent from the webview to the extension host. See vscode/src/chat/protocol.ts for the
+ * protocol.
+ */
+data class WebviewMessage(
+    val command: String,
+    val text: String,
+    val submitType: String, // One of: "user", "suggestion", "example"
+    val addEnhancedContext: Boolean? = null,
+    val contextFiles: List<ContextFile>? = null,
+    val error: ChatError? = null,
+)
+
+data class WebviewReceiveMessageParams(val id: String, val message: WebviewMessage)
+
+/**
+ * A message sent from the extension host to the webview. See vscode/src/chat/protocol.ts for the
+ * protocol.
+ */
+data class ExtensionMessage(
+    val type: String,
+    val messages: List<ChatMessage>? = null,
+    val isMessageInProgress: Boolean? = null,
+    val chatID: String? = null,
+    val isTranscriptError: Boolean? = null,
+    val customPrompts: List<List<Any>>? = null,
+    val context: Any? = null
+)
+
+data class WebviewPostMessageParams(val id: String, val message: ExtensionMessage)

--- a/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -210,8 +210,12 @@ public class FindPopupDialog extends DialogWrapper {
 
     Point location = windowStateService.getLocation(SERVICE_KEY);
     Dimension size = windowStateService.getSize(SERVICE_KEY);
-    setLocation(location);
-    setSize(size.width, size.height);
+    if (location != null) {
+      setLocation(location);
+    }
+    if (size != null) {
+      setSize(size.width, size.height);
+    }
   }
 
   @Override

--- a/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.sourcegraph.cody.agent.CodyAgentClient;
 import org.cef.callback.CefCallback;
 import org.cef.handler.CefResourceHandlerAdapter;
 import org.cef.misc.IntRef;

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -9,7 +9,7 @@ import com.sourcegraph.common.ProjectFileUtils
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, private val project: Project) {
+class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
 
   // TODO: Support list of repository names instead of just one.
   private val application = ApplicationManager.getApplication()

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
@@ -2,6 +2,8 @@ package com.sourcegraph.cody.agent
 
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 object CodyAgentManager {
@@ -34,17 +36,17 @@ object CodyAgentManager {
   }
 
   @JvmStatic
-  fun stopAgent(project: Project) {
+  fun stopAgent(project: Project): Future<out CompletableFuture<Void>?>? {
     if (project.isDisposed) {
-      return
+      return null
     }
-    val service = project.getService(CodyAgent::class.java) ?: return
-    service.shutdown()
+    val service = project.getService(CodyAgent::class.java) ?: return null
+    return service.shutdown()
   }
 
   @JvmStatic
   fun restartAgent(project: Project) {
-    stopAgent(project)
+    stopAgent(project)?.get()?.get()
     startAgent(project)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -72,4 +72,18 @@ interface CodyAgentServer {
   fun completionAccepted(logID: CompletionItemParams)
 
   @JsonNotification("$/cancelRequest") fun cancelRequest(cancelParams: CancelParams)
+
+  // Webviews
+  @JsonRequest("webview/didDispose") fun webviewDidDispose(): CompletableFuture<Void?>
+
+  @JsonNotification("webview/receiveMessage")
+  fun webviewReceiveMessage(params: WebviewReceiveMessageParams)
+
+  @JsonRequest("command/execute")
+  fun commandExecute(params: CommandExecuteParams): CompletableFuture<Any?>
+
+  @JsonRequest("chat/new") fun chatNew(): CompletableFuture<String>
+
+  @JsonRequest("chat/submitMessage")
+  fun chatSubmitMessage(params: ChatSubmitMessageParams): CompletableFuture<ExtensionMessage>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
@@ -1,10 +1,44 @@
 package com.sourcegraph.cody.agent.protocol
 
+import java.time.OffsetDateTime
+
+data class ChatError(
+    val kind: String? = null,
+    val name: String,
+    val message: String,
+    val retryAfter: String? = null,
+    val limit: Int? = null,
+    val userMessage: String? = null,
+    val retryAfterDate: OffsetDateTime? = null,
+    val retryMessage: String? = null,
+    val feature: String? = null,
+    val upgradeIsAvailable: Boolean? = null,
+) {
+  fun toRateLimitError(): RateLimitError? {
+    if (this.retryAfter == null ||
+        this.limit == null ||
+        this.userMessage == null ||
+        this.retryMessage == null ||
+        this.feature == null ||
+        this.upgradeIsAvailable == null) {
+      return null
+    }
+    return RateLimitError(
+        upgradeIsAvailable = this.upgradeIsAvailable,
+        limit = this.limit,
+        retryAfterDate = this.retryAfterDate,
+        userMessage = this.userMessage,
+        retryMessage = this.retryMessage,
+    )
+  }
+}
+
 data class ChatMessage(
     override val speaker: Speaker,
     override val text: String?,
     val displayText: String? = null,
-    val contextFiles: List<ContextFile>? = null
+    val contextFiles: List<ContextFile>? = null,
+    val error: ChatError? = null
 ) : Message {
   fun actualMessage(): String = displayText ?: text ?: ""
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSubmitMessageParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSubmitMessageParams.kt
@@ -1,0 +1,5 @@
+package com.sourcegraph.cody.agent.protocol
+
+import com.sourcegraph.cody.agent.WebviewMessage
+
+data class ChatSubmitMessageParams(val id: String, val message: WebviewMessage) {}

--- a/src/main/kotlin/com/sourcegraph/cody/chat/MessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/MessagePanel.kt
@@ -31,7 +31,7 @@ class MessagePanel(
   fun updateContentWith(message: ChatMessage) {
     val markdownNodes = markdownParser.parse(message.actualMessage())
     val lastMarkdownNode = markdownNodes.lastChild
-    if (lastMarkdownNode.isCodeBlock()) {
+    if (lastMarkdownNode != null && lastMarkdownNode.isCodeBlock()) {
       val (code, language) = lastMarkdownNode.extractCodeAndLanguage()
       addOrUpdateCode(code, language)
     } else {

--- a/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.webview
+
+class CodyWebviewPanel(id: String) {}

--- a/src/main/resources/html/index.html
+++ b/src/main/resources/html/index.html
@@ -1,9 +1,9 @@
 <html lang="en">
 <head>
-  <title>Sourcegraph</title>
-  <link href="/dist/style.css" rel="stylesheet" />
-  <link href="/dist/search.css" rel="stylesheet" />
-  <meta charset="utf-8" />
+    <title>Sourcegraph</title>
+    <link href="/dist/style.css" rel="stylesheet"/>
+    <link href="/dist/search.css" rel="stylesheet"/>
+    <meta charset="utf-8"/>
 </head>
 <body>
 <div id="main"></div>


### PR DESCRIPTION
Previously, the JetBrains plugin used the `chat-question` recipe to power chat. This was problematic because this recipe was not used by VS Code meaning that users had a different experience in JetBrains and VS Code, usually a worse experience in JetBrains because it didn't keep up with the rapid context improvements in VS Code.

Now, with this PR, JetBrains uses new `chat/*` and `webview/*` related endpoints in the agent to power chat. This PR requires the changes from https://github.com/sourcegraph/cody/pull/2396 to be merged. The new chat UI in VS Code is entirely designed around webviews that have a low-level notification-based protocol (no requests). This low-lever protocol is a bit more complicated to work with but it supports richer functionality, including triggering indexing of local embeddings, manually adding individual files to the context, selecting the language model, and more. This PR only implements the basics: submitting a message, stopping a reply, and handling rate limit errors.

Importantly, this PR alone won't close the full gap against VS Code for chat or commands. This is just an important milestone towards that goal.

## Test plan

Only the following two cases work right now:

- Send message "Hello", it replies with "Hello!" without complaining about missing context
- Send message from Cody Free rate limited account and it displays an upsell

The following cases don't work yet, but are P0 issues that need to be fixed, ideally before merging this PR. Both of these issues are on the JetBrains side:

- Cancelation: asking "Give 5 examples comparing Scala 2 and Scala 3", click on "Stop"  button and it stops generating the reply. Currently, the stop button disappears immediately
- Transcript memory: currently, we call `chat/new` on every message, we don't preserve the transcript between messages. To test this feature, send "My name is Olafur", and send another message "What is my name?". It should reply something like "You told me your name is Olafur.".

The following cases need further validation, but are not P0 issues:

- Select some code and ask a question that requires the full open file. This doesn't work in VS Code either unless you have embeddings enabled. I didn't confirm with embeddings in JetBrains.
- Ask a question about that requires the README file. I implemented several changes in the agent to make the automatic README detection work correctly but I didn't get around to confirming this works (neither in agent or JetBrains).
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
