### PR TITLE
Agent: move from recipes to the new webview-based chat API

### DIFF
--- a/.tool-version
+++ b/.tool-version
@@ -1,0 +1,1 @@
+java adoptopenjdk-11.0.21+9

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,6 +232,10 @@ tasks {
     }
     val codyDir = unzipCody()
     println("Using cody from codyDir=$codyDir")
+    if (System.getenv("CODY_DIR") != null) {
+      // Use `pnpm agent` instead
+      return buildCodyDir
+    }
     exec {
       workingDir(codyDir)
       commandLine("pnpm", "install", "--frozen-lockfile")
@@ -381,6 +385,7 @@ tasks {
     // Specify pre-release label to publish the plugin in a custom Release Channel automatically.
     // Read more:
     // https://plugins.jetbrains.com/docs/intellij/deployment.html#specifying-a-release-channel
+
     channels.set(
         listOf(
             properties("pluginVersion").split('-').getOrElse(1) { "default" }.split('.').first()))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "4d41f85b0bf4162693d4dcc7b4c26196e858e849"
+  val codyCommit = "ae3572af8f9d6f93687a1b6737fd2a85856b1edb"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -232,10 +232,6 @@ tasks {
     }
     val codyDir = unzipCody()
     println("Using cody from codyDir=$codyDir")
-    if (System.getenv("CODY_DIR") != null) {
-      // Use `pnpm agent` instead
-      return buildCodyDir
-    }
     exec {
       workingDir(codyDir)
       commandLine("pnpm", "install", "--frozen-lockfile")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "a7123c2fbaa94c2209c98a593f92812edfd9ccf9"
+  val codyCommit = "4d41f85b0bf4162693d4dcc7b4c26196e858e849"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -3,12 +3,23 @@ package com.sourcegraph.cody.agent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.jcef.JBCefApp;
 import com.sourcegraph.cody.agent.protocol.ChatMessage;
 import com.sourcegraph.cody.agent.protocol.DebugMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import com.sourcegraph.find.FindPopupDialog;
+import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
+import com.sourcegraph.find.browser.SourcegraphJBCefBrowser;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -61,5 +72,35 @@ public class CodyAgentClient {
   @JsonNotification("debug/message")
   public void debugMessage(DebugMessage msg) {
     logger.warn(String.format("%s: %s", msg.getChannel(), msg.getMessage()));
+  }
+
+  // Webviews
+  @JsonRequest("webview/create")
+  public CompletableFuture<Void> webviewCreate(WebviewCreateParams params) {
+    logger.error("webview/create This request should not happen if you are using chat/new.");
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @JsonNotification("webview/postMessage")
+  public void webviewPostMessage(WebviewPostMessageParams params) {
+    if (onChatUpdateMessageInProgress != null
+        && params.getMessage().getType().equals("transcript")) {
+      if (Boolean.FALSE.equals(params.getMessage().isMessageInProgress())) {
+        onFinishedProcessing.run();
+      } else if (params.getMessage().getMessages() != null
+          && !params.getMessage().getMessages().isEmpty()) {
+        ApplicationManager.getApplication()
+            .invokeLater(
+                () ->
+                    onChatUpdateMessageInProgress.accept(
+                        Objects.requireNonNull(params.getMessage().getMessages())
+                            .get(params.getMessage().getMessages().size() - 1)));
+
+      } else {
+        logger.warn("webview/postMessage: no messages in transcript");
+      }
+    } else {
+      logger.warn(String.format("webview/postMessage %s: %s", params.getId(), params.getMessage()));
+    }
   }
 }

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -3,21 +3,12 @@ package com.sourcegraph.cody.agent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.util.Disposer;
-import com.intellij.ui.jcef.JBCefApp;
 import com.sourcegraph.cody.agent.protocol.ChatMessage;
 import com.sourcegraph.cody.agent.protocol.DebugMessage;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import com.sourcegraph.find.FindPopupDialog;
-import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
-import com.sourcegraph.find.browser.SourcegraphJBCefBrowser;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -75,7 +75,7 @@ public class CodyAgentClient {
   @JsonNotification("webview/postMessage")
   public void webviewPostMessage(WebviewPostMessageParams params) {
     if (onChatUpdateMessageInProgress != null
-        && params.getMessage().getType().equals("transcript")) {
+        && params.getMessage().getType().equals(ExtensionMessage.Type.TRANSCRIPT)) {
       if (Boolean.FALSE.equals(params.getMessage().isMessageInProgress())) {
         onFinishedProcessing.run();
       } else if (params.getMessage().getMessages() != null
@@ -91,6 +91,7 @@ public class CodyAgentClient {
         logger.warn("webview/postMessage: no messages in transcript");
       }
     } else {
+      logger.warn("onChatUpdateMessageInProgress is null or message type is not transcript");
       logger.warn(String.format("webview/postMessage %s: %s", params.getId(), params.getMessage()));
     }
   }

--- a/src/main/java/com/sourcegraph/cody/agent/CommandExecuteParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/CommandExecuteParams.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.agent
+
+data class CommandExecuteParams(val command: String, val args: List<String>)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewCreateParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewCreateParams.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.agent
+
+data class WebviewCreateParams(val id: String)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -35,6 +35,11 @@ data class ExtensionMessage(
     val errors: String?
 ) {
 
+  object Type {
+    const val TRANSCRIPT = "transcript"
+    const val ERRORS = "errors"
+  }
+
   fun toPanelNotFoundError(): PanelNotFoundError? {
     // e.g.: "No panel with id 414f6f9c-ed62-4d7b-8ebd-023ded81e9da found"
     if (this.errors?.matches(Regex("^No panel with id .* found$")) == true) {

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.agent
 import com.sourcegraph.cody.agent.protocol.ChatError
 import com.sourcegraph.cody.agent.protocol.ChatMessage
 import com.sourcegraph.cody.agent.protocol.ContextFile
+import com.sourcegraph.cody.agent.protocol.PanelNotFoundError
 
 /**
  * A message sent from the webview to the extension host. See vscode/src/chat/protocol.ts for the
@@ -30,7 +31,17 @@ data class ExtensionMessage(
     val chatID: String? = null,
     val isTranscriptError: Boolean? = null,
     val customPrompts: List<List<Any>>? = null,
-    val context: Any? = null
-)
+    val context: Any? = null,
+    val errors: String?
+) {
+
+  fun toPanelNotFoundError(): PanelNotFoundError? {
+    // e.g.: "No panel with id 414f6f9c-ed62-4d7b-8ebd-023ded81e9da found"
+    if (this.errors?.matches(Regex("^No panel with id .* found$")) == true) {
+      return PanelNotFoundError(this.errors)
+    }
+    return null
+  }
+}
 
 data class WebviewPostMessageParams(val id: String, val message: ExtensionMessage)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -1,0 +1,36 @@
+package com.sourcegraph.cody.agent
+
+import com.sourcegraph.cody.agent.protocol.ChatError
+import com.sourcegraph.cody.agent.protocol.ChatMessage
+import com.sourcegraph.cody.agent.protocol.ContextFile
+
+/**
+ * A message sent from the webview to the extension host. See vscode/src/chat/protocol.ts for the
+ * protocol.
+ */
+data class WebviewMessage(
+    val command: String,
+    val text: String,
+    val submitType: String, // One of: "user", "suggestion", "example"
+    val addEnhancedContext: Boolean? = null,
+    val contextFiles: List<ContextFile>? = null,
+    val error: ChatError? = null,
+)
+
+data class WebviewReceiveMessageParams(val id: String, val message: WebviewMessage)
+
+/**
+ * A message sent from the extension host to the webview. See vscode/src/chat/protocol.ts for the
+ * protocol.
+ */
+data class ExtensionMessage(
+    val type: String,
+    val messages: List<ChatMessage>? = null,
+    val isMessageInProgress: Boolean? = null,
+    val chatID: String? = null,
+    val isTranscriptError: Boolean? = null,
+    val customPrompts: List<List<Any>>? = null,
+    val context: Any? = null
+)
+
+data class WebviewPostMessageParams(val id: String, val message: ExtensionMessage)

--- a/src/main/java/com/sourcegraph/find/FindPopupDialog.java
+++ b/src/main/java/com/sourcegraph/find/FindPopupDialog.java
@@ -210,8 +210,12 @@ public class FindPopupDialog extends DialogWrapper {
 
     Point location = windowStateService.getLocation(SERVICE_KEY);
     Dimension size = windowStateService.getSize(SERVICE_KEY);
-    setLocation(location);
-    setSize(size.width, size.height);
+    if (location != null) {
+      setLocation(location);
+    }
+    if (size != null) {
+      setSize(size.width, size.height);
+    }
   }
 
   @Override

--- a/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -6,9 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
-
-import com.intellij.openapi.diagnostic.Logger;
-import com.sourcegraph.cody.agent.CodyAgentClient;
 import org.cef.callback.CefCallback;
 import org.cef.handler.CefResourceHandlerAdapter;
 import org.cef.misc.IntRef;

--- a/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
+++ b/src/main/java/com/sourcegraph/find/browser/HttpSchemeHandler.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.sourcegraph.cody.agent.CodyAgentClient;
 import org.cef.callback.CefCallback;
 import org.cef.handler.CefResourceHandlerAdapter;
 import org.cef.misc.IntRef;

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -23,11 +23,7 @@ import com.sourcegraph.cody.agent.CodyAgent.Companion.getInitializedServer
 import com.sourcegraph.cody.agent.CodyAgent.Companion.isConnected
 import com.sourcegraph.cody.agent.CodyAgentManager.tryRestartingAgentIfNotRunning
 import com.sourcegraph.cody.agent.CodyAgentServer
-import com.sourcegraph.cody.agent.protocol.ChatMessage
-import com.sourcegraph.cody.agent.protocol.ContextMessage
-import com.sourcegraph.cody.agent.protocol.GetFeatureFlag
-import com.sourcegraph.cody.agent.protocol.RecipeInfo
-import com.sourcegraph.cody.agent.protocol.Speaker
+import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.autocomplete.CodyEditorFactoryListener
 import com.sourcegraph.cody.chat.*
 import com.sourcegraph.cody.config.CodyAccount
@@ -134,13 +130,19 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
   override fun loadNewChatId(callback: () -> Unit) {
     id = null
-    promptPanel.textArea.isEnabled = false
-    promptPanel.textArea.emptyText.text = "Connecting to agent..."
+
+    ApplicationManager.getApplication().invokeLater {
+      promptPanel.textArea.isEnabled = false
+      promptPanel.textArea.emptyText.text = "Connecting to agent..."
+    }
+
     ApplicationManager.getApplication().executeOnPooledThread {
       getInitializedServer(project).thenAccept { server ->
         id = server.chatNew().get()
-        promptPanel.textArea.isEnabled = true
-        promptPanel.textArea.emptyText.text = "Ask a question about this code..."
+        ApplicationManager.getApplication().invokeLater {
+          promptPanel.textArea.isEnabled = true
+          promptPanel.textArea.emptyText.text = "Ask a question about this code..."
+        }
         callback.invoke()
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -436,9 +436,9 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
       messagesPanel.revalidate()
       messagesPanel.repaint()
       chatMessageHistory.clearHistory()
-      ApplicationManager.getApplication().executeOnPooledThread {
-        getInitializedServer(project).thenAccept { it?.transcriptReset() }
-      }
+      // todo (#260): call agent to reset the transcript instead of unsetting the chat id
+      inProgressChat.abort()
+      loadNewChatId()
       ensureBlinkingCursorIsNotDisplayed()
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -92,6 +92,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     stopGeneratingButton.addActionListener {
       inProgressChat.abort()
       stopGeneratingButton.isVisible = false
+      ensureBlinkingCursorIsNotDisplayed()
     }
     stopGeneratingButton.isVisible = false
     stopGeneratingButtonPanel.add(stopGeneratingButton)
@@ -114,7 +115,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
     addWelcomeMessage()
     refreshSubscriptionTab()
-    loadChat()
+    loadNewChatId()
   }
 
   fun refreshSubscriptionTab() {
@@ -131,7 +132,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     }
   }
 
-  override fun loadChat(callback: () -> Unit) {
+  override fun loadNewChatId(callback: () -> Unit) {
     id = null
     promptPanel.textArea.isEnabled = false
     promptPanel.textArea.emptyText.text = "Connecting to agent..."

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -88,6 +88,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     stopGeneratingButton.addActionListener {
       inProgressChat.abort()
       stopGeneratingButton.isVisible = false
+      sendButton.isEnabled = promptPanel.textArea.text.isNotBlank()
       ensureBlinkingCursorIsNotDisplayed()
     }
     stopGeneratingButton.isVisible = false

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -59,6 +59,7 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
   private val recipesPanel: JBPanelWithEmptyText
   val embeddingStatusView: EmbeddingStatusView
   override var isChatVisible = false
+  override var id: String? = null
   private var codyOnboardingGuidancePanel: CodyOnboardingGuidancePanel? = null
   private val chatMessageHistory = CodyChatMessageHistory(CHAT_MESSAGE_HISTORY_CAPACITY)
 
@@ -113,6 +114,8 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
     addWelcomeMessage()
     refreshSubscriptionTab()
+    contentPanel.isVisible = false
+    loadChat()
   }
 
   fun refreshSubscriptionTab() {
@@ -125,6 +128,15 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
           tabbedPane.remove(SUBSCRIPTION_TAB_INDEX)
           addNewSubscriptionTab(server)
         }
+      }
+    }
+  }
+
+  private fun loadChat() {
+    ApplicationManager.getApplication().executeOnPooledThread {
+      getInitializedServer(project).thenAccept { server ->
+        id = server.chatNew().get()
+        contentPanel.isVisible = true
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -114,7 +114,6 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
     addWelcomeMessage()
     refreshSubscriptionTab()
-    contentPanel.isVisible = false
     loadChat()
   }
 
@@ -134,11 +133,13 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
 
   override fun loadChat(callback: () -> Unit) {
     id = null
-    contentPanel.isVisible = false
+    promptPanel.textArea.isEnabled = false
+    promptPanel.textArea.emptyText.text = "Connecting to agent..."
     ApplicationManager.getApplication().executeOnPooledThread {
       getInitializedServer(project).thenAccept { server ->
         id = server.chatNew().get()
-        contentPanel.isVisible = true
+        promptPanel.textArea.isEnabled = true
+        promptPanel.textArea.emptyText.text = "Ask a question about this code..."
         callback.invoke()
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -132,11 +132,14 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     }
   }
 
-  private fun loadChat() {
+  override fun loadChat(callback: () -> Unit) {
+    id = null
+    contentPanel.isVisible = false
     ApplicationManager.getApplication().executeOnPooledThread {
       getInitializedServer(project).thenAccept { server ->
         id = server.chatNew().get()
         contentPanel.isVisible = true
+        callback.invoke()
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
@@ -18,7 +18,9 @@ interface UpdatableChat {
 
   val isChatVisible: Boolean
 
-  val id: String?
+  var id: String?
 
   fun activateChatTab()
+
+  fun loadChat(callback: () -> Unit = {})
 }

--- a/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
@@ -22,5 +22,5 @@ interface UpdatableChat {
 
   fun activateChatTab()
 
-  fun loadChat(callback: () -> Unit = {})
+  fun loadNewChatId(callback: () -> Unit = {})
 }

--- a/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/UpdatableChat.kt
@@ -18,5 +18,7 @@ interface UpdatableChat {
 
   val isChatVisible: Boolean
 
+  val id: String?
+
   fun activateChatTab()
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -9,7 +9,7 @@ import com.sourcegraph.common.ProjectFileUtils
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.vcs.RepoUtil
 
-class CodyAgentCodebase(private val underlying: CodyAgentServer, private val project: Project) {
+class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Project) {
 
   // TODO: Support list of repository names instead of just one.
   private val application = ApplicationManager.getApplication()

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentManager.kt
@@ -2,6 +2,8 @@ package com.sourcegraph.cody.agent
 
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 
 object CodyAgentManager {
@@ -34,17 +36,17 @@ object CodyAgentManager {
   }
 
   @JvmStatic
-  fun stopAgent(project: Project) {
+  fun stopAgent(project: Project): Future<out CompletableFuture<Void>?>? {
     if (project.isDisposed) {
-      return
+      return null
     }
-    val service = project.getService(CodyAgent::class.java) ?: return
-    service.shutdown()
+    val service = project.getService(CodyAgent::class.java) ?: return null
+    return service.shutdown()
   }
 
   @JvmStatic
   fun restartAgent(project: Project) {
-    stopAgent(project)
+    stopAgent(project)?.get()?.get()
     startAgent(project)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -72,4 +72,18 @@ interface CodyAgentServer {
   fun completionAccepted(logID: CompletionItemParams)
 
   @JsonNotification("$/cancelRequest") fun cancelRequest(cancelParams: CancelParams)
+
+  // Webviews
+  @JsonRequest("webview/didDispose") fun webviewDidDispose(): CompletableFuture<Void?>
+
+  @JsonNotification("webview/receiveMessage")
+  fun webviewReceiveMessage(params: WebviewReceiveMessageParams)
+
+  @JsonRequest("command/execute")
+  fun commandExecute(params: CommandExecuteParams): CompletableFuture<Any?>
+
+  @JsonRequest("chat/new") fun chatNew(): CompletableFuture<String>
+
+  @JsonRequest("chat/submitMessage")
+  fun chatSubmitMessage(params: ChatSubmitMessageParams): CompletableFuture<ExtensionMessage>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
@@ -15,20 +15,12 @@ data class ChatError(
     val upgradeIsAvailable: Boolean? = null,
 ) {
   fun toRateLimitError(): RateLimitError? {
-    if (this.retryAfter == null ||
-        this.limit == null ||
-        this.userMessage == null ||
-        this.retryMessage == null ||
-        this.feature == null ||
-        this.upgradeIsAvailable == null) {
+    if (this.upgradeIsAvailable == null) {
       return null
     }
     return RateLimitError(
         upgradeIsAvailable = this.upgradeIsAvailable,
         limit = this.limit,
-        retryAfterDate = this.retryAfterDate,
-        userMessage = this.userMessage,
-        retryMessage = this.retryMessage,
     )
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatMessage.kt
@@ -1,10 +1,44 @@
 package com.sourcegraph.cody.agent.protocol
 
+import java.time.OffsetDateTime
+
+data class ChatError(
+    val kind: String? = null,
+    val name: String,
+    val message: String,
+    val retryAfter: String? = null,
+    val limit: Int? = null,
+    val userMessage: String? = null,
+    val retryAfterDate: OffsetDateTime? = null,
+    val retryMessage: String? = null,
+    val feature: String? = null,
+    val upgradeIsAvailable: Boolean? = null,
+) {
+  fun toRateLimitError(): RateLimitError? {
+    if (this.retryAfter == null ||
+        this.limit == null ||
+        this.userMessage == null ||
+        this.retryMessage == null ||
+        this.feature == null ||
+        this.upgradeIsAvailable == null) {
+      return null
+    }
+    return RateLimitError(
+        upgradeIsAvailable = this.upgradeIsAvailable,
+        limit = this.limit,
+        retryAfterDate = this.retryAfterDate,
+        userMessage = this.userMessage,
+        retryMessage = this.retryMessage,
+    )
+  }
+}
+
 data class ChatMessage(
     override val speaker: Speaker,
     override val text: String?,
     val displayText: String? = null,
-    val contextFiles: List<ContextFile>? = null
+    val contextFiles: List<ContextFile>? = null,
+    val error: ChatError? = null
 ) : Message {
   fun actualMessage(): String = displayText ?: text ?: ""
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSubmitMessageParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSubmitMessageParams.kt
@@ -1,0 +1,5 @@
+package com.sourcegraph.cody.agent.protocol
+
+import com.sourcegraph.cody.agent.WebviewMessage
+
+data class ChatSubmitMessageParams(val id: String, val message: WebviewMessage) {}

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/PanelNotFoundError.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/PanelNotFoundError.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class PanelNotFoundError(val message: String)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -90,7 +90,7 @@ class Chat {
                     if (rateLimitError != null) {
                       handleRateLimitError(project, chat, rateLimitError)
                     } else if (panelNotFoundError != null) {
-                      chat.loadChat {
+                      chat.loadNewChatId {
                         this.sendMessageViaAgent(project, humanMessage, recipeId, chat, token)
                       }
                     } else if (error != null) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -46,7 +46,8 @@ class Chat {
                 ?.map { contextFile: ContextFile ->
                   ContextMessage(Speaker.ASSISTANT, agentChatMessageText, contextFile)
                 }
-                ?.collect(Collectors.toList()) ?: emptyList()
+                ?.collect(Collectors.toList())
+                ?: emptyList()
         chat.displayUsedContext(contextMessages)
         chat.addMessageToChat(chatMessage)
       } else {
@@ -58,12 +59,10 @@ class Chat {
           .thenAcceptAsync(
               { server ->
                 try {
-                  // TODO: only create one chat ID per project instead of per message
-                  val id = server.chatNew().get()
                   val reply =
                       server.chatSubmitMessage(
                           ChatSubmitMessageParams(
-                              id,
+                              chat.id!!,
                               WebviewMessage(
                                   command = "submit",
                                   text = humanMessage.actualMessage(),

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -79,9 +79,20 @@ class Chat {
                         } else {
                           null
                         }
+                    val panelNotFoundError =
+                        if (lastReply.type == "errors" && lastReply.errors != null) {
+                          lastReply.toPanelNotFoundError()
+                        } else {
+                          null
+                        }
                     logger.warn("rateLimitError: $rateLimitError")
+                    logger.warn("panelNotFoundError: $panelNotFoundError")
                     if (rateLimitError != null) {
                       handleRateLimitError(project, chat, rateLimitError)
+                    } else if (panelNotFoundError != null) {
+                      chat.loadChat {
+                        this.sendMessageViaAgent(project, humanMessage, recipeId, chat, token)
+                      }
                     } else if (error != null) {
                       handleError(project, error, chat)
                       null

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -69,7 +69,7 @@ class Chat {
                                   text = humanMessage.actualMessage(),
                                   submitType = "user",
                                   addEnhancedContext = true,
-                                  // TODO: allow to manually add files to the context via `@`
+                                  // TODO(#242): allow to manually add files to the context via `@`
                                   contextFiles = listOf())))
                   token.onCancellationRequested { reply.cancel(true) }
                   reply.handle { lastReply, error ->
@@ -93,7 +93,7 @@ class Chat {
                       handleRateLimitError(project, chat, rateLimitError)
                     } else if (panelNotFoundError != null) {
                       chat.loadNewChatId {
-                        this.sendMessageViaAgent(project, humanMessage, recipeId, chat, token)
+                        sendMessageViaAgent(project, humanMessage, recipeId, chat, token)
                       }
                     } else if (error != null) {
                       handleError(project, error, chat)
@@ -104,6 +104,7 @@ class Chat {
                   }
                 } catch (ignored: Exception) {
                   // Ignore bugs in the agent when executing recipes
+                  logger.warn("Ignored error executing recipe: $ignored")
                 }
               },
               CodyAgent.executorService)
@@ -128,6 +129,7 @@ class Chat {
                   }
                 } catch (ignored: Exception) {
                   // Ignore bugs in the agent when executing recipes
+                  logger.warn("Ignored error executing recipe: $ignored")
                 }
               },
               CodyAgent.executorService)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.UpdatableChat
 import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.agent.ExtensionMessage
 import com.sourcegraph.cody.agent.WebviewMessage
 import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
@@ -73,14 +74,15 @@ class Chat {
                   token.onCancellationRequested { reply.cancel(true) }
                   reply.handle { lastReply, error ->
                     val rateLimitError =
-                        if (lastReply.type == "transcript" &&
+                        if (lastReply.type == ExtensionMessage.Type.TRANSCRIPT &&
                             lastReply.messages?.lastOrNull()?.error != null) {
                           lastReply.messages.lastOrNull()?.error?.toRateLimitError()
                         } else {
                           null
                         }
                     val panelNotFoundError =
-                        if (lastReply.type == "errors" && lastReply.errors != null) {
+                        if (lastReply.type == ExtensionMessage.Type.ERRORS &&
+                            lastReply.errors != null) {
                           lastReply.toPanelNotFoundError()
                         } else {
                           null

--- a/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/Chat.kt
@@ -87,8 +87,6 @@ class Chat {
                         } else {
                           null
                         }
-                    logger.warn("rateLimitError: $rateLimitError")
-                    logger.warn("panelNotFoundError: $panelNotFoundError")
                     if (rateLimitError != null) {
                       handleRateLimitError(project, chat, rateLimitError)
                     } else if (panelNotFoundError != null) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/MessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/MessagePanel.kt
@@ -31,7 +31,7 @@ class MessagePanel(
   fun updateContentWith(message: ChatMessage) {
     val markdownNodes = markdownParser.parse(message.actualMessage())
     val lastMarkdownNode = markdownNodes.lastChild
-    if (lastMarkdownNode.isCodeBlock()) {
+    if (lastMarkdownNode != null && lastMarkdownNode.isCodeBlock()) {
       val (code, language) = lastMarkdownNode.extractCodeAndLanguage()
       addOrUpdateCode(code, language)
     } else {

--- a/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
@@ -1,0 +1,3 @@
+package com.sourcegraph.cody.webview
+
+class CodyWebviewPanel(id: String) {}

--- a/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/webview/CodyWebviewPanel.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.webview
-
-class CodyWebviewPanel(id: String) {}

--- a/src/main/resources/html/index.html
+++ b/src/main/resources/html/index.html
@@ -1,9 +1,9 @@
 <html lang="en">
 <head>
-  <title>Sourcegraph</title>
-  <link href="/dist/style.css" rel="stylesheet" />
-  <link href="/dist/search.css" rel="stylesheet" />
-  <meta charset="utf-8" />
+    <title>Sourcegraph</title>
+    <link href="/dist/style.css" rel="stylesheet"/>
+    <link href="/dist/search.css" rel="stylesheet"/>
+    <meta charset="utf-8"/>
 </head>
 <body>
 <div id="main"></div>


### PR DESCRIPTION
I take over Olaf's: https://github.com/sourcegraph/jetbrains/pull/217.
See the original PR for more context.

The related PR in Cody: https://github.com/sourcegraph/cody/pull/2457.

## Test plan 

- [x] Restart Chat Session
- [x] Rate limit error is displayed
- [x] User can cancel chat generation
- [x] Gracefully handle the case where we submit a message when the agent process is killed
- [x] Streaming reply

# The original description

Previously, the JetBrains plugin used the `chat-question` recipe to power chat. This was problematic because this recipe was not used by VS Code meaning that users had a different experience in JetBrains and VS Code, usually a worse experience in JetBrains because it didn't keep up with the rapid context improvements in VS Code.

Now, with this PR, JetBrains uses new `chat/*` and `webview/*` related endpoints in the agent to power chat. This PR requires the changes from https://github.com/sourcegraph/cody/pull/2396 to be merged. The new chat UI in VS Code is entirely designed around webviews that have a low-level notification-based protocol (no requests). This low-lever protocol is a bit more complicated to work with but it supports richer functionality, including triggering indexing of local embeddings, manually adding individual files to the context, selecting the language model, and more. This PR only implements the basics: submitting a message, stopping a reply, and handling rate limit errors.

Importantly, this PR alone won't close the full gap against VS Code for chat or commands. This is just an important milestone towards that goal.

## Test plan

Only the following two cases work right now:

- Send message "Hello", it replies with "Hello!" without complaining about missing context
- Send message from Cody Free rate limited account and it displays an upsell

The following cases don't work yet, but are P0 issues that need to be fixed, ideally before merging this PR. Both of these issues are on the JetBrains side:

- Cancelation: asking "Give 5 examples comparing Scala 2 and Scala 3", click on "Stop"  button and it stops generating the reply. Currently, the stop button disappears immediately
- Transcript memory: currently, we call `chat/new` on every message, we don't preserve the transcript between messages. To test this feature, send "My name is Olafur", and send another message "What is my name?". It should reply something like "You told me your name is Olafur.".

The following cases need further validation, but are not P0 issues:

- Select some code and ask a question that requires the full open file. This doesn't work in VS Code either unless you have embeddings enabled. I didn't confirm with embeddings in JetBrains.
- Ask a question about that requires the README file. I implemented several changes in the agent to make the automatic README detection work correctly but I didn't get around to confirming this works (neither in agent or JetBrains).
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
