### PR TITLE
Fix the subscription panel presentation on `Sign in with an Enterprise Instance`

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -7,6 +7,7 @@ import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.telemetry.GraphQlLogger
 
@@ -42,14 +43,17 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
               agentServer.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
             }
 
+            val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
             // Refresh onboarding panels
             if (ConfigUtil.isCodyEnabled()) {
-              val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
               codyToolWindowContent.refreshPanelsVisibility()
               codyToolWindowContent.embeddingStatusView.updateEmbeddingStatus()
             }
 
+            UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+            UpgradeToCodyProNotification.chatRateLimitError.set(null)
             CodyAutocompleteStatusService.resetApplication(project)
+            codyToolWindowContent.refreshSubscriptionTab()
 
             // Log install events
             if (context.serverUrlChanged) {

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -15,13 +15,10 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.EmptyIcon
-import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.auth.ui.customAccountsPanel
 import com.sourcegraph.cody.config.*
 import com.sourcegraph.cody.config.notification.AccountSettingChangeActionNotifier
 import com.sourcegraph.cody.config.notification.AccountSettingChangeContext
-import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
-import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import java.awt.Dimension
 
@@ -120,11 +117,6 @@ class AccountConfigurable(val project: Project) :
     }
 
     applyChannelConfiguration()
-
-    UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
-    UpgradeToCodyProNotification.chatRateLimitError.set(null)
-    CodyAutocompleteStatusService.resetApplication(project)
-    CodyToolWindowContent.getInstance(project).refreshSubscriptionTab()
   }
 
   private fun applyChannelConfiguration() {


### PR DESCRIPTION
We had no issue for that. I just noticed it. The subscription tab is not appearing after login from Github etc. 

This PR fixes the issue + it moves the logic related to account changes to [AccountSettingChangeListener.kt](https://github.com/sourcegraph/jetbrains/pull/238/files#diff-4a4dd118349f1f574c51f4eccff0ced92175b76217627c7c21c5a936d841cc9a).

## Test plan
- test log in with GitHub/GitLab/Google
- test sign in with an enterprise