### PR TITLE
Disable Commands while a message is being generated

### DIFF
--- a/src/main/java/com/sourcegraph/cody/SubscriptionPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/SubscriptionPanel.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
 import com.intellij.ui.dsl.builder.panel
+import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.config.ConfigUtil
 
 fun createSubscriptionTab(isCurrentUserPro: Boolean) = panel {
@@ -17,6 +18,6 @@ fun createSubscriptionTab(isCurrentUserPro: Boolean) = panel {
     button("Check Usage") { BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage") }
   }
   if (!isCurrentUserPro) {
-    row { label("(Already upgraded to Pro? Restart your IDE for changes to take effect)") }
+    row { text(CodyBundle.getString("tab.subscription.already-pro")) }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -390,14 +390,22 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
     ApplicationManager.getApplication().invokeLater {
       stopGeneratingButton.isVisible = true
       sendButton.isEnabled = false
+      recipesPanel.components.filterIsInstance<JButton>().forEach {
+        it.isEnabled = false
+        it.toolTipText = "Message generation in progress..."
+      }
     }
   }
 
   override fun finishMessageProcessing() {
     ApplicationManager.getApplication().invokeLater {
-      stopGeneratingButton.isVisible = false
       ensureBlinkingCursorIsNotDisplayed()
+      stopGeneratingButton.isVisible = false
       sendButton.isEnabled = promptPanel.textArea.text.isNotBlank()
+      recipesPanel.components.filterIsInstance<JButton>().forEach {
+        it.isEnabled = true
+        it.toolTipText = null
+      }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -7,6 +7,7 @@ import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
+import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.telemetry.GraphQlLogger
 
@@ -42,14 +43,17 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
               agentServer.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
             }
 
+            val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
             // Refresh onboarding panels
             if (ConfigUtil.isCodyEnabled()) {
-              val codyToolWindowContent = CodyToolWindowContent.getInstance(project)
               codyToolWindowContent.refreshPanelsVisibility()
               codyToolWindowContent.embeddingStatusView.updateEmbeddingStatus()
             }
 
+            UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+            UpgradeToCodyProNotification.chatRateLimitError.set(null)
             CodyAutocompleteStatusService.resetApplication(project)
+            codyToolWindowContent.refreshSubscriptionTab()
 
             // Log install events
             if (context.serverUrlChanged) {

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/AccountConfigurable.kt
@@ -15,13 +15,10 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.EmptyIcon
-import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.auth.ui.customAccountsPanel
 import com.sourcegraph.cody.config.*
 import com.sourcegraph.cody.config.notification.AccountSettingChangeActionNotifier
 import com.sourcegraph.cody.config.notification.AccountSettingChangeContext
-import com.sourcegraph.cody.statusbar.CodyAutocompleteStatusService
-import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import java.awt.Dimension
 
@@ -120,11 +117,6 @@ class AccountConfigurable(val project: Project) :
     }
 
     applyChannelConfiguration()
-
-    UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
-    UpgradeToCodyProNotification.chatRateLimitError.set(null)
-    CodyAutocompleteStatusService.resetApplication(project)
-    CodyToolWindowContent.getInstance(project).refreshSubscriptionTab()
   }
 
   private fun applyChannelConfiguration() {

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -62,3 +62,5 @@ UpgradeToCodyProNotification.content.upgrade=\
     (Already upgraded to Pro? Restart your IDE for changes to take effect)\
   </html>
 UpgradeToCodyProNotification.content.explain=To ensure that Cody can stay operational for all Cody users, please come back tomorrow for more chats, commands, and autocompletes.
+
+tab.subscription.already-pro=(Already upgraded to Pro? Restart your IDE for changes to take effect)


### PR DESCRIPTION
We have no issue for that and the Commands are to be migrated to commands (we are still using recipes actually) but this is a quick and small fix. 

## Test plan
1. run command/write a prompt
2. verify that commands are disabled during the message generation but are reenabled after that 