### PR TITLE
Wrap "Already upgraded..." text in the subscription tab

### DIFF
--- a/src/main/java/com/sourcegraph/cody/SubscriptionPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/SubscriptionPanel.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
 import com.intellij.ui.dsl.builder.panel
+import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.config.ConfigUtil
 
 fun createSubscriptionTab(isCurrentUserPro: Boolean) = panel {
@@ -17,6 +18,6 @@ fun createSubscriptionTab(isCurrentUserPro: Boolean) = panel {
     button("Check Usage") { BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage") }
   }
   if (!isCurrentUserPro) {
-    row { label("(Already upgraded to Pro? Restart your IDE for changes to take effect)") }
+    row { text(CodyBundle.getString("tab.subscription.already-pro")) }
   }
 }

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -62,3 +62,5 @@ UpgradeToCodyProNotification.content.upgrade=\
     (Already upgraded to Pro? Restart your IDE for changes to take effect)\
   </html>
 UpgradeToCodyProNotification.content.explain=To ensure that Cody can stay operational for all Cody users, please come back tomorrow for more chats, commands, and autocompletes.
+
+tab.subscription.already-pro=(Already upgraded to Pro? Restart your IDE for changes to take effect)


### PR DESCRIPTION
We have no issue for this one but the text exceeding the line width is not visible - these changes fix that.

## Test plan
- play with Cody tool window width 
- verify that the text is wrapped 