### PR TITLE
Fix getRelativePathToProjectRoot call (fixes #246)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -35,9 +35,11 @@ class CodyAgentCodebase(private val underlying: CodyAgentServer, val project: Pr
       application.runReadAction {
         val openedFileName = file.name
         val relativeFilePath: String? = ProjectFileUtils.getRelativePathToProjectRoot(project, file)
-        CodyToolWindowContent.getInstance(project)
-            .embeddingStatusView
-            .setOpenedFileName(openedFileName, relativeFilePath)
+        ApplicationManager.getApplication().invokeLater {
+          CodyToolWindowContent.getInstance(project)
+              .embeddingStatusView
+              .setOpenedFileName(openedFileName, relativeFilePath)
+        }
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/context/CurrentlyOpenFileListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/CurrentlyOpenFileListener.kt
@@ -11,15 +11,18 @@ class CurrentlyOpenFileListener(
     private val embeddingStatusView: EmbeddingStatusView
 ) : FileEditorManagerListener {
   override fun selectionChanged(event: FileEditorManagerEvent) {
-    ApplicationManager.getApplication().runReadAction {
-      val newFile = event.newFile
-      val openedFileName = newFile?.name ?: ""
-      var relativeFilePath: String? = null
+    val newFile = event.newFile
+    val openedFileName = newFile?.name ?: ""
+    var relativeFilePath: String? = null
 
+    ApplicationManager.getApplication().executeOnPooledThread {
       if (newFile != null) {
         relativeFilePath = ProjectFileUtils.getRelativePathToProjectRoot(project, newFile)
       }
-      embeddingStatusView.setOpenedFileName(openedFileName, relativeFilePath)
+
+      ApplicationManager.getApplication().invokeLater {
+        embeddingStatusView.setOpenedFileName(openedFileName, relativeFilePath)
+      }
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/EmbeddingStatusView.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/EmbeddingStatusView.kt
@@ -103,7 +103,7 @@ class EmbeddingStatusView(private val project: Project) : JPanel() {
   }
 
   fun setOpenedFileName(fileName: String, filePath: String?) {
-    openedFileContent.setText(fileName)
-    openedFileContent.setToolTipText(filePath)
+    openedFileContent.text = fileName
+    openedFileContent.toolTipText = filePath
   }
 }

--- a/src/main/kotlin/com/sourcegraph/common/ProjectFileUtils.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ProjectFileUtils.kt
@@ -1,13 +1,18 @@
 package com.sourcegraph.common
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
 
 object ProjectFileUtils {
   fun getRelativePathToProjectRoot(project: Project, file: VirtualFile): String? {
-    val rootForFile = ProjectFileIndex.getInstance(project).getContentRootForFile(file)
+    val rootForFile =
+        ApplicationManager.getApplication()
+            .runReadAction(
+                Computable { ProjectFileIndex.getInstance(project).getContentRootForFile(file) })
     return if (rootForFile != null) {
       File(rootForFile.path).toURI().relativize(File(file.path).toURI()).getPath()
     } else null


### PR DESCRIPTION
## Test plan
- install the plugin built from these changes on IntelliJ 2023.2 (or 2023.3)
- the error should not appear 

(alternatively runIde against this version of IDE)