### PR TITLE
Add feedback issue template for JetBrains

### DIFF
--- a/.github/ISSUE_TEMPLATE/jetbrains_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/jetbrains_feedback.yml
@@ -1,0 +1,38 @@
+name: JetBrains Feedback ፨
+description: "File feedback for any of the JetBrains IDEs: IntelliJ, Goland, WebStorm, etc."
+title: "feedback: "
+labels:
+  - team/jetbrains
+projects:
+  - sourcegraph/381
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to share your feedback with us! If you'd like to report a bug, please use the [JetBrains Bug report template](https://github.com/sourcegraph/jetbrains/issues/new/choose) instead.
+        
+        Tip: You can attach images or videos by dragging it into the text box.
+  - type: textarea
+    attributes:
+      label: Installation Information
+      description: Trigger the action "About", click on "Copy and close" and paste the output here
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Share your feedback
+      description: Let us know how we can keep improving Cody for JetBrains. If relevant, please include steps on how to reproduce behaviour.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context (logs, images, etc)
+      description: |
+        Please add any links, images, or references that can give us more context around your feedback.
+
+        For logs - Trigger the action "Show Log", open the file, search for exceptions related to Cody/Sourcegraph and copy relevant lines here
+        Alternatively, feel free to upload idea.log as an attachment but please make sure it doesn't contain sensitive information (it normally doesn't)
+
+        Tip: You can attach images or videos by dragging it into the text box.
+    validations:
+      required: false


### PR DESCRIPTION
Adds a template for users to submit non-bug feedback for the JetBrains plugin. 

## Test plan
Passing CI
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
