### PR TITLE
Disable displaying feature limits

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -56,10 +56,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
             Triple(
                 CodyBundle.getString("status-widget.warning.autocompletion-and-chat.action-title"),
                 CodyBundle.getString("status-widget.warning.autocompletion-and-chat.content")
-                    .fmt(
-                        autocompleteRLE.limit?.let { " $it" } ?: "",
-                        chatRLE.limit?.let { " $it" } ?: "",
-                        suggestionOrExplanation),
+                    .fmt(suggestionOrExplanation),
                 CodyBundle.getString("status-widget.warning.autocompletion-and-chat.dialog-title"))
           }
           autocompleteRLE != null -> {
@@ -67,14 +64,14 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
             Triple(
                 CodyBundle.getString("status-widget.warning.autocompletion.action-title"),
                 CodyBundle.getString("status-widget.warning.autocompletion.content")
-                    .fmt(autocompleteRLE.limit?.let { " $it" } ?: "", suggestionOrExplanation),
+                    .fmt(suggestionOrExplanation),
                 CodyBundle.getString("status-widget.warning.autocompletion.dialog-title"))
           }
           chatRLE != null -> {
             Triple(
                 CodyBundle.getString("status-widget.warning.chat.action-title"),
                 CodyBundle.getString("status-widget.warning.chat.content")
-                    .fmt(chatRLE.limit?.let { " $it" } ?: "", suggestionOrExplanation),
+                    .fmt(suggestionOrExplanation),
                 CodyBundle.getString("status-widget.warning.chat.dialog-title"))
           }
           else -> return null

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -11,21 +11,21 @@ status-widget.warning.autocompletion-and-chat.action-title=<html><b>Warning:</b>
 status-widget.warning.autocompletion-and-chat.dialog-title=You've used up your autocompletes, chat and commands for the month
 status-widget.warning.autocompletion-and-chat.content=\
   <html>\
-    You''ve used all{0} autocomplete suggestions, and all{1} chat messages and commands for the month. {2}\
+    You''ve used all autocomplete suggestions, and all{0} chat messages and commands for the month. {1}\
   </html>
 
 status-widget.warning.autocompletion.action-title=<html><b>Warning:</b> Autocomplete Limit Reached...</html>
 status-widget.warning.autocompletion.dialog-title=You've used up your autocompletes for the month
 status-widget.warning.autocompletion.content=\
   <html>\
-    You''ve used all{0} autocomplete suggestions for the month. {1}\
+    You''ve used all autocomplete suggestions for the month. {0}\
   </html>
 
 status-widget.warning.chat.action-title=<html><b>Warning:</b> Chat and Commands Limit Reached...</html>
 status-widget.warning.chat.dialog-title=You've used up your chat and commands for the month
 status-widget.warning.chat.content=\
   <html>\
-    You''ve used all{0} chat messages and commands for the month. {1}\
+    You''ve used all chat messages and commands for the month. {0}\
   </html>
 
 status-widget.warning.upgrade= \


### PR DESCRIPTION
The problem is that we're displaying 160 chats in the error message:

![image](https://github.com/sourcegraph/cody/assets/2552265/415dc740-6b91-4ee8-9403-fe4f0ad05cd7)

while on the /cody/manage page, we display 20:

![image](https://github.com/sourcegraph/cody/assets/2552265/cd0bbbf9-ee34-4774-8ffc-cc137179d36f)

Cody Gateway only knows the LLM limits (which is 160 for Free users), and that's what it returns in the error header, so that's all the client knows as well. We should display the official limit of 20 instead, but we can't know it for now on the client side.

So my quick solution is just to hide this info on the UI.

## Test plan

Relying on the JetBrains team to test this
