### PR TITLE
Fix slow op on refreshSubscriptionTab + restart the agent on jetbrains' and agent's user id mismatch

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.config.notification
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
@@ -53,7 +54,9 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
             UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
             UpgradeToCodyProNotification.chatRateLimitError.set(null)
             CodyAutocompleteStatusService.resetApplication(project)
-            codyToolWindowContent.refreshSubscriptionTab()
+            ApplicationManager.getApplication().executeOnPooledThread {
+              codyToolWindowContent.refreshSubscriptionTab()
+            }
 
             // Log install events
             if (context.serverUrlChanged) {


### PR DESCRIPTION


## Test plan 
- put a breakpoint in `addNewSubscriptionTab` and set `agentUserId` a dummy value so it mismatch the `jetbrainsUserId`(that will test the error handling)
  - internal ide error should not appear 
  - agent should restart and a new proper matching id should be assigned 

- in `addNewSubscriptionTab` increase the timeout & runIde
  - UI should not freeeze 🥶  