### PR TITLE
Fix right-click Cody commands selection

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -304,6 +304,9 @@ class CodyToolWindowContent(private val project: Project) : UpdatableChat {
           object : DumbAwareAction(recipe.title) {
             override fun actionPerformed(e: AnActionEvent) {
               GraphQlLogger.logCodyEvent(project, "recipe:" + recipe.id, "clicked")
+              val editorManager = FileEditorManager.getInstance(project)
+              CodyEditorFactoryListener.Util.informAgentAboutEditorChange(
+                  editorManager.selectedTextEditor)
               sendMessage(project, recipe.title, recipe.id)
             }
           }


### PR DESCRIPTION
Fixes #232 

## Test plan
- execute a command (a recipe) from the context menu