### PR TITLE
Add "Open GitHub Issue" error submitter

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyError.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyError.kt
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.error
+
+data class CodyError(
+    val title: String?,
+    val pluginVersion: String?,
+    val ideVersion: String?,
+    val additionalInfo: String?,
+    val stacktrace: String?
+)

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
@@ -1,0 +1,21 @@
+package com.sourcegraph.cody.error
+
+object CodyErrorFormatter {
+
+    fun formatToMarkdown(error: CodyError) = mapOf(
+        "Plugin version" to error.pluginVersion,
+        "IDE version" to error.ideVersion,
+        "Additional information" to error.additionalInfo,
+        "Exception" to error.title,
+        "Stacktrace" to error.stacktrace
+    ).filterValues { it != null }
+        .map { toLabeledCodeBlock(it.key, it.value!!) }
+        .joinToString("\n")
+
+    private fun toLabeledCodeBlock(label: String, text: String) =
+        if (text.lines().size != 1)
+            "$label:\n```text\n$text\n```"
+        else
+            "$label: ```$text```"
+
+}

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
@@ -2,20 +2,17 @@ package com.sourcegraph.cody.error
 
 object CodyErrorFormatter {
 
-    fun formatToMarkdown(error: CodyError) = mapOf(
-        "Plugin version" to error.pluginVersion,
-        "IDE version" to error.ideVersion,
-        "Additional information" to error.additionalInfo,
-        "Exception" to error.title,
-        "Stacktrace" to error.stacktrace
-    ).filterValues { it != null }
-        .map { toLabeledCodeBlock(it.key, it.value!!) }
-        .joinToString("\n")
+  fun formatToMarkdown(error: CodyError) =
+      mapOf(
+              "Plugin version" to error.pluginVersion,
+              "IDE version" to error.ideVersion,
+              "Additional information" to error.additionalInfo,
+              "Exception" to error.title,
+              "Stacktrace" to error.stacktrace)
+          .filterValues { it != null }
+          .map { toLabeledCodeBlock(it.key, it.value!!) }
+          .joinToString("\n")
 
-    private fun toLabeledCodeBlock(label: String, text: String) =
-        if (text.lines().size != 1)
-            "$label:\n```text\n$text\n```"
-        else
-            "$label: ```$text```"
-
+  private fun toLabeledCodeBlock(label: String, text: String) =
+      if (text.lines().size != 1) "$label:\n```text\n$text\n```" else "$label: ```$text```"
 }

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -1,0 +1,60 @@
+package com.sourcegraph.cody.error
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.diagnostic.ErrorReportSubmitter
+import com.intellij.openapi.diagnostic.IdeaLoggingEvent
+import com.intellij.openapi.diagnostic.SubmittedReportInfo
+import com.intellij.openapi.diagnostic.SubmittedReportInfo.SubmissionStatus
+import com.intellij.util.Consumer
+import java.awt.Component
+import java.net.URLEncoder
+
+class CodyErrorSubmitter : ErrorReportSubmitter() {
+
+    override fun getReportActionText() =
+        "Open GitHub Issue"
+
+    override fun submit(
+        events: Array<out IdeaLoggingEvent>,
+        additionalInfo: String?,
+        parentComponent: Component,
+        consumer: Consumer<in SubmittedReportInfo>
+    ): Boolean {
+        try {
+            if (events.isNotEmpty()) {
+                val event = events.first()
+                val error = getErrorDetails(event, additionalInfo)
+                val issueTitle = "bug: ${error.title}"
+                val formattedError = CodyErrorFormatter.formatToMarkdown(error)
+                val url = encodeIssue(issueTitle, formattedError)
+                BrowserUtil.browse(url)
+            }
+        } catch (e: Exception) {
+            consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
+            return false
+        }
+        consumer.consume(SubmittedReportInfo(SubmissionStatus.NEW_ISSUE))
+        return true
+    }
+
+    private fun getErrorDetails(event: IdeaLoggingEvent, additionalInfo: String?) =
+        CodyError(
+            title = event.throwableText.lines().first(),
+            pluginVersion = (pluginDescriptor as? IdeaPluginDescriptor)?.version,
+            ideVersion = ApplicationInfo.getInstance().build.toString(),
+            additionalInfo = additionalInfo,
+            stacktrace = event.throwableText
+        )
+
+    private fun encodeIssue(title: String, body: String): String =
+        "https://github.com/sourcegraph/jetbrains/issues/new" +
+                "?labels=bug" +
+                "&title=${encode(title)}" +
+                "&body=${encode(body)}"
+
+    private fun encode(text: String) =
+        URLEncoder.encode(text, "UTF-8")
+
+}

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -13,48 +13,44 @@ import java.net.URLEncoder
 
 class CodyErrorSubmitter : ErrorReportSubmitter() {
 
-    override fun getReportActionText() =
-        "Open GitHub Issue"
+  override fun getReportActionText() = "Open GitHub Issue"
 
-    override fun submit(
-        events: Array<out IdeaLoggingEvent>,
-        additionalInfo: String?,
-        parentComponent: Component,
-        consumer: Consumer<in SubmittedReportInfo>
-    ): Boolean {
-        try {
-            if (events.isNotEmpty()) {
-                val event = events.first()
-                val error = getErrorDetails(event, additionalInfo)
-                val issueTitle = "bug: ${error.title}"
-                val formattedError = CodyErrorFormatter.formatToMarkdown(error)
-                val url = encodeIssue(issueTitle, formattedError)
-                BrowserUtil.browse(url)
-            }
-        } catch (e: Exception) {
-            consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
-            return false
-        }
-        consumer.consume(SubmittedReportInfo(SubmissionStatus.NEW_ISSUE))
-        return true
+  override fun submit(
+      events: Array<out IdeaLoggingEvent>,
+      additionalInfo: String?,
+      parentComponent: Component,
+      consumer: Consumer<in SubmittedReportInfo>
+  ): Boolean {
+    try {
+      if (events.isNotEmpty()) {
+        val event = events.first()
+        val error = getErrorDetails(event, additionalInfo)
+        val issueTitle = "bug: ${error.title}"
+        val formattedError = CodyErrorFormatter.formatToMarkdown(error)
+        val url = encodeIssue(issueTitle, formattedError)
+        BrowserUtil.browse(url)
+      }
+    } catch (e: Exception) {
+      consumer.consume(SubmittedReportInfo(SubmissionStatus.FAILED))
+      return false
     }
+    consumer.consume(SubmittedReportInfo(SubmissionStatus.NEW_ISSUE))
+    return true
+  }
 
-    private fun getErrorDetails(event: IdeaLoggingEvent, additionalInfo: String?) =
-        CodyError(
-            title = event.throwableText.lines().first(),
-            pluginVersion = (pluginDescriptor as? IdeaPluginDescriptor)?.version,
-            ideVersion = ApplicationInfo.getInstance().build.toString(),
-            additionalInfo = additionalInfo,
-            stacktrace = event.throwableText
-        )
+  private fun getErrorDetails(event: IdeaLoggingEvent, additionalInfo: String?) =
+      CodyError(
+          title = event.throwableText.lines().first(),
+          pluginVersion = (pluginDescriptor as? IdeaPluginDescriptor)?.version,
+          ideVersion = ApplicationInfo.getInstance().build.toString(),
+          additionalInfo = additionalInfo,
+          stacktrace = event.throwableText)
 
-    private fun encodeIssue(title: String, body: String): String =
-        "https://github.com/sourcegraph/jetbrains/issues/new" +
-                "?labels=bug" +
-                "&title=${encode(title)}" +
-                "&body=${encode(body)}"
+  private fun encodeIssue(title: String, body: String): String =
+      "https://github.com/sourcegraph/jetbrains/issues/new" +
+          "?labels=bug" +
+          "&title=${encode(title)}" +
+          "&body=${encode(body)}"
 
-    private fun encode(text: String) =
-        URLEncoder.encode(text, "UTF-8")
-
+  private fun encode(text: String) = URLEncoder.encode(text, "UTF-8")
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,8 @@
         <!-- autocomplete -->
         <editorFactoryListener implementation="com.sourcegraph.cody.autocomplete.CodyEditorFactoryListener"/>
 
+        <errorHandler implementation="com.sourcegraph.cody.error.CodyErrorSubmitter"/>
+
         <!-- status bar -->
         <statusBarWidgetFactory order="first" id="cody.statusBarWidget"
                                 implementation="com.sourcegraph.cody.statusbar.CodyWidgetFactory"/>

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
@@ -1,0 +1,40 @@
+package com.sourcegraph.cody.error
+
+import junit.framework.TestCase
+
+class CodyErrorFormatterTest : TestCase() {
+
+    fun `test error markdown formatting`() {
+        val error = CodyError(
+            title = "java.lang.NullPointerException",
+            pluginVersion = "5.2.18066-nightly",
+            ideVersion = "IU-233.11799.241",
+            additionalInfo = null,
+            stacktrace = """
+            java.lang.NullPointerException: Exception description
+                at com.example.Some.handle(Some.java:326)
+                ... 54 more
+            """.trimIndent()
+        )
+        val markdown = CodyErrorFormatter.formatToMarkdown(error)
+        val expectedMarkdown = """
+            Plugin version: ```5.2.18066-nightly```
+            IDE version: ```IU-233.11799.241```
+            Exception: ```java.lang.NullPointerException```
+            Stacktrace:
+            ```text
+            java.lang.NullPointerException: Exception description
+                at com.example.Some.handle(Some.java:326)
+                ... 54 more
+            ```
+        """.trimIndent()
+        assertEquals(expectedMarkdown, markdown)
+    }
+
+    fun `test null report results empty markdown`() {
+        val error = CodyError(null, null, null, null, null)
+        val markdown = CodyErrorFormatter.formatToMarkdown(error)
+        assertEquals("", markdown)
+    }
+
+}

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
@@ -4,20 +4,23 @@ import junit.framework.TestCase
 
 class CodyErrorFormatterTest : TestCase() {
 
-    fun `test error markdown formatting`() {
-        val error = CodyError(
+  fun `test error markdown formatting`() {
+    val error =
+        CodyError(
             title = "java.lang.NullPointerException",
             pluginVersion = "5.2.18066-nightly",
             ideVersion = "IU-233.11799.241",
             additionalInfo = null,
-            stacktrace = """
+            stacktrace =
+                """
             java.lang.NullPointerException: Exception description
                 at com.example.Some.handle(Some.java:326)
                 ... 54 more
-            """.trimIndent()
-        )
-        val markdown = CodyErrorFormatter.formatToMarkdown(error)
-        val expectedMarkdown = """
+            """
+                    .trimIndent())
+    val markdown = CodyErrorFormatter.formatToMarkdown(error)
+    val expectedMarkdown =
+        """
             Plugin version: ```5.2.18066-nightly```
             IDE version: ```IU-233.11799.241```
             Exception: ```java.lang.NullPointerException```
@@ -27,14 +30,14 @@ class CodyErrorFormatterTest : TestCase() {
                 at com.example.Some.handle(Some.java:326)
                 ... 54 more
             ```
-        """.trimIndent()
-        assertEquals(expectedMarkdown, markdown)
-    }
+        """
+            .trimIndent()
+    assertEquals(expectedMarkdown, markdown)
+  }
 
-    fun `test null report results empty markdown`() {
-        val error = CodyError(null, null, null, null, null)
-        val markdown = CodyErrorFormatter.formatToMarkdown(error)
-        assertEquals("", markdown)
-    }
-
+  fun `test null report results empty markdown`() {
+    val error = CodyError(null, null, null, null, null)
+    val markdown = CodyErrorFormatter.formatToMarkdown(error)
+    assertEquals("", markdown)
+  }
 }


### PR DESCRIPTION
Unplanned, but I've made decision to add it, especially since implementing it was a small effort. Convenient issue reporting will help us receive more exceptions, so we'll be able to react to them by Feb GA and increase the discoverability of the project. Maybe someone will be engaged enough to participate in our open source project, who knows?

Related to: #135

## Test plan

1. Add `throw RuntimeException()` somewhere in the plugin code to simulate exception.
2. Run the plugin and trigger that exception. An error notification will appear. 
3. Open notification, then click `Open GitHub Issue`.
4. Browser will open at the `issues/new` with useful context (plugin version, IDE version, stacktrace, etc). You should be able to submit that issue (but you shouldn't do it if the exception is only for testing purposes!!).

## Demo

Before:

![Selection_038](https://github.com/sourcegraph/jetbrains/assets/5013708/88567fe7-a16b-421c-be04-fa1520d6a3e0)

After: 

![Selection_035](https://github.com/sourcegraph/jetbrains/assets/5013708/4a2b6d6e-d63a-4fdf-b928-5e8cc9a8ad80)
![Selection_039](https://github.com/sourcegraph/jetbrains/assets/5013708/fe6d2f5d-9334-4e4a-b1e0-1e4dfc1af215)
