### PR TITLE
Fix account updater UI

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.auth.ui
 
-import com.intellij.collaboration.auth.ui.AccountsPanelFactory.accountsPanel
 import com.intellij.collaboration.messages.CollaborationToolsBundle
 import com.intellij.collaboration.ui.util.JListHoveredRowMaterialiser
 import com.intellij.icons.AllIcons

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.auth.ui
 
+import com.intellij.collaboration.auth.ui.AccountsPanelFactory.accountsPanel
 import com.intellij.collaboration.messages.CollaborationToolsBundle
 import com.intellij.collaboration.ui.util.JListHoveredRowMaterialiser
 import com.intellij.icons.AllIcons
@@ -25,13 +26,7 @@ import com.sourcegraph.cody.auth.PersistentActiveAccountHolder
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
-import javax.swing.Icon
-import javax.swing.JComponent
-import javax.swing.JMenuItem
-import javax.swing.JPopupMenu
-import javax.swing.ListCellRenderer
-import javax.swing.ListSelectionModel
-import javax.swing.SwingUtilities
+import javax.swing.*
 
 /**
  * Custom factory method to create and account panel with possibility to add mouse listener for list
@@ -88,14 +83,18 @@ private fun <A : Account, Cred, R> create(
   if (model is AccountsListModel.WithActive) {
     toolbar.addExtraAction(
         object : ToolbarDecorator.ElementActionButton("Set as Active", AllIcons.Actions.Checked) {
+          init {
+            addCustomUpdater { isEnabled && model.activeAccount != accountsList.selectedValue }
+          }
+
           override fun actionPerformed(e: AnActionEvent) {
             val selected = accountsList.selectedValue
             if (selected == model.activeAccount) return
             if (selected != null) model.activeAccount = selected
           }
 
-          override fun updateButton(e: AnActionEvent) {
-            isEnabled = isEnabled && model.activeAccount != accountsList.selectedValue
+          override fun isDumbAware(): Boolean {
+            return true
           }
         })
   }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/304

## Test plan

Manual verification in settings panel

## Changes
Fixes two bugs:
* `Set as active` action was incorrectly disabled during the indexing
* `Set as active` was active also if already active user was selected