### PR TITLE
Fix context files presentation on Windows

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextFile.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextFile.kt
@@ -22,7 +22,7 @@ val contextFileDeserializer =
               uriObj["scheme"]?.asString,
               uriObj["host"]?.asString,
               uriObj["path"]?.asString,
-              uriObj["fragment"]?.asString)
+              /* fragment= */ null)
       val repoName = jsonObject["repoName"]?.asString
       val revision = jsonObject["revision"]?.asString
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ContextFilesMessage.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ContextFilesMessage.kt
@@ -22,6 +22,7 @@ import java.awt.Insets
 import java.nio.file.Paths
 import javax.swing.JPanel
 import javax.swing.border.EmptyBorder
+import kotlin.io.path.absolutePathString
 
 class ContextFilesMessage(val project: Project, contextMessages: List<ContextMessage>) :
     PanelWithGradientBorder(ASSISTANT_MESSAGE_GRADIENT_WIDTH, Speaker.ASSISTANT) {
@@ -35,7 +36,7 @@ class ContextFilesMessage(val project: Project, contextMessages: List<ContextMes
               if (it.repoName != null) {
                 "${project.basePath}/${it.uri.path}"
               } else {
-                it.uri.path
+                Paths.get(it.uri).absolutePathString()
               }
             }
             .toSet()


### PR DESCRIPTION
I should have tested it in the scope of: https://github.com/sourcegraph/jetbrains/pull/297. Anyway, it fixes the links in Windows.

## Test plan 
- [x] Test on Windows + MacOS
- [x] run command/ prompt chat & see the files
- [x] files should be clickable and navigate correctly