### PR TITLE
Expand context panel tree on EDT

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.context.ui
 
 import com.intellij.openapi.actionSystem.ActionToolbarPosition
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.ui.CheckboxTree
@@ -60,8 +61,10 @@ class EnhancedContextPanel(private val project: Project) : JPanel() {
 
   init {
     layout = VerticalFlowLayout(VerticalFlowLayout.BOTTOM, 14, 0, true, false)
-    tree.expandRow(0)
 
-    add(toolbarPanel)
+    ApplicationManager.getApplication().invokeLater {
+      tree.expandRow(0)
+      add(toolbarPanel)
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -62,6 +62,8 @@ class EnhancedContextPanel(private val project: Project) : JPanel() {
   init {
     layout = VerticalFlowLayout(VerticalFlowLayout.BOTTOM, 14, 0, true, false)
 
+    // Fix for https://github.com/sourcegraph/jetbrains/issues/344
+    // Sometimes we are not instantiated on the EDT.
     ApplicationManager.getApplication().invokeLater {
       tree.expandRow(0)
       add(toolbarPanel)


### PR DESCRIPTION
This is a fix for [the recent exception I'm seeing in nightly.](https://github.com/sourcegraph/jetbrains/issues/344)

I unfortunately was not able to repro with a local build. So I'm not sure how it's getting called from a non-EDT thread -- some sort of race condition, possibly. But this looks like the right fix -- I tried it with/without, and the new context panel expands the tree properly for me in both cases.

## Test plan

Manual testing. Passed.