### PR TITLE
Enterprise: add ability to disable logging events to dotcom

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -100,6 +100,10 @@ private constructor(
         processBuilder.environment()["NODE_TLS_REJECT_UNAUTHORIZED"] = "0"
       }
 
+      if (java.lang.Boolean.getBoolean("cody.log-events-to-connected-instance-only")) {
+        processBuilder.environment()["CODY_LOG_EVENT_MODE"] = "connected-instance-only"
+      }
+
       val process =
           processBuilder
               .redirectErrorStream(false)


### PR DESCRIPTION
Previously, the JetBrains plugin always sent a request to sourcegraph.com to log events. This was problematic for some enterprise users on airgapped instances where the agent was failing to initialize because a request to sourcegraph.com was timing out. This PR adds a VM option
`-Dcody.log-events-to-connected-instance-only=true` that disables this behavior. This VM options is a short-term solution. The ideal solution is that the Cody agent automatically turns on this logging mode based on information from the site instance, which is configured by the site admin. Since this is a workaround, we don't need to add a UI in the settings to enable this behavior.

Paired with @chwarwick 
## Test plan

Manually tested this with a local build of cody and confirmed that it does set the logging mode.
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
