### PR TITLE
Bump Cody commit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -198,7 +198,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "7dd0fdc666ef7066cc4c5ab91d55c4ff266738af"
+  val codyCommit = "9cb9d75a6c8300ea3fcc1a4046ff8a7b8b89b46f"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")


### PR DESCRIPTION
This bump brings in several important comits

```
9cb9d75a Agent: add ability to disable network requests to sourcegraph.com (#2909)
5f44688b Agent: reduce automatic requests to sourcegraph.com (#2908)
581734aa Add multi-repo search for enterprise, remove remote embeddings (#2879)
be1bce8b Edit: Remove debug logs (#2907)
3a7b94e1 Fix git clone URL converstion for dots in repo names (#2901)
450d5ef6 VS Code chat UI matches design (#2896)
e54bf2d7 fix: do not display non-chat view in panel (#2904)
6270c8a9 Autocomplete: adaptive dynamic multiline completions (#2881)
3765eac9 Clean up chat editor title buttons & history separators (#2895)
646d0b71 Run embeddings and symf retrieval in parallel and implement basic fusion (#2804)
80caa983 Workspace settings: Disable codeActionsOnSave (#2900)
af9c24f4 Agent: use more helpful assertion in squirrel test (#2897)
e62ca32a Move context warnings from the UI to the debug log (#2891)
ad9c9a64 Clarify custom command codebase property removal changelog (#2892)
56f98de2 Update guardrails shield icon (#2888)
82d51a1f Autocomplete: add test utility for completions streaming (#2880)
35c6cefd Implement history quick pick (#2250)
451dd52e Agent: add support for inline edit command "Document code" (#2870)
a19591b1 fix: doc command with empty chat (#2886)
d2139d9a Agent: update squirrel test to assert context files (#2877)
0bb92450 Autocomplete: Log wether we're inside a test file (#2868)
37c8bc14 Autocomplete: Cancel requests that are no longer relevant (#2855)
256ada97 feat: chat editings, new keybindings, with updated UI (#2826)
9ab02d28 Update the Enhanced Context popover copy and link to docs (#2864)
a94ee57d VS Code enables attribution based on site config (#2815)

```

Most notably:

- Multi-repo context
- Inline edit command support
- `CODY_LOG_EVENT_MODE` support (to disable dotcom requests on airgapped enterprise instance)

## Test plan

I did not follow all step here https://github.com/sourcegraph/jetbrains/blob/main/TESTING.md

I tried a lot of features and it worked according to my expectations.

- Enterprise chat
- PLG chat
- Commands
- Autocomplete (single line + multiline)
- Stopping chat
- Parallel commands
- Restart agent and submit message


<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
