### PR TITLE
IntelliJ can now debug the Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # User local IDEA configuration files
 .idea/
+.run/
 
 # IntelliJ project
 *.iml

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.agent
 
-import CodyAgent
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service


### PR DESCRIPTION
I wanted a decent debugging setup, so I modified the agent to be able to be debugged by IntelliJ. This lets me set breakpoints on both sides of the protocol.

This was a fairly straightforward change, but I have only used it for a few hours, so there may be issues. However it is very useful to be able to debug the agent, so I am committing it now.

There are two modes of operation supported: Cody can spawn the agent or IntelliJ can spawn it. The latter allows Cody to talk to any remote agent.

I added detailed instructions on how to set this up in CONTRIBUTING.md.

## Test plan

Locally/manually tested. This is a dev-only code path, and tricky to unit test.