### PR TITLE
Fix chat history sorting after posting message to the old chat

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryTree.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryTree.kt
@@ -78,6 +78,17 @@ class HistoryTree(
         for (child in sorted) period.add(child)
         model.reload(period)
       }
+    } else {
+      val period =
+          root
+              .periods()
+              .flatMap { it.leafs() }
+              .find { it.chat.internalId == chat.internalId }!!
+              .parent as PeriodNode
+      val sorted = period.leafs().sortedByDescending { it.chat.getUpdatedTimeAt() }
+      period.removeAllChildren()
+      for (child in sorted) period.add(child)
+      model.reload(period)
     }
   }
 


### PR DESCRIPTION
It fixes issue with chat history sorting when new message is posted in the old chat: https://github.com/sourcegraph/jetbrains/pull/438#issuecomment-1919594604
## Test plan
* Create new chat and post message
* Create second chat and post message
* Check history tree
* Post message in the first chat
* Old chat should be moved to the top of the tree
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
