### PR TITLE
Add "New Chat" shortcut and fix existing shortcut names

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -300,6 +300,7 @@ Test ideas:
 9. Use only the keyboard. For example, navigate transcripts with arrows, delete, enter.
 10. Start typing while being focused on Chat History to perform search-by-title.
 11. Open multiple chats and ask few simultaneous questions in several sessions at once.
+12. Open new chat with <kbd>Alt</kbd> + <kbd>=</kbd> shortcut.
 
 ## Code Search
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -300,7 +300,7 @@ Test ideas:
 9. Use only the keyboard. For example, navigate transcripts with arrows, delete, enter.
 10. Start typing while being focused on Chat History to perform search-by-title.
 11. Open multiple chats and ask few simultaneous questions in several sessions at once.
-12. Open new chat with <kbd>Alt</kbd> + <kbd>=</kbd> shortcut.
+12. Open new chat with <kbd>Alt</kbd> + <kbd>=</kbd> shortcut (or <kbd>Option</kbd> + <kbd>=</kbd> on Mac).
 
 ## Code Search
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
@@ -2,7 +2,10 @@ package com.sourcegraph.cody.chat
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.CodyToolWindowFactory
 
 class NewChatAction : DumbAwareAction() {
 
@@ -11,5 +14,9 @@ class NewChatAction : DumbAwareAction() {
     CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
       switchToChatSession(AgentChatSession.createNew(project))
     }
+    showToolbar(project)
   }
+
+  private fun showToolbar(project: Project) =
+    ToolWindowManager.getInstance(project).getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)?.show()
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
@@ -18,5 +18,7 @@ class NewChatAction : DumbAwareAction() {
   }
 
   private fun showToolbar(project: Project) =
-    ToolWindowManager.getInstance(project).getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)?.show()
+      ToolWindowManager.getInstance(project)
+          .getToolWindow(CodyToolWindowFactory.TOOL_WINDOW_ID)
+          ?.show()
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -143,36 +143,38 @@
 
         <!-- autocomplete -->
         <action id="cody.acceptAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction"
+                text="Accept Autocomplete Suggestion">
             <keyboard-shortcut first-keystroke="TAB" keymap="$default"/>
-            <override-text place="MainMenu" text="Accept Autocomplete Suggestion"/>
         </action>
         <action id="cody.cycleForwardAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction"
+                text="Cycle Forward Autocomplete Suggestion">
             <keyboard-shortcut first-keystroke="alt OPEN_BRACKET" keymap="$default"/>
-            <override-text place="MainMenu" text="Cycle Autocomplete Suggestion"/>
         </action>
         <action id="cody.cycleBackAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction"
+                text="Cycle Backwards Autocomplete Suggestion">
             <keyboard-shortcut first-keystroke="alt CLOSE_BRACKET" keymap="$default"/>
-            <override-text place="MainMenu" text="Cycle Autocomplete Suggestion"/>
         </action>
 
-        <action id="cody.disposeInlays" class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction">
+        <action id="cody.disposeInlays"
+                class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction"
+                text="Hide Completions">
             <keyboard-shortcut first-keystroke="ESCAPE" keymap="$default"/>
-            <override-text place="MainMenu" text="Hide Completions"/>
         </action>
 
         <action id="cody.triggerAutocomplete"
-                class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction"
+                text="Autocomplete">
             <keyboard-shortcut first-keystroke="alt BACK_SLASH" keymap="$default"/>
-            <override-text place="MainMenu" text="Autocomplete"/>
         </action>
 
         <action id="cody.newChat"
                 icon="/icons/chat/newChat.svg"
                 text="New Chat"
                 class="com.sourcegraph.cody.chat.NewChatAction">
+            <keyboard-shortcut first-keystroke="alt EQUALS" keymap="$default"/>
         </action>
 
         <action


### PR DESCRIPTION
Related to: #322
Fixes: https://github.com/sourcegraph/jetbrains/issues/79

## Test plan

1. Use `Alt` + `=` to invoke New Chat action.
2. Go to Key Bindings settings and verify if all Cody shortcuts have correctly displayed names.