### PR TITLE
Cody action group should be visible even during the indexing

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
+++ b/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
@@ -6,6 +6,12 @@ import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class CodyActionGroup extends DefaultActionGroup {
+
+  @Override
+  public boolean isDumbAware() {
+    return true;
+  }
+
   @Override
   public void update(@NotNull AnActionEvent e) {
     super.update(e);


### PR DESCRIPTION
## Test plan

Manual testing:
1) Trigger clearing caches from File menu
2) Check if Cody context menu is present and enabled during the indexing