### PR TITLE
Bugfix: Disable New Chat action when there are no active accounts

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
@@ -8,11 +8,12 @@ import com.sourcegraph.cody.config.getFirstAccountOrNull
 import com.sourcegraph.cody.initialization.Activity
 
 class SelectOneOfTheAccountsAsActive : Activity {
+
   override fun runActivity(project: Project) {
-    val codyAuthenticationManager = CodyAuthenticationManager.instance
-    if (codyAuthenticationManager.getActiveAccount(project) == null) {
-      val newActiveAccount = codyAuthenticationManager.getAccounts().getFirstAccountOrNull()
-      codyAuthenticationManager.setActiveAccount(project, newActiveAccount)
+    if (CodyAuthenticationManager.instance.hasNoActiveAccount(project)) {
+      val newActiveAccount =
+          CodyAuthenticationManager.instance.getAccounts().getFirstAccountOrNull()
+      CodyAuthenticationManager.instance.setActiveAccount(project, newActiveAccount)
       ApplicationManager.getApplication().invokeLater {
         CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) { refreshPanelsVisibility() }
       }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -145,8 +145,7 @@ class CodyAutocompleteManager {
     }
     val textDocument: TextDocument = IntelliJTextDocument(editor, project)
 
-    if (isTriggeredExplicitly &&
-        CodyAuthenticationManager.instance.getActiveAccount(project) == null) {
+    if (isTriggeredExplicitly && CodyAuthenticationManager.instance.hasNoActiveAccount(project)) {
       HintManager.getInstance().showErrorHint(editor, "Cody: Sign in to use autocomplete")
       return
     }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/NewChatAction.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.CodyToolWindowFactory
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 
 class NewChatAction : DumbAwareAction() {
 
@@ -15,6 +16,12 @@ class NewChatAction : DumbAwareAction() {
       switchToChatSession(AgentChatSession.createNew(project))
     }
     showToolbar(project)
+  }
+
+  override fun update(event: AnActionEvent) {
+    val project = event.project ?: return
+    val hasActiveAccount = !CodyAuthenticationManager.instance.hasNoActiveAccount(project)
+    event.presentation.isEnabledAndVisible = hasActiveAccount
   }
 
   private fun showToolbar(project: Project) =

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -56,6 +56,8 @@ class CodyAuthenticationManager internal constructor() {
     return getActiveAccount(project)?.getAccountType() ?: AccountType.DOTCOM
   }
 
+  fun hasNoActiveAccount(project: Project) = instance.getActiveAccount(project) == null
+
   companion object {
     @JvmStatic
     val instance: CodyAuthenticationManager

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -160,7 +160,7 @@ class SettingsMigration : Activity {
     loadUserDetails(requestExecutorFactory, accessToken, progressIndicator, server) {
       val codyAccount = CodyAccount.create(it.name, it.displayName, server, it.id)
       addAccount(codyAccount, accessToken)
-      if (CodyAuthenticationManager.instance.getActiveAccount(project) == null)
+      if (CodyAuthenticationManager.instance.hasNoActiveAccount(project))
           CodyAuthenticationManager.instance.setActiveAccount(project, codyAccount)
     }
   }


### PR DESCRIPTION
Also: Added `CodyAuthenticationManager.hasNoActiveAccount(project)` and used everywhere (?).

## Test plan

1. Remove account -> icon should be hidden & action shortcut should be disabled
2. Add account -> icon appears & action shortcut works again
