### PR TITLE
Add "Delete All Chats" popup action

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -32,7 +32,7 @@ class CodyToolWindowContent(private val project: Project) {
 
   private var codyOnboardingGuidancePanel: CodyOnboardingGuidancePanel? = null
   private val signInWithSourcegraphPanel = SignInWithSourcegraphPanel(project)
-  private val historyTree = HistoryTree(::selectHistory, ::deleteHistory)
+  private val historyTree = HistoryTree(::selectChat, ::removeChat, ::removeAllChats)
   private val tabbedPane = JBTabbedPane()
   private val currentChatSession: AtomicReference<AgentChatSession?> = AtomicReference(null)
 
@@ -132,12 +132,12 @@ class CodyToolWindowContent(private val project: Project) {
   }
 
   @RequiresEdt
-  private fun selectHistory(state: ChatState) {
+  private fun selectChat(state: ChatState) {
     val session = AgentChatSessionService.getInstance(project).getOrCreateFromState(state)
     switchToChatSession(session)
   }
 
-  private fun deleteHistory(state: ChatState) {
+  private fun removeChat(state: ChatState) {
     HistoryService.getInstance().remove(state.internalId)
     if (AgentChatSessionService.getInstance(project).removeSession(state)) {
       val isVisible = currentChatSession.get()?.getInternalId() == state.internalId
@@ -145,6 +145,12 @@ class CodyToolWindowContent(private val project: Project) {
         switchToChatSession(AgentChatSession.createNew(project), showChatWindow = false)
       }
     }
+  }
+
+  private fun removeAllChats() {
+    AgentChatSessionService.getInstance(project).removeAllSessions()
+    HistoryService.getInstance().removeAll()
+    switchToChatSession(AgentChatSession.createNew(project))
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -31,6 +31,10 @@ class HistoryService : SimplePersistentStateComponent<HistoryState>(HistoryState
     state.chats.removeIf { it.internalId == internalId }
   }
 
+  fun removeAll() {
+    state.chats = mutableListOf()
+  }
+
   private fun convertToMessageState(chatMessage: ChatMessage): MessageState {
     val message = MessageState()
     message.text = chatMessage.text

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -95,5 +95,7 @@ duration.x-months-ago={0} months ago
 duration.last-year=Last year
 duration.x-years-ago={0} years ago
 duration.x-ago={0} ago
+
 popup.select-chat=Select Chat
 popup.remove-chat=Remove Chat
+popup.remove-all-chats=Remove All Chats


### PR DESCRIPTION
Fixes #371

## Test plan

1. The Remove All action should be always enabled.
2. You should be able to use the Remove All action while tokens are still being generated.
3. The Chat panel should be automatically cleared, and sessions terminated.