### PR TITLE
auth: update endpoint for SAMS redirect

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/auth/SourcegraphAuthService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/SourcegraphAuthService.kt
@@ -31,17 +31,17 @@ internal class SourcegraphAuthService : AuthServiceBase() {
         when (authMethod) {
           SsoAuthMethod.GITHUB -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=github&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           SsoAuthMethod.GITLAB -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=gitlab&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           SsoAuthMethod.GOOGLE -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=google&pc=PhZek7LEdAkR3-I9XyVEMw&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           else ->


### PR DESCRIPTION
This is a follow-up improvement to https://github.com/sourcegraph/jetbrains/pull/464. TIL we can configure auth provider in Sourcegraph to have a static `pc` to reference to. This is strictly better than relying on the brittle sha256 of current provider config.

## Test plan

Manually tested

and

![CleanShot 2024-02-05 at 14 55 27@2x](https://github.com/sourcegraph/cody/assets/2946214/6633b293-fe68-494a-8c9e-f9bcafcaab19)

