### PR TITLE
cody: update CTA url

### DIFF
--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -78,12 +78,12 @@ EndOfTrialNotification.do-not-show-again=Don't show again
 TrialEndingSoonNotification.ignore=cody.ignore.notification.trial-ending-soon
 TrialEndingSoonNotification.ending-soon.title=Your Cody Pro trial is ending soon
 TrialEndingSoonNotification.ending-soon.content=Setup your payment information to continue using Cody Pro, you won't be charged until February 15.
-TrialEndingSoonNotification.ending-soon.link=https://accounts.sourcegraph.com/cody/subscription?on-trial=true
+TrialEndingSoonNotification.ending-soon.link=https://sourcegraph.com/cody/subscription?on-trial=true
 
 TrialEndedNotification.ignore=cody.ignore.notification.trial-ended
 TrialEndedNotification.ended.title=Your Cody Pro trial has ended
 TrialEndedNotification.ended.content=<html>Thank you for trying Cody Pro! Your trial period has ended. To keep enjoying all the features of Cody Pro, subscribe to our monthly plan. You can cancel anytime.</html>
-TrialEndedNotification.ended.link=https://accounts.sourcegraph.com/cody/subscription
+TrialEndedNotification.ended.link=https://sourcegraph.com/cody/subscription
 
 duration.today=Today
 duration.yesterday=Yesterday


### PR DESCRIPTION
Changing CTA url to the Cody subscription page instead of the checkout page, see [thread](https://sourcegraph.slack.com/archives/C05SZB829D0/p1706857322038529) for more info

## Test plan
N/A - url change
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
