### PR TITLE
Isolate chats between accounts

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -18,6 +18,7 @@
     - [ ] [Autoscroll to latest message](#autoscroll-to-latest-message)
     - [ ] [Read chat history without interruptions](#read-chat-history-without-interruptions)
     - [ ] [Organize multiple chats](#organize-multiple-chats)
+    - [ ] [Isolate multiple chats](#isolate-multiple-chats)
 - Sourcegraph Code Search
     - [ ] [Find with Sourcegraph...](#find-with-sourcegraph)
     - [ ] [Search Selection on Sourcegraph Web](#search-selection-on-sourcegraph-web)
@@ -262,6 +263,19 @@ Test ideas:
 13. Open existing chat with shortcut <kbd>Alt</kbd> + <kbd>-</kbd> (or <kbd>Option</kbd> + <kbd>-</kbd> on Mac) and start typing question. Tab should be switched automatically on Chat.
 14. Second click <kbd>Alt</kbd> + <kbd-</kbd> should hide tool window if focused (similar behavior as other tool windows).
 15. Click <kbd>Esc</kbd> while being focused inside Cody tool window. You should be automatically focused on code.  
+
+#### Isolate multiple chats
+
+Prerequisite: You need two working accounts. Preferably one Free, and one Enterprise.
+
+1. Switch to first account.
+2. Send a message.
+3. Switch to second account. 
+4. Send a message.
+
+These two chats should be isolated between different accounts. Both accounts should have one conversation each.
+
+You should also be able to switch between accounts while tokens are still being generated.
 
 ## Code Search
 

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -32,7 +32,7 @@ class CodyToolWindowContent(private val project: Project) {
 
   private var codyOnboardingGuidancePanel: CodyOnboardingGuidancePanel? = null
   private val signInWithSourcegraphPanel = SignInWithSourcegraphPanel(project)
-  private val historyTree = HistoryTree(::selectChat, ::removeChat, ::removeAllChats)
+  private val historyTree = HistoryTree(project, ::selectChat, ::removeChat, ::removeAllChats)
   private val tabbedPane = JBTabbedPane()
   private val currentChatSession: AtomicReference<AgentChatSession?> = AtomicReference(null)
 
@@ -103,6 +103,8 @@ class CodyToolWindowContent(private val project: Project) {
       }
     }
   }
+
+  @RequiresEdt fun refreshHistoryTree() = historyTree.rebuildTree(project)
 
   @RequiresEdt
   fun refreshPanelsVisibility() {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -179,7 +179,7 @@ private constructor(
     }
     messages.add(message)
     chatPanel.addOrUpdateMessage(message)
-    HistoryService.getInstance().update(internalId, messages)
+    HistoryService.getInstance().update(project, internalId, messages)
   }
 
   @RequiresEdt

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -40,6 +40,7 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
               CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
                 refreshPanelsVisibility()
                 refreshMyAccountTab()
+                refreshHistoryTree()
               }
             }
 

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -16,6 +16,8 @@ class ChatState : BaseState() {
 
   @get:OptionTag(tag = "updatedAt", nameAttribute = "") var updatedAt: String? by string()
 
+  @get:OptionTag(tag = "accountId", nameAttribute = "") var accountId: String? by string()
+
   fun title(): String? = messages.firstOrNull()?.text
 
   fun setUpdatedTimeAt(date: LocalDateTime) {
@@ -30,5 +32,12 @@ class ChatState : BaseState() {
   companion object {
 
     private val DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+    fun create(accountId: String?, internalId: String): ChatState {
+      val chat = ChatState()
+      chat.accountId = accountId
+      chat.internalId = internalId
+      return chat
+    }
   }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
@@ -14,6 +14,7 @@ class HistoryStateTest : TestCase() {
         HistoryState().apply {
           chats +=
               ChatState().apply {
+                accountId = "VXNlkjoxEFU3NjE="
                 internalId = "0f8b7034-9fa8-488a-a13e-09c52677008a"
                 updatedAt = "2024-01-31T01:06:18.524621"
                 messages +=
@@ -37,6 +38,7 @@ class HistoryStateTest : TestCase() {
         <chats>
           <list>
             <chat>
+              <accountId value="VXNlkjoxEFU3NjE=" />
               <internalId value="0f8b7034-9fa8-488a-a13e-09c52677008a" />
               <messages>
                 <list>


### PR DESCRIPTION
Fixes #374

## Test Plan

Prerequisite: You need two working accounts. Preferably one Free, and one Enterprise.

1. Switch to first account.
2. Send a message.
3. Switch to second account.
4. Send a message.

These two chats should be isolated between different accounts. Both accounts should have one conversation each. It doesn't matter if you're on FREE or Enterprise: every chat now is assigned to account.

You should also be able to switch between accounts while tokens are still being generated.

Note about migration: Old chats will preserved in the new schema. This works so that orphaned chats will be assigned to the currently active account.