### PR TITLE
Fix Bad Request on Open GitHub Issue report when URL is too long 

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyError.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyError.kt
@@ -1,9 +1,9 @@
 package com.sourcegraph.cody.error
 
 data class CodyError(
-    val title: String?,
+    val title: String,
     val pluginVersion: String?,
-    val ideVersion: String?,
+    val ideVersion: String,
     val additionalInfo: String?,
-    val stacktrace: String?
+    val stacktrace: String
 )

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorFormatter.kt
@@ -7,7 +7,6 @@ object CodyErrorFormatter {
               "Plugin version" to error.pluginVersion,
               "IDE version" to error.ideVersion,
               "Additional information" to error.additionalInfo,
-              "Exception" to error.title,
               "Stacktrace" to error.stacktrace)
           .filterValues { it != null }
           .map { toLabeledCodeBlock(it.key, it.value!!) }

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
@@ -23,7 +23,6 @@ class CodyErrorFormatterTest : TestCase() {
         """
             Plugin version: ```5.2.18066-nightly```
             IDE version: ```IU-233.11799.241```
-            Exception: ```java.lang.NullPointerException```
             Stacktrace:
             ```text
             java.lang.NullPointerException: Exception description

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorFormatterTest.kt
@@ -34,10 +34,4 @@ class CodyErrorFormatterTest : TestCase() {
             .trimIndent()
     assertEquals(expectedMarkdown, markdown)
   }
-
-  fun `test null report results empty markdown`() {
-    val error = CodyError(null, null, null, null, null)
-    val markdown = CodyErrorFormatter.formatToMarkdown(error)
-    assertEquals("", markdown)
-  }
 }


### PR DESCRIPTION
Motivation: If the URL is too long (mainly because of stacktrace), GitHub blocks the `issues/new` endpoint. User is facing Bad Request.

Also: I've added few improvements.
    
## Test plan

1. Add error("test") to CodyToolWindowContent constructor.

## Demo

-----

![Selection_072](https://github.com/sourcegraph/jetbrains/assets/5013708/314f33ce-0c73-461e-a30b-872c6da0e2b8)

---- 

![Selection_070](https://github.com/sourcegraph/jetbrains/assets/5013708/d0b5cb77-6dd4-4039-a1dc-3c6a560c6e7c)

