### PR TITLE
Fix uri for autocomplete

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/AutocompleteParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/AutocompleteParams.kt
@@ -1,23 +1,13 @@
 package com.sourcegraph.cody.agent.protocol
 
-import java.net.URI
-import java.nio.file.Paths
-
 enum class AutocompleteTriggerKind(val value: String) {
   AUTOMATIC("Automatic"),
   INVOKE("Invoke"),
 }
 
 data class AutocompleteParams(
-    val uri: URI,
+    val uri: String,
     val position: Position,
     val triggerKind: String? = AutocompleteTriggerKind.AUTOMATIC.value,
     val selectedCompletionInfo: SelectedCompletionInfo? = null
-) {
-  constructor(
-      filePath: String,
-      position: Position,
-      triggerKind: String? = AutocompleteTriggerKind.AUTOMATIC.value,
-      selectedCompletionInfo: SelectedCompletionInfo? = null
-  ) : this(Paths.get(filePath).toUri(), position, triggerKind, selectedCompletionInfo)
-}
+)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -45,6 +45,7 @@ import com.sourcegraph.utils.CodyFormatter
 import difflib.Delta
 import difflib.DiffUtils
 import difflib.Patch
+import java.nio.file.Paths
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -199,14 +200,14 @@ class CodyAutocompleteManager {
     val params =
         if (lookupString.isNullOrEmpty())
             AutocompleteParams(
-                virtualFile.path,
+                Paths.get(virtualFile.path).toUri().path,
                 Position(position.line, position.character),
                 if (triggerKind == InlineCompletionTriggerKind.INVOKE)
                     AutocompleteTriggerKind.INVOKE.value
                 else AutocompleteTriggerKind.AUTOMATIC.value)
         else
             AutocompleteParams(
-                virtualFile.path,
+                Paths.get(virtualFile.path).toUri().path,
                 Position(position.line, position.character),
                 AutocompleteTriggerKind.AUTOMATIC.value,
                 SelectedCompletionInfo(


### PR DESCRIPTION
The recent changes (https://github.com/sourcegraph/jetbrains/pull/367) broke autocomplete. The uri was string before but not it is properly serialized 😅 Agent expect the param to be string (not an object). Let's keep the serialisation for now but just pass string as param.


## Test plan
- autocomplete works