### PR TITLE
Remove JetBrains Client compatibility

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,8 @@
     -->
     <idea-version since-build="221.5080.210"/>
 
+    <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
+
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-perforce.xml">PerforceDirectPlugin</depends>


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/366 
Fixes https://github.com/sourcegraph/jetbrains/issues/537 
Fixes https://github.com/sourcegraph/sourcegraph/issues/57569

Motivation: Multiple features are simply not working on this "thin" IDE (see: linked issues) due to missing classes. 

More details here: #537

JetBrains client is prefixed with "JBC" (for example: JBC-232.10227.8).

## Test plan

You shouldn't be able to install Cody on JetBrains Client. It's hard to reproduce (I had issues to download & use this), however this can be simply verified on Cody plugin JetBrains Marketplace page > Versions > Compatible with... (currently JetBrains Client is listed there).