### PR TITLE
make uri serializer more tolerant to type errors

### DIFF
--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -269,13 +269,18 @@ data class AtExpression(
     val value: String
 )
 
-val atExpressionPattern = """(@(?:\\\s|[^\s])+)(?:\s|$)""".toRegex()
+val atExpressionPattern = """(@(?:\\\s|\S)*)(?:\s|$)""".toRegex()
 
 fun findAtExpressions(text: String): List<AtExpression> {
   val matches = atExpressionPattern.findAll(text)
   val expressions = ArrayList<AtExpression>()
   for (match in matches) {
-    val subMatch = match.groups.get(1)
+    val mainMatch = match.groups[0] ?: continue
+    val prevIndex = mainMatch.range.first - 1
+    // filter out things like email addresses
+    if (prevIndex >= 0 && !text[prevIndex].isWhitespace()) continue
+
+    val subMatch = match.groups[1]
     if (subMatch != null) {
       val value = subMatch.value.substring(1).replace("\\ ", " ")
       expressions.add(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextFile.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextFile.kt
@@ -39,24 +39,34 @@ val contextFileDeserializer =
 
 val uriDeserializer =
     JsonDeserializer { jsonElement: JsonElement, typ: Type, context: JsonDeserializationContext ->
-      val j = jsonElement.asJsonObject
-      URI(
-          j["scheme"]?.asString,
-          j["authority"]?.asString,
-          j["path"]?.asString,
-          j["query"]?.asString,
-          j["fragment"]?.asString,
-      )
+      val j = jsonElement?.asJsonObject
+      if (j == null || j.isJsonNull) {
+        null
+      } else if (j.isJsonPrimitive) {
+        j.asString
+      } else {
+        URI(
+            j["scheme"]?.asString,
+            j["authority"]?.asString,
+            j["path"]?.asString,
+            j["query"]?.asString,
+            j["fragment"]?.asString,
+        )
+      }
     }
 
 val uriSerializer = JsonSerializer { uri: URI, type, context ->
-  val obj = JsonObject()
-  obj.addProperty("scheme", uri.scheme)
-  obj.addProperty("authority", uri.authority)
-  obj.addProperty("path", uri.path)
-  obj.addProperty("query", uri.query)
-  obj.addProperty("fragment", uri.fragment)
-  obj
+  if (uri == null) {
+    JsonNull.INSTANCE
+  } else {
+    val obj = JsonObject()
+    obj.addProperty("scheme", uri.scheme)
+    obj.addProperty("authority", uri.authority)
+    obj.addProperty("path", uri.path)
+    obj.addProperty("query", uri.query)
+    obj.addProperty("fragment", uri.fragment)
+    obj
+  }
 }
 
 fun contextFilesFromList(list: List<Any>): List<String> {

--- a/src/test/kotlin/com/sourcegraph/cody/PromptPanelTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/PromptPanelTest.kt
@@ -33,7 +33,12 @@ class PromptPanelTest : TestCase() {
                         "foo ".length + "@file\\ with\\ spaces".length,
                         "@file\\ with\\ spaces",
                         "file with spaces"),
-                )))
+                )),
+            Case("@", listOf(AtExpression(0, 1, "@", ""))),
+            Case("foo @", listOf(AtExpression("foo ".length, "foo @".length, "@", ""))),
+            Case("@ foo", listOf(AtExpression(0, 1, "@", ""))),
+            Case("foo@email.com", listOf()),
+        )
 
     for (case in cases) {
       assertEquals(case.expected, findAtExpressions(case.text))


### PR DESCRIPTION
Make the URI deserializer tolerant to the following errors that can occur in deserialization:
* value is `null` or missing
* value is a string, rather than a `URI` object

Previously, we saw the following errors:

Example 1: https://github.com/sourcegraph/jetbrains/pull/526
Example 2:
```
2024-02-08 18:20:43,368 [  32696] SEVERE - o.e.l.j.j.StreamMessageProducer - An error occurred while processing an incoming message.
java.lang.NullPointerException
   at com.sourcegraph.cody.agent.protocol.ContextFileKt.uriDeserializer$lambda$1(ContextFile.kt:42)
   at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:76)
   at com.google.gson.Gson.fromJson(Gson.java:1227)
   at com.google.gson.Gson.fromJson(Gson.java:1329)
   at com.google.gson.Gson.fromJson(Gson.java:1300)
```

Note: this PR also includes changes from https://github.com/sourcegraph/jetbrains/pull/555

## Test plan

Tested locally