### PR TITLE
show context files on empty at-expression

### DIFF
--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -269,13 +269,18 @@ data class AtExpression(
     val value: String
 )
 
-val atExpressionPattern = """(@(?:\\\s|[^\s])+)(?:\s|$)""".toRegex()
+val atExpressionPattern = """(@(?:\\\s|\S)*)(?:\s|$)""".toRegex()
 
 fun findAtExpressions(text: String): List<AtExpression> {
   val matches = atExpressionPattern.findAll(text)
   val expressions = ArrayList<AtExpression>()
   for (match in matches) {
-    val subMatch = match.groups.get(1)
+    val mainMatch = match.groups[0] ?: continue
+    val prevIndex = mainMatch.range.first - 1
+    // filter out things like email addresses
+    if (prevIndex >= 0 && !text[prevIndex].isWhitespace()) continue
+
+    val subMatch = match.groups[1]
     if (subMatch != null) {
       val value = subMatch.value.substring(1).replace("\\ ", " ")
       expressions.add(

--- a/src/test/kotlin/com/sourcegraph/cody/PromptPanelTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/PromptPanelTest.kt
@@ -33,7 +33,12 @@ class PromptPanelTest : TestCase() {
                         "foo ".length + "@file\\ with\\ spaces".length,
                         "@file\\ with\\ spaces",
                         "file with spaces"),
-                )))
+                )),
+            Case("@", listOf(AtExpression(0, 1, "@", ""))),
+            Case("foo @", listOf(AtExpression("foo ".length, "foo @".length, "@", ""))),
+            Case("@ foo", listOf(AtExpression(0, 1, "@", ""))),
+            Case("foo@email.com", listOf()),
+        )
 
     for (case in cases) {
       assertEquals(case.expected, findAtExpressions(case.text))


### PR DESCRIPTION
<img width="282" alt="image" src="https://github.com/sourcegraph/jetbrains/assets/1646931/70d25486-37ac-4fd9-bd4f-06045388ad51">

Partially resolves https://github.com/sourcegraph/jetbrains/issues/554

(This is stacked on top of #551 to make the PR review more convenient)

## Test plan

Test locally