### PR TITLE
Make agent restart code much less error-prone

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
@@ -45,17 +45,17 @@ public final class CodyFocusChangeListener implements FocusChangeListener, Start
       return;
     }
 
-    CodyAgentService.applyAgentOnBackgroundThread(
-        project,
-        agent -> {
-          try {
-            // TODO: This is bad but needed to avoid race with file context of commands executed
-            // through context menu
-            Thread.sleep(100);
-          } catch (InterruptedException ignored) {
-          }
-          agent.getServer().textDocumentDidFocus(TextDocument.fromPath(file.getPath()));
-        });
+    CodyAgentService.withAgent(project)
+        .thenAccept(
+            agent -> {
+              try {
+                // TODO: This is bad but needed to avoid race with file context of commands executed
+                // through context menu
+                Thread.sleep(100);
+              } catch (InterruptedException ignored) {
+              }
+              agent.getServer().textDocumentDidFocus(TextDocument.fromPath(file.getPath()));
+            });
 
     CodyAgentCodebase.getInstance(project).onFileOpened(project, file);
   }

--- a/src/main/java/com/sourcegraph/cody/attribution/AttributionSearchCommand.kt
+++ b/src/main/java/com/sourcegraph/cody/attribution/AttributionSearchCommand.kt
@@ -24,7 +24,7 @@ class AttributionSearchCommand(private val project: Project) {
    */
   fun onSnippetFinished(snippet: String, sessionId: SessionId, listener: AttributionListener) {
     if (attributionEnabled()) {
-      CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+      CodyAgentService.withAgent(project).thenAccept { agent ->
         ApplicationManager.getApplication().invokeLater { listener.onAttributionSearchStart() }
         val params = AttributionSearchParams(id = sessionId, snippet = snippet)
         agent.server.attributionSearch(params).handle(updateEditor(listener))

--- a/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -65,9 +65,13 @@ public class GraphQlLogger {
   // This could be exposed later (as public), but currently, we don't use it externally.
   private static CompletableFuture<Boolean> logEvent(
       @NotNull Project project, @NotNull Event event) {
-    return CodyAgentService.getAgent(project)
-        .thenApply(agent -> agent.getServer().logEvent(event))
-        .thenApply((ignored) -> true)
-        .exceptionally((ignored) -> false);
+    return CodyAgentService.withAgent(project)
+        .thenCompose(
+            agent ->
+                agent
+                    .getServer()
+                    .logEvent(event)
+                    .thenApply((ignored) -> true)
+                    .exceptionally((ignored) -> false));
   }
 }

--- a/src/main/java/com/sourcegraph/vcs/RepoUtil.java
+++ b/src/main/java/com/sourcegraph/vcs/RepoUtil.java
@@ -151,27 +151,25 @@ public class RepoUtil {
 
     if (vcsType == VCSType.GIT && repository != null) {
       String cloneURL = GitUtil.getRemoteRepoUrl((GitRepository) repository, project);
-      String codebaseName = null;
-
       if (ConfigUtil.isCodyEnabled()) {
-        codebaseName =
-            CodyAgentService.getAgent(project)
+        String codebaseName =
+            CodyAgentService.withAgent(project)
                 .thenCompose(
                     agent ->
                         agent.getServer().convertGitCloneURLToCodebaseName(new CloneURL(cloneURL)))
                 .completeOnTimeout(null, 15, TimeUnit.SECONDS)
                 .get();
 
-        if (codebaseName == null) {
+        if (codebaseName != null) {
+          return codebaseName;
+        } else {
           logger.warn(
               "Failed to convert git clone URL to codebase name for cloneURL via agent for cloneUrl="
                   + cloneURL);
         }
       }
 
-      return codebaseName != null
-          ? codebaseName
-          : convertGitCloneURLToCodebaseNameOrError(cloneURL);
+      return convertGitCloneURLToCodebaseNameOrError(cloneURL);
     }
 
     if (vcsType == VCSType.PERFORCE) {

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -89,7 +89,7 @@ class CodyToolWindowContent(private val project: Project) {
   }
 
   fun refreshMyAccountTab() {
-    CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+    CodyAgentService.withAgent(project).thenAccept { agent ->
       fetchMyAccountPanelData(project, agent.server).thenApply { data ->
         if (data != null) {
           ApplicationManager.getApplication().invokeLater {

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -30,7 +30,7 @@ class CodyAgentCodebase(val project: Project) {
       val repositoryName = RepoUtil.findRepositoryName(project, file)
       if (repositoryName != null && inferredUrl.getNow(null) != repositoryName) {
         inferredUrl.complete(repositoryName)
-        CodyAgentService.applyAgentOnBackgroundThread(project) {
+        CodyAgentService.withAgent(project).thenAccept {
           it.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
         }
       }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
@@ -98,7 +98,7 @@ class CodyEditorFactoryListener : EditorFactoryListener {
 
         // This notification must be sent after the above, see tracker comment for more details.
         AcceptCodyAutocompleteAction.tracker.getAndSet(null)?.let { completionID ->
-          CodyAgentService.applyAgentOnBackgroundThread(editor.project!!) { agent ->
+          CodyAgentService.withAgent(editor.project!!).thenAccept { agent ->
             agent.server.completionAccepted(CompletionItemParams(completionID))
             agent.server.autocompleteClearLastCandidate()
           }
@@ -170,7 +170,7 @@ class CodyEditorFactoryListener : EditorFactoryListener {
         CodyAgentCodebase.getInstance(project).onFileOpened(project, file)
       }
 
-      CodyAgentService.applyAgentOnBackgroundThread(project) {
+      CodyAgentService.withAgent(project).thenAccept {
         it.server.textDocumentDidOpen(document)
         afterUpdate()
       }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
@@ -19,7 +19,7 @@ class CodyPersistentAccountsHost(private val project: Project?) : CodyAccountsHo
     if (project != null) {
       CodyAuthenticationManager.instance.setActiveAccount(project, codyAccount)
       // Notify Cody Agent about config changes.
-      CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+      CodyAgentService.withAgentRestartIfNeeded(project).thenAccept { agent ->
         agent.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
       }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -23,7 +23,7 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
 
             // Notify Cody Agent about config changes.
             if (ConfigUtil.isCodyEnabled()) {
-              CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+              CodyAgentService.withAgentRestartIfNeeded(project).thenAccept { agent ->
                 agent.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
               }
               CodyAgentService.getInstance(project).restartAgent(project)

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -31,7 +31,7 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
             }
 
             // Notify Cody Agent about config changes.
-            CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+            CodyAgentService.withAgentRestartIfNeeded(project).thenAccept { agent ->
               if (ConfigUtil.isCodyEnabled()) {
                 agent.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
               }

--- a/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
@@ -8,16 +8,14 @@ import java.util.concurrent.CompletableFuture
 
 object RemoteRepoUtils {
   fun getRepository(project: Project, codebaseName: String): CompletableFuture<Repo?> {
-    val result = CompletableFuture<List<Repo>>()
-    CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+    return CodyAgentService.withAgent(project).thenCompose { agent ->
       try {
         agent.server.getRepoIds(GetRepoIdsParam(listOf(codebaseName), 1)).thenApply {
-          result.complete(it?.repos)
+          it?.repos?.firstOrNull()
         }
       } catch (e: Exception) {
-        result.complete(null)
+        null
       }
     }
-    return result.thenApply { it?.firstOrNull() }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/ReindexButton.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/ReindexButton.kt
@@ -20,7 +20,7 @@ class ReindexButton(private val project: Project) :
   override fun isEnabled() = !isReindexingInProgress.get()
 
   override fun actionPerformed(p0: AnActionEvent) {
-    CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+    CodyAgentService.withAgentRestartIfNeeded(project).thenAccept { agent ->
       ProgressManager.getInstance()
           .run(
               object :

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
@@ -36,7 +36,7 @@ class EndOfTrialNotificationScheduler private constructor(val project: Project) 
             return@scheduleAtFixedRate
           }
 
-          CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+          CodyAgentService.withAgentRestartIfNeeded(project).thenAccept { agent ->
             val currentUserCodySubscription =
                 agent.server
                     .getCurrentUserCodySubscription()
@@ -45,7 +45,7 @@ class EndOfTrialNotificationScheduler private constructor(val project: Project) 
 
             if (currentUserCodySubscription == null) {
               logger.debug("currentUserCodySubscription is null")
-              return@applyAgentOnBackgroundThread
+              return@thenAccept
             }
 
             val codyProTrialEnded =

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -81,14 +81,12 @@ private constructor(title: String, content: String, shouldShowUpgradeOption: Boo
     fun isCodyProJetbrains(project: Project): CompletableFuture<Boolean> {
       val activeAccountType = CodyAuthenticationManager.instance.getActiveAccount(project)
       if (activeAccountType != null && activeAccountType.isDotcomAccount()) {
-        return CodyAgentService.getAgent(project)
-            .thenCompose { agent ->
-              agent.server.evaluateFeatureFlag(GetFeatureFlag.CodyProJetBrains)
-            }
-            .thenApply { it == true }
+        return CodyAgentService.withAgent(project).thenCompose { agent ->
+          agent.server.evaluateFeatureFlag(GetFeatureFlag.CodyProJetBrains).thenApply { it == true }
+        }
+      } else {
+        return CompletableFuture.completedFuture(false)
       }
-
-      return CompletableFuture.completedFuture(false)
     }
 
     var isFirstRLEOnAutomaticAutocompletionsShown: Boolean = false


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/439

##
Changes
* Removed agent recovery loop, recovery is now on demand
* Added a bit of defensive code in case of unexpected exceptions
* Added few timeouts in places where we shouldn't wait forever
* Improved robustness of the shutdown
* Added additional safeguard for old agent binary file deletion

## Test plan
I added Thread that was destroying agent process in a fixed time after startup.
I tested durations from 100ms to 10s.
Crashes after 200ms (which simulated complete agent failure) were not spamming the logs with too much info, and were not leaving trash on the disk.
Delay around 4-5s was enough for the chat to recover and give really short answer. It was able to recover infinite amount of times, which means we could survive even repeated crashes or hangs of the agent (if that would ever be the case).