### PR TITLE
Fix: Initialize Chat History tree on EDT

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBTabbedPane
 import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.intellij.util.ui.UIUtil
 import com.jetbrains.rd.util.AtomicReference
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.chat.AgentChatSession
@@ -183,9 +184,11 @@ class CodyToolWindowContent(private val project: Project) {
         project: Project,
         myAction: CodyToolWindowContent.() -> Unit
     ) {
-      if (!project.isDisposed) {
-        val codyToolWindowContent = project.getService(CodyToolWindowContent::class.java)
-        codyToolWindowContent.myAction()
+      UIUtil.invokeLaterIfNeeded {
+        if (!project.isDisposed) {
+          val codyToolWindowContent = project.getService(CodyToolWindowContent::class.java)
+          codyToolWindowContent.myAction()
+        }
       }
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -46,9 +46,7 @@ class CodyToolWindowContent(private val project: Project) {
 
   private val commandsPanel =
       CommandsTabPanel(project) { commandId: CommandId ->
-        ApplicationManager.getApplication().invokeLater {
-          switchToChatSession(AgentChatSession.createFromCommand(project, commandId))
-        }
+        switchToChatSession(AgentChatSession.createFromCommand(project, commandId))
       }
 
   private val myAccountPanel = MyAccountTabPanel()
@@ -69,13 +67,11 @@ class CodyToolWindowContent(private val project: Project) {
 
   fun removeAllChatSessions() {
     AgentChatSessionService.getInstance(project).removeAllSessions()
-    ApplicationManager.getApplication().invokeLater {
-      switchToChatSession(AgentChatSession.createNew(project))
-    }
+    switchToChatSession(AgentChatSession.createNew(project))
   }
 
   fun switchToChatSession(chatSession: AgentChatSession, showChatWindow: Boolean = true) {
-    ApplicationManager.getApplication().invokeLater {
+    UIUtil.invokeLaterIfNeeded {
       currentChatSession.getAndSet(chatSession)
       chatContainerPanel.removeAll()
       chatContainerPanel.add(chatSession.getPanel())

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -57,7 +57,6 @@ class CodyToolWindowContent(private val project: Project) {
     tabbedPane.insertSimpleTab("Chat", chatContainerPanel, CHAT_TAB_INDEX)
     tabbedPane.insertSimpleTab("Chat History", historyTree, HISTORY_TAB_INDEX)
     tabbedPane.insertSimpleTab("Commands", commandsPanel, COMMANDS_TAB_INDEX)
-    tabbedPane.insertSimpleTab("My Account", myAccountPanel, MY_ACCOUNT_TAB_INDEX)
 
     allContentPanel.add(tabbedPane, MAIN_PANEL, CHAT_PANEL_INDEX)
     allContentPanel.add(signInWithSourcegraphPanel, SIGN_IN_PANEL, SIGN_IN_PANEL_INDEX)

--- a/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/SelectOneOfTheAccountsAsActive.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.auth
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.config.CodyAuthenticationManager
@@ -14,9 +13,7 @@ class SelectOneOfTheAccountsAsActive : Activity {
       val newActiveAccount =
           CodyAuthenticationManager.instance.getAccounts().getFirstAccountOrNull()
       CodyAuthenticationManager.instance.setActiveAccount(project, newActiveAccount)
-      ApplicationManager.getApplication().invokeLater {
-        CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) { refreshPanelsVisibility() }
-      }
+      CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) { refreshPanelsVisibility() }
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -20,10 +20,10 @@ import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.UpgradeToCodyProNotification.Companion.isCodyProJetbrains
 import com.sourcegraph.telemetry.GraphQlLogger
-import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
+import org.slf4j.LoggerFactory
 
 class AgentChatSession
 private constructor(

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.chat.actions
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
@@ -17,9 +16,7 @@ abstract class BaseCommandAction : BaseChatAction() {
     FileEditorManager.getInstance(project).selectedTextEditor?.let {
       CodyEditorFactoryListener.Util.informAgentAboutEditorChange(it, hasFileChanged = false) {
         CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
-          ApplicationManager.getApplication().invokeLater {
-            switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
-          }
+          switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
         }
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -61,7 +61,7 @@ class ChatPanel(project: Project, chatSession: ChatSession) :
   }
 
   fun addModelDropdown(project: Project, sessionId: String, selectedModel: ChatModel?) {
-    CodyAgentService.applyAgentOnBackgroundThread(project) { agent ->
+    CodyAgentService.withAgent(project).thenApply { agent ->
       val activeAccountType = CodyAuthenticationManager.instance.getActiveAccount(project)
       // Display available model for Enterprise user without possibility to change
       if (activeAccountType != null && !activeAccountType.isDotcomAccount()) {

--- a/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
@@ -1,7 +1,6 @@
 package com.sourcegraph.cody.commands.ui
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBPanelWithEmptyText
@@ -27,7 +26,7 @@ class CommandsTabPanel(
   private fun executeCommandWithContext(commandId: CommandId) {
     FileEditorManager.getInstance(project).selectedTextEditor?.let {
       CodyEditorFactoryListener.Util.informAgentAboutEditorChange(it, hasFileChanged = false) {
-        ApplicationManager.getApplication().invokeLater { executeCommand(commandId) }
+        executeCommand(commandId)
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryTree.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryTree.kt
@@ -4,6 +4,7 @@ import com.intellij.icons.AllIcons
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.SimpleToolWindowPanel
 import com.intellij.ui.PopupHandler
@@ -39,16 +40,7 @@ class HistoryTree(
   private val root
     get() = model.root as RootNode
 
-  private val tree =
-      SimpleTree(model).apply {
-        isRootVisible = false
-        cellRenderer = HistoryTreeNodeRenderer()
-        selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
-        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), ENTER_MAP_KEY)
-        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), DELETE_MAP_KEY)
-        actionMap.put(ENTER_MAP_KEY, ActionWrapper(::selectLeaf))
-        actionMap.put(DELETE_MAP_KEY, ActionWrapper(::removeLeaf))
-      }
+  private lateinit var tree: SimpleTree
 
   init {
     val group = DefaultActionGroup()
@@ -68,10 +60,21 @@ class HistoryTree(
             AllIcons.Actions.GC,
             isEnabled = { true },
             ::removeAllLeafs))
-
-    PopupHandler.installPopupMenu(tree, group, "ChatActionsPopup")
-    EditSourceOnDoubleClickHandler.install(tree, ::selectLeaf)
-    setContent(ScrollPaneFactory.createScrollPane(tree))
+    ApplicationManager.getApplication().invokeLater {
+      tree =
+          SimpleTree(model).apply {
+            isRootVisible = false
+            cellRenderer = HistoryTreeNodeRenderer()
+            selectionModel.selectionMode = TreeSelectionModel.SINGLE_TREE_SELECTION
+            inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), ENTER_MAP_KEY)
+            inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0), DELETE_MAP_KEY)
+            actionMap.put(ENTER_MAP_KEY, ActionWrapper(::selectLeaf))
+            actionMap.put(DELETE_MAP_KEY, ActionWrapper(::removeLeaf))
+          }
+      PopupHandler.installPopupMenu(tree, group, "ChatActionsPopup")
+      EditSourceOnDoubleClickHandler.install(tree, ::selectLeaf)
+      setContent(ScrollPaneFactory.createScrollPane(tree))
+    }
     HistoryService.getInstance(project).listenOnUpdate(::updatePresentation)
   }
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -30,8 +30,8 @@ status-widget.warning.upgrade=\
 status-widget.warning.explain=The allowed number of request per day is limited at the moment to ensure the service stays functional.
 chat.rate-limit-error.upgrade=\
   <html>\
-    <b>You''ve used up your chat and commands for the month:</b> \
-    You''ve used all chat messages and commands for the month. \
+    <b>You've used up your chat and commands for the month:</b> \
+    You've used all chat messages and commands for the month. \
     Upgrade to Cody Pro for unlimited autocompletes, chats, and commands. \
     <a href=\"https://sourcegraph.com/cody/subscription\">Upgrade</a> \
     or <a href=\"https://sourcegraph.com/cody/subscription\">learn more</a>.<br><br>\
@@ -68,7 +68,6 @@ UpgradeToCodyProNotification.content.upgrade=\
     (Already upgraded to Pro? Restart your IDE for changes to take effect)\
   </html>
 UpgradeToCodyProNotification.content.explain=To ensure that Cody can stay operational for all Cody users, please come back tomorrow for more chats, commands, and autocompletes.
-tab.subscription.already-pro=(Already upgraded to Pro? Restart your IDE for changes to take effect)
 context-panel.button.remove-remote-repo=Remove Remote Repository
 context-panel.button.add-remote-repo=Add Remote Repository
 context-panel.button.reindex=Reindex Local Project


### PR DESCRIPTION
Fixes:

```
Access is allowed from Event Dispatch Thread (EDT) only

com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Current thread: Thread[pool-5-thread-1,5,main] 2019340008 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 1891108169
	at com.intellij.openapi.application.impl.ApplicationImpl.throwThreadAccessException(ApplicationImpl.java:1050)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertIsDispatchThread(ApplicationImpl.java:1037)
	at com.intellij.ui.SpeedSearchBase.isPopupActive(SpeedSearchBase.java:181)
	at com.intellij.ui.speedSearch.SpeedSearchSupply.getSupply(SpeedSearchSupply.java:53)
	at com.intellij.ui.speedSearch.SpeedSearchSupply.getSupply(SpeedSearchSupply.java:42)
	at com.intellij.ui.speedSearch.SpeedSearchUtil.applySpeedSearchHighlightingFiltered(SpeedSearchUtil.java:185)
	at com.intellij.ui.ColoredTreeCellRenderer.rendererComponentInner(ColoredTreeCellRenderer.java:123)
	at com.intellij.ui.ColoredTreeCellRenderer.getTreeCellRendererComponent(ColoredTreeCellRenderer.java:52)
	at com.intellij.ui.tree.ui.DefaultTreeUI.getRenderer(DefaultTreeUI.java:187)
	at com.intellij.ui.tree.ui.DefaultTreeUI$2.getNodeDimensions(DefaultTreeUI.java:561)
	at java.desktop/javax.swing.tree.AbstractLayoutCache.getNodeDimensions(AbstractLayoutCache.java:497)
	at java.desktop/javax.swing.tree.VariableHeightLayoutCache$TreeStateNode.updatePreferredSize(VariableHeightLayoutCache.java:1344)
	at java.desktop/javax.swing.tree.VariableHeightLayoutCache.rebuild(VariableHeightLayoutCache.java:723)
	at java.desktop/javax.swing.tree.VariableHeightLayoutCache.setModel(VariableHeightLayoutCache.java:111)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI.setModel(BasicTreeUI.java:506)
	at com.intellij.ui.tree.ui.DefaultTreeUI.setModel(DefaultTreeUI.java:532)
	at java.desktop/javax.swing.plaf.basic.BasicTreeUI$Handler.propertyChange(BasicTreeUI.java:3903)
	at com.intellij.ui.tree.ui.DefaultTreeUI$5.propertyChange(DefaultTreeUI.java:671)
	at java.desktop/java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:343)
	at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:335)
	at java.desktop/java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:268)
	at java.desktop/java.awt.Component.firePropertyChange(Component.java:8758)
	at java.desktop/javax.swing.JTree.setModel(JTree.java:947)
	at com.intellij.ui.treeStructure.SimpleTree.<init>(SimpleTree.java:86)
	at com.sourcegraph.cody.history.HistoryTree.<init>(HistoryTree.kt:43)
	at com.sourcegraph.cody.CodyToolWindowContent.<init>(CodyToolWindowContent.kt:35)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:1007)
	at com.intellij.serviceContainer.ComponentManagerImpl.createLightService(ComponentManagerImpl.kt:970)
	at com.intellij.serviceContainer.ComponentManagerImpl.getOrCreateLightService(ComponentManagerImpl.kt:774)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:726)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:670)
	at com.sourcegraph.cody.CodyToolWindowContent$Companion.executeOnInstanceIfNotDisposed(CodyToolWindowContent.kt:183)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager$triggerAutocompleteAsync$1$2$1.invoke(CodyAutocompleteManager.kt:240)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager$triggerAutocompleteAsync$1$2$1.invoke(CodyAutocompleteManager.kt:231)
	at com.sourcegraph.cody.autocomplete.CodyAutocompleteManager$sam$java_util_function_BiFunction$0.apply(CodyAutocompleteManager.kt)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2147)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.handleResponse(RemoteEndpoint.java:212)
	at org.eclipse.lsp4j.jsonrpc.RemoteEndpoint.consume(RemoteEndpoint.java:193)
	at org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.consume(TracingMessageConsumer.java:114)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.handleMessage(StreamMessageProducer.java:194)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:94)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```