### PR TITLE
Fix restoring chat session with custom llm

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -52,7 +52,7 @@ private constructor(
     }
   }
 
-  fun restoreAgentSession(agent: CodyAgent, model: String? = null) {
+  fun restoreAgentSession(agent: CodyAgent, model: ChatModel? = null) {
     val messagesToReload =
         messages
             .toList()
@@ -61,8 +61,6 @@ private constructor(
               if (acc.lastOrNull()?.speaker == msg.speaker) acc else acc.plus(msg)
             }
 
-    val modelFromState = model?.let { ChatModel.fromDisplayNameNullable(it) }
-
     val selectedItem =
         chatPanel.modelDropdown.selectedItem?.let {
           ChatModel.fromDisplayNameNullable(it.toString())
@@ -70,7 +68,7 @@ private constructor(
     val restoreParams =
         ChatRestoreParams(
             //        TODO: Change in the agent handling chat restore with null model
-            modelFromState?.agentName ?: selectedItem?.agentName ?: DEFAULT_MODEL.agentName,
+            model?.agentName ?: selectedItem?.agentName ?: DEFAULT_MODEL.agentName,
             messagesToReload,
             UUID.randomUUID().toString())
     val newSessionId = agent.server.chatRestore(restoreParams)
@@ -355,7 +353,7 @@ private constructor(
       }
 
       CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
-        chatSession.restoreAgentSession(agent)
+        chatSession.restoreAgentSession(agent, selectedModel)
       }
 
       AgentChatSessionService.getInstance(project).addSession(chatSession)


### PR DESCRIPTION
## Test plan
1. Create chat session with non-default llm
2. Write a message
3. Change account and then go back to initial account
4. Open pervious chat from the history
5. Ask in chat what model is used

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
