### PR TITLE
Bump Cody commit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -199,7 +199,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "f6473571f0031e77f4e06ecd06fd7fae9a5330b9"
+  val codyCommit = "4d26d73664ad92945196c7f0ef3203490464149e"
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")


### PR DESCRIPTION
Brings in this diff
```diff
diff --git a/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.test.ts b/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.test.ts
new file mode 100644
index 00000000..d835def6
--- /dev/null
+++ b/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.test.ts
@@ -0,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { matchesGlobPatterns } from './matchesGlobPatterns'
+
+describe('matchesGlobPatterns', () => {
+    it('should return true when value matches include globs', () => {
+        const includeGlobs = ['*.ts']
+        const excludeGlobs = ['*.test.ts']
+        const value = 'index.ts'
+
+        const result = matchesGlobPatterns(includeGlobs, excludeGlobs, value)
+
+        expect(result).toBe(true)
+    })
+
+    it('should return false when value matches exclude globs', () => {
+        const includeGlobs = ['*.ts']
+        const excludeGlobs = ['index.*']
+        const value = 'index.ts'
+
+        const result = matchesGlobPatterns(includeGlobs, excludeGlobs, value)
+
+        expect(result).toBe(false)
+    })
+
+    it('should work on complex exclusions', () => {
+        const includeGlobs: string[] = []
+        const excludeGlobs = [
+            '**/{*.env,.git/,.class,out/,dist/,build/,snap,node_modules/,__pycache__/,bin/,.bin/}**',
+        ]
+        const cases: {
+            value: string
+            expected: boolean
+        }[] = [
+            { value: 'index.ts', expected: true },
+            { value: '.git/config', expected: false },
+            { value: '.git/index', expected: false },
+            { value: 'node_modules/.bin/foo', expected: false },
+            { value: 'node_modules/foo', expected: false },
+            { value: 'foo/bar/baz/node_modules/.bin/foo', expected: false },
+            {
+                value: 'node_modules/.pnpm/@grpc+proto-loader@0.7.8/node_modules/@grpc/proto-loader/LICENSE',
+                expected: false,
+            },
+            { value: 'node_modules/.pnpm', expected: false },
+        ]
+
+        for (const { value, expected } of cases) {
+            const result = matchesGlobPatterns(includeGlobs, excludeGlobs, value)
+            expect(result).toBe(expected)
+        }
+    })
+})
diff --git a/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.ts b/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.ts
index 6660b466..6ef92703 100644
--- a/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.ts
+++ b/agent/src/cli/evaluate-autocomplete/matchesGlobPatterns.ts
@@ -13,6 +13,8 @@ export function matchesGlobPatterns(
         return false
     }
 
-    const matchingExcludePatttern = excludeGlobs.find(excludePattern => minimatch(value, excludePattern))
+    const matchingExcludePatttern = excludeGlobs.find(excludePattern =>
+        minimatch(value, excludePattern, { dot: true })
+    )
     return !matchingExcludePatttern
 }
diff --git a/agent/src/index.ts b/agent/src/index.ts
index 12c11393..147f11db 100644
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -10,6 +10,16 @@ console.log = console.error
 // stdout/stdin to communicate with the agent client.
 const rootCommand: Command = require('./cli/root').rootCommand
 
+process.on('uncaughtException', e => {
+    // By default, an uncaught exception will take down the entire process.
+    // Instead of taking down the process, we just report it to stderr and move
+    // on.  In almost all cases, an uncaught exception is an innocent error that
+    // does not have to take down the process. For example, if a telemetry
+    // request fails, then it's totally fine to just report it here with a stack
+    // trace so we can look into it and fix it.
+    console.error('Uncaught exception:', e)
+})
+
 const args = process.argv.slice(2)
 const { operands } = rootCommand.parseOptions(args)
 if (operands.length === 0) {
diff --git a/agent/src/vscode-shim.ts b/agent/src/vscode-shim.ts
index e69e93fe..c066e246 100644
--- a/agent/src/vscode-shim.ts
+++ b/agent/src/vscode-shim.ts
@@ -212,6 +212,9 @@ const _workspace: typeof vscode.workspace = {
                 const uri = Uri.file(path.join(dir.fsPath, name))
                 const relativePath = path.relative(workspaceRoot.fsPath, uri.fsPath)
                 if (fileType.valueOf() === FileType.Directory.valueOf()) {
+                    if (!matchesGlobPatterns([], exclude ? [exclude] : [], relativePath)) {
+                        continue
+                    }
                     await loop(workspaceRoot, uri)
                 } else if (fileType.valueOf() === FileType.File.valueOf()) {
                     if (
diff --git a/vscode/src/editor/utils/editor-context.ts b/vscode/src/editor/utils/editor-context.ts
index 36f232d3..3705ada3 100644
--- a/vscode/src/editor/utils/editor-context.ts
+++ b/vscode/src/editor/utils/editor-context.ts
@@ -24,7 +24,8 @@ const findWorkspaceFiles = async (
     // TODO(toolmantim): Add support for the search.exclude option, e.g.
     // Object.keys(vscode.workspace.getConfiguration().get('search.exclude',
     // {}))
-    const fileExcludesPattern = '**/{*.env,.git,out/,dist/,snap,node_modules,__pycache__}**'
+    const fileExcludesPattern =
+        '**/{*.env,.git/,.class,out/,dist/,build/,snap,node_modules/,__pycache__/}**'
     // TODO(toolmantim): Check this performs with remote workspaces (do we need a UI spinner etc?)
     return vscode.workspace.findFiles('', fileExcludesPattern, undefined, cancellationToken)
 }

```


## Test plan


<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
