### PR TITLE
Fix next-release.sh script for the latest releases

### DIFF
--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -32,7 +32,7 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
-LAST_MAJOR_MINOR_ZERO_RELEASE=$(gh release list --repo sourcegraph/sourcegraph --limit 20 --exclude-drafts --exclude-pre-releases | awk '$3 ~ /v[0-9]+\.[0-9]+\.0$/ { print $3, $4; exit }')
+LAST_MAJOR_MINOR_ZERO_RELEASE=$(gh release list --repo sourcegraph/sourcegraph --limit 20 --exclude-drafts --exclude-pre-releases | sed 's/Latest//' | awk '$3 ~ /v[0-9]+\.[0-9]+\.0$/ { print $3, $4; exit }')
 MAJOR_MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f1,2)
 LAST_RELEASE_TIMESTAMP=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $2 }')
 


### PR DESCRIPTION
```
gh release list --repo sourcegraph/sourcegraph --limit 20 --exclude-drafts --exclude-pre-releases
```

returns something like

```
TITLE                                TYPE    TAG NAME                        PUBLISHED
Sourcegraph 5.3.0                    Latest  v5.3.0                          about 3 hours ago
Sourcegraph 5.2.7                            v5.2.7                          about 19 days ago
Sourcegraph 5.2.6                            v5.2.6                          about 1 month ago
Sourcegraph 5.2.5                            v5.2.5                          about 2 months ago
Sourcegraph 5.2.4                            v5.2.4                          about 2 months ago
Sourcegraph 5.2.3                            v5.2.3                          about 2 months ago
Sourcegraph 5.2.2                            v5.2.2                          about 3 months ago
Sourcegraph 5.2.1                            v5.2.1                          about 3 months ago
Sourcegraph 5.2.0                            v5.2.0                          about 4 months ago
Cody App v2023.9.22+1398.91e4161d32          app-v2023.9.22+1398.91e4161d32  about 4 months ago
...
```

Note it contains an additional value in the type column - `Latest`. That value breaks the following matching to `/v[0-9]+\.[0-9]+\.0$/` in 

```
awk '$3 ~ /v[0-9]+\.[0-9]+\.0$/ { print $3, $4; exit }'
```

(`$3` takes the third value in the row which is `Latest` instead of `v5.3.0`)

## Test plan
1. play with the script (it should derive the version properly when 
