### PR TITLE
Add additional safeguard against project being disposed

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -41,8 +41,10 @@ class CodyAgentService(project: Project) : Disposable {
         }
       }
 
-      FileEditorManager.getInstance(project).openFiles.forEach { file ->
-        CodyFileEditorListener.fileOpened(project, agent, file)
+      if (!project.isDisposed) {
+        FileEditorManager.getInstance(project).openFiles.forEach { file ->
+          CodyFileEditorListener.fileOpened(project, agent, file)
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/632

## Changes
We have to add addional safeguard against actions which can be executed when project is already disposed or not ready.
This particular problem can happen if user extremely quickly close and reopen the project.

## Test plan
Manual verification, but it's not easy to reproduce the issue.