### PR TITLE
Add `agent: true` to logs

### DIFF
--- a/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -1,6 +1,8 @@
 package com.sourcegraph.telemetry;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.intellij.json.psi.JsonValue;
 import com.intellij.openapi.project.Project;
 import com.sourcegraph.cody.agent.CodyAgentService;
 import com.sourcegraph.cody.agent.protocol.Event;
@@ -59,6 +61,7 @@ public class GraphQlLogger {
     extensionDetails.addProperty("ideExtensionType", "Cody");
     extensionDetails.addProperty("version", ConfigUtil.getPluginVersion());
     updatedEventParameters.add("extensionDetails", extensionDetails);
+    updatedEventParameters.add("agent", new JsonPrimitive(true));
     return updatedEventParameters;
   }
 


### PR DESCRIPTION
Rel to https://github.com/sourcegraph/jetbrains/issues/637.


## Test plan
1. tbd

```
[Trace - 00:17:46 PM] Sending request 'graphql/logEvent - (48)'
Params: {
  "event": "CodyJetBrainsPlugin:chat-question:executed",
  "userCookieID": "53611122-6572-417d-8156-824c713ea337",
  "url": "",
  "source": "IDEEXTENSION",
  "referrer": "JETBRAINS",
  "argument": {},
  "publicArgument": {
    "serverEndpoint": "https://sourcegraph.com/",
    "extensionDetails": {
      "ide": "JetBrains",
      "ideExtensionType": "Cody",
      "version": "6.0-localbuild"
    },
    "agent": true
  },
  "client": "JETBRAINS_CODY_EXTENSION",
  "deviceID": "53611128-6572-417d-8156-824c713ea337"
}
```
