### PR TITLE
Do not call agent to obtain repo URL

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -39,9 +39,6 @@ interface CodyAgentServer {
   @JsonRequest("graphql/getRepoIds")
   fun getRepoIds(repoName: GetRepoIdsParam): CompletableFuture<GetRepoIdsResponse>
 
-  @JsonRequest("git/codebaseName")
-  fun convertGitCloneURLToCodebaseName(cloneURL: CloneURL): CompletableFuture<String?>
-
   @JsonRequest("featureFlags/getFeatureFlag")
   fun evaluateFeatureFlag(flagName: GetFeatureFlag): CompletableFuture<Boolean?>
 

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.vcs
 
+import com.intellij.testFramework.UsefulTestCase.assertThrows
 import junit.framework.TestCase
 
 class ConvertUtilTest : TestCase() {
@@ -88,9 +89,9 @@ class ConvertUtilTest : TestCase() {
         convertGitCloneURLToCodebaseNameOrError("http://github.com/sourcegraph/sourcegraph"))
   }
 
-  //  fun `test if returns null for invalid UR`() {
-  //    assertThrows(Exception::class.java) { convertGitCloneURLToCodebaseNameOrError("invalid") }
-  //  }
+  fun `test if returns null for invalid UR`() {
+    assertThrows(Exception::class.java) { convertGitCloneURLToCodebaseNameOrError("invalid") }
+  }
 
   fun `test conversion URLs with dots in the repo name`() {
     assertEquals(

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -89,8 +89,10 @@ class ConvertUtilTest : TestCase() {
         convertGitCloneURLToCodebaseNameOrError("http://github.com/sourcegraph/sourcegraph"))
   }
 
-  fun `test if returns null for invalid UR`() {
-    assertThrows(Exception::class.java) { convertGitCloneURLToCodebaseNameOrError("invalid") }
+  private fun invalidConversion() = convertGitCloneURLToCodebaseNameOrError("invalid")
+
+  fun `test if returns null for invalid URL`() {
+    assertThrows(Exception::class.java) { invalidConversion() }
   }
 
   fun `test conversion URLs with dots in the repo name`() {

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -1,0 +1,101 @@
+package com.sourcegraph.vcs
+
+import junit.framework.TestCase
+
+class ConvertUtilTest : TestCase() {
+
+  fun `test conversion Azure DevOps UR`() {
+    assertEquals(
+        "dev.azure.com/organization/project/repository",
+        convertGitCloneURLToCodebaseNameOrError(
+            "https://dev.azure.com/organization/project/_git/repository"))
+  }
+
+  fun `test conversion GitHub SSH UR`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("git@github.com:sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion GitHub SSH URL with different user`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError(
+            "jdsbcnuqwew@github.com:sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion GitHub SSH URL with the port number`() {
+    assertEquals(
+        "gitlab-my-company.net/path/repo",
+        convertGitCloneURLToCodebaseNameOrError(
+            "ssh://git@gitlab-my-company.net:20022/path/repo.git"))
+  }
+
+  fun `test conversion GitHub SSH URL no trailing git`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("git@github.com:sourcegraph/sourcegraph"))
+  }
+
+  fun `test conversion GitHub HTTPS UR`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("https://github.com/sourcegraph/sourcegraph"))
+  }
+
+  fun `test conversion Bitbucket HTTPS UR`() {
+    assertEquals(
+        "bitbucket.org/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError(
+            "https://username@bitbucket.org/sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion Bitbucket SSH UR`() {
+    assertEquals(
+        "bitbucket.sgdev.org/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError(
+            "git@bitbucket.sgdev.org:sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion GitLab SSH UR`() {
+    assertEquals(
+        "gitlab.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("git@gitlab.com:sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion GitLab HTTPS UR`() {
+
+    assertEquals(
+        "gitlab.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("https://gitlab.com/sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion GitHub SSH URL with Git`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("git@github.com:sourcegraph/sourcegraph.git"))
+  }
+
+  fun `test conversion Eriks SSH Alias UR`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("github:sourcegraph/sourcegraph"))
+  }
+
+  fun `test conversion HTTP UR`() {
+    assertEquals(
+        "github.com/sourcegraph/sourcegraph",
+        convertGitCloneURLToCodebaseNameOrError("http://github.com/sourcegraph/sourcegraph"))
+  }
+
+  //  fun `test if returns null for invalid UR`() {
+  //    assertThrows(Exception::class.java) { convertGitCloneURLToCodebaseNameOrError("invalid") }
+  //  }
+
+  fun `test conversion URLs with dots in the repo name`() {
+    assertEquals(
+        "github.com/philipp-spiess/philippspiess.com",
+        convertGitCloneURLToCodebaseNameOrError(
+            "git@github.com:philipp-spiess/philippspiess.com.git"))
+  }
+}


### PR DESCRIPTION
## Changes

`getRemoteRepoUrl` should be local function, not depending on agent.
It's user in a few critical places, also around a IDE startup time, so relaying on agent being ready there is potentially risky.

## Test plan

Added unit-tests + manual verification of the agent startup.