### PR TITLE
Bump cody agent timeout

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -68,7 +68,7 @@ class CodyAgentService(project: Project) : Disposable {
   fun startAgent(project: Project): CompletableFuture<CodyAgent> {
     ApplicationManager.getApplication().executeOnPooledThread {
       try {
-        val agent = CodyAgent.create(project).get(15, TimeUnit.SECONDS)
+        val agent = CodyAgent.create(project).get(25, TimeUnit.SECONDS)
         if (!agent.isConnected()) {
           val msg = "Failed to connect to agent Cody agent"
           logger.error(msg)


### PR DESCRIPTION
## Changes

I noticed in some cases agent needs close to 15 sec to startup correctly, and looking on reports from users even more.
For example, on windows and big project (IJ Community) fresh startup took 12s:

```
2024-02-20 15:19:26,461 [2141596]   INFO - #com.sourcegraph.cody.agent.CodyAgent - Cody Agent shut down gracefully
2024-02-20 15:19:26,464 [2141599]   INFO - #com.sourcegraph.cody.agent.CodyAgent - extracting Cody agent binary to C:\Users\PIOTRK~1\AppData\Local\Temp\cody-agent728123588240703395.exe
2024-02-20 15:19:26,531 [2141666]   INFO - #com.sourcegraph.cody.agent.CodyAgent - starting Cody agent C:\Users\PIOTRK~1\AppData\Local\Temp\cody-agent728123588240703395.exe
2024-02-20 15:19:28,010 [2143145]   INFO - #c.i.i.s.download - Selected pre-built shared index SharedIndexResult(request='ProjectIndexRequest(url='https://index-cdn.jetbrains.com/v2/project/intellij-community', auth=null)', url='https://index-cdn.jetbrains.com/v2/data/project/intellij-community/e1c32b10ad4ea80022532175810faee2870c007d/project-linux-2e570c7cf7d03aad7bef696da8d559021a160f428119d5b6d366c40f4d6ebd3c.ijx.gz', weakHash=3183f394aec4, sha256='2e570c7cf7d03aad7bef696da8d559021a160f428119d5b6d366c40f4d6ebd3c') from https://index-cdn.jetbrains.com/v2/project/intellij-community/vcs/e1c32b10ad4ea80022532175810faee2870c007d for ProjectIndexRequest(url='https://index-cdn.jetbrains.com/v2/project/intellij-community', auth=null)
2024-02-20 15:19:32,916 [2148051]   INFO - #c.i.u.g.s.GistStorageImpl - Cleaning old huge-gists dirs from [C:\Users\Piotr Kukielka\AppData\Local\JetBrains\IntelliJIdea2023.3\caches\huge-gists] ...
2024-02-20 15:19:32,916 [2148051]   INFO - #c.i.u.g.s.GistStorageImpl - Cleaning old huge-gists dirs finished
2024-02-20 15:19:34,329 [2149464]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ VSCodeSecretStorage:getAccessToken: failed 
2024-02-20 15:19:34,330 [2149465]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.extension/installed: {"parameters":{"version":0,"metadata":[{"key":"contextSelection","value":2},{"key":"guardrails","value":0}]},"timestamp":"2024-02-20T14:19:34.288Z"}
2024-02-20 15:19:34,330 [2149465]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ AuthProvider:init:lastEndpoint: https://sourcegraph.com/
2024-02-20 15:19:35,205 [2150340]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ GraphQLTelemetryExporter: evaluated export mode: 5.2.5+
2024-02-20 15:19:35,633 [2150768]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ ChatManager:constructor: init no local embeddings
2024-02-20 15:19:35,634 [2150769]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ ChatPanelsManager:constructor: init
2024-02-20 15:19:35,635 [2150770]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ CommandsController:disposeWatchers: watchers disposed
2024-02-20 15:19:35,636 [2150771]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ CommandsController:fileWatcherInit: watchers created
2024-02-20 15:19:35,636 [2150771]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - window.showErrorMessage: Continue setting up Cody
2024-02-20 15:19:35,637 [2150772]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ VSCodeSecretStorage:getAccessToken: failed 
2024-02-20 15:19:35,638 [2150773]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ CodyCompletionProvider:notSignedIn: You are not signed in.
2024-02-20 15:19:35,682 [2150817]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ symf: using downloaded symf "c:\Users\Piotr Kukielka\AppData\Local\Cody-nodejs\Data\symf\symf-v0.0.6-x86_64-windows"
2024-02-20 15:19:36,818 [2151953]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ symf: creating index file:///c%3A/Users/Piotr%20Kukielka/AppData/Local/Cody-nodejs/Data/symf/indexroot/C/work/intellij-community/
2024-02-20 15:19:37,565 [2152700]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ ContextProvider:onConfigurationChange: using codebase github.com/JetBrains/intellij-community
2024-02-20 15:19:37,566 [2152701]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ Cody:publishConfig: configForWebview 
2024-02-20 15:19:37,567 [2152702]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ ContextProvider:onConfigurationChange: using codebase github.com/JetBrains/intellij-community
2024-02-20 15:19:37,567 [2152702]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ logEvent: CodyJetBrainsPlugin:Auth:connected JetBrains {"opts":{"agent":true}}
2024-02-20 15:19:37,567 [2152702]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ telemetry-v2: recordEvent: cody.auth/connected: {"parameters":{"version":0,"metadata":[{"key":"contextSelection","value":2},{"key":"guardrails","value":0}]},"timestamp":"2024-02-20T14:19:37.545Z"}
2024-02-20 15:19:38,024 [2153159]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ CodyEngine: loading bfg
2024-02-20 15:19:38,024 [2153159]   WARN - #com.sourcegraph.cody.agent.CodyAgentClient - Cody by Sourcegraph: █ CodyCompletionProvider:initialized: fireworks/llama-code-13b
2024-02-20 15:19:38,025 [2153160]   INFO - #com.sourcegraph.cody.agent.CodyAgent - Connected to Cody agent cody-agent
```

## Test plan

No testplan needed