### PR TITLE
Recognize language of Markdown code block only once

### DIFF
--- a/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
+++ b/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
@@ -157,7 +157,7 @@ public class CodeEditorFactory {
     editor.addEditorMouseListener(editorMouseListener);
     CodeEditorPart codeEditorPart =
         new CodeEditorPart(layeredEditorPane, editor, attributionButtonController);
-    codeEditorPart.updateLanguage(language);
+    codeEditorPart.recognizeLanguage(language);
     return codeEditorPart;
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagePart.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagePart.kt
@@ -5,7 +5,6 @@ import com.intellij.lang.Language
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.ex.EditorEx
-import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.FileTypeManager
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.project.Project
@@ -30,6 +29,7 @@ class CodeEditorPart(
     val attribution: AttributionButtonController
 ) : MessagePart {
 
+  private var recognizedLanguage: Language? = null
   private val _text = AtomicReference("")
   var text: String
     set(value) {
@@ -38,20 +38,23 @@ class CodeEditorPart(
     get() = _text.get()
 
   fun updateCode(project: Project, code: String, language: String?) {
-    updateLanguage(language)
+    recognizeLanguage(language)
     updateText(project, code)
   }
 
-  fun updateLanguage(language: String?) {
-    val fileType: FileType =
-        Language.getRegisteredLanguages()
-            .firstOrNull { it.displayName.equals(language, ignoreCase = true) }
-            ?.let { FileTypeManager.getInstance().findFileTypeByLanguage(it) }
-            ?: PlainTextFileType.INSTANCE
-    val editorHighlighter =
-        HighlighterFactory.createHighlighter(
-            fileType, EditorColorsManager.getInstance().schemeForCurrentUITheme, null)
-    editor.highlighter = editorHighlighter
+  fun recognizeLanguage(languageName: String?) {
+    if (recognizedLanguage != null) return
+    val language = Language.getRegisteredLanguages()
+          .filter { it != Language.ANY }
+          .firstOrNull { it.displayName.equals(languageName, ignoreCase = true) }
+    if (language != null) {
+      val fileType = FileTypeManager.getInstance().findFileTypeByLanguage(language)
+          ?: PlainTextFileType.INSTANCE
+      val settings = EditorColorsManager.getInstance().schemeForCurrentUITheme
+      val editorHighlighter = HighlighterFactory.createHighlighter(fileType, settings, null)
+      editor.highlighter = editorHighlighter
+      recognizedLanguage = language
+    }
   }
 
   private fun updateText(project: Project, text: String) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagePart.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagePart.kt
@@ -44,12 +44,14 @@ class CodeEditorPart(
 
   fun recognizeLanguage(languageName: String?) {
     if (recognizedLanguage != null) return
-    val language = Language.getRegisteredLanguages()
-          .filter { it != Language.ANY }
-          .firstOrNull { it.displayName.equals(languageName, ignoreCase = true) }
+    val language =
+        Language.getRegisteredLanguages()
+            .filter { it != Language.ANY }
+            .firstOrNull { it.displayName.equals(languageName, ignoreCase = true) }
     if (language != null) {
-      val fileType = FileTypeManager.getInstance().findFileTypeByLanguage(language)
-          ?: PlainTextFileType.INSTANCE
+      val fileType =
+          FileTypeManager.getInstance().findFileTypeByLanguage(language)
+              ?: PlainTextFileType.INSTANCE
       val settings = EditorColorsManager.getInstance().schemeForCurrentUITheme
       val editorHighlighter = HighlighterFactory.createHighlighter(fileType, settings, null)
       editor.highlighter = editorHighlighter


### PR DESCRIPTION
Related to #509

This fix improves performance of the chat messages that contains code (when response is generated).

## Test Plan

1. Ask Cody to generate a response with source code OR use Generate Test. Language must be supported by the IDE.
2. The language syntax/keywords in response is instantly and properly highlighted.
