### PR TITLE
Validate adding the same repo multiple times

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -224,7 +224,8 @@ class EnhancedContextPanel(private val project: Project, private val chatSession
       toolbarDecorator.setAddActionName(
           CodyBundle.getString("context-panel.button.add-remote-repo"))
       toolbarDecorator.setAddAction {
-        AddRepositoryDialog(project) { repoUrl -> addRemoteRepository(repoUrl) }.show()
+        AddRepositoryDialog(project, remoteContextNode) { repoUrl -> addRemoteRepository(repoUrl) }
+            .show()
         expandAllNodes()
       }
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -83,6 +83,7 @@ context-panel.add-repo-dialog.title=Add Remote Repo
 context-panel.add-repo-dialog.error-empty-url=Remote repository URL cannot be empty
 context-panel.add-repo-dialog.error-invalid-url=Remote repository URL must be valid
 context-panel.add-repo-dialog.error-no-repo=Remote repository not found on the server
+context-panel.add-repo-dialog.error-repo-already-added=Remote repository has been added already
 context-panel.add-repo-dialog.url-input-label=<html><b>Repo URL</b><html>
 context-panel.add-repo-dialog.url-input-help=<html><span>Example: <b>github.com/sourcegraph/cody</b><br>Only repos indexed on customer instance are valid.<br><br>Contact your Sourcegraph admin to add missing repo.<span><html>
 messages-panel.welcome-text=Hello! I'm Cody. I can write code and answer questions for you. See [Cody documentation](https://sourcegraph.com/docs/cody) for help and tips.


### PR DESCRIPTION
Fixes #659.

## Test plan
1. Open add remote dialog
2. write remote that is already added


<img width="1407" alt="image" src="https://github.com/sourcegraph/jetbrains/assets/19799111/5960209e-4487-484e-897b-c0fc1ec29454">
