### PR TITLE
Remove excessive memory allocations during Chat History sorting

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -33,10 +33,8 @@ class ChatState : BaseState() {
   }
 
   fun getUpdatedTimeAt(): LocalDateTime {
-    if (updatedAt == null)
-      return LocalDateTime.now()
-    if (updatedAtDate == null)
-      updatedAtDate = LocalDateTime.parse(updatedAt, DATE_FORMAT)
+    if (updatedAt == null) return LocalDateTime.now()
+    if (updatedAtDate == null) updatedAtDate = LocalDateTime.parse(updatedAt, DATE_FORMAT)
     return updatedAtDate!!
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -35,7 +35,7 @@ class ChatState : BaseState() {
   fun getUpdatedTimeAt(): LocalDateTime {
     if (updatedAt == null) return LocalDateTime.now()
     if (updatedAtDate == null) updatedAtDate = LocalDateTime.parse(updatedAt, DATE_FORMAT)
-    return updatedAtDate!!
+    return updatedAtDate ?: LocalDateTime.now()
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -23,15 +23,21 @@ class ChatState : BaseState() {
   @get:OptionTag(tag = "enhancedContext", nameAttribute = "")
   var enhancedContext: EnhancedContextState? by property()
 
+  private var updatedAtDate: LocalDateTime? = null
+
   fun title(): String? = messages.firstOrNull()?.text?.take(48)
 
   fun setUpdatedTimeAt(date: LocalDateTime) {
+    updatedAtDate = date
     updatedAt = date.format(DATE_FORMAT)
   }
 
   fun getUpdatedTimeAt(): LocalDateTime {
-    if (updatedAt == null) return LocalDateTime.now()
-    return LocalDateTime.parse(updatedAt, DATE_FORMAT)
+    if (updatedAt == null)
+      return LocalDateTime.now()
+    if (updatedAtDate == null)
+      updatedAtDate = LocalDateTime.parse(updatedAt, DATE_FORMAT)
+    return updatedAtDate!!
   }
 
   companion object {


### PR DESCRIPTION
Related to #509

This simple fix introduces cache for ChatState.updatedAt date. The getUpdatedTimeAt getter was causing memory allocations because each call invoked the LocalDateTime.parse method. Value updatedAt is stored internally as string. This date is used as a basis for sorting, so it's intensively used during the Chat History tree update (in multiple places).

## Test Plan

1. Start new conversation -> date in is properly initialized (today's date) and saved to XML
2. Continue old conversation -> date is properly updated, moved to top of the list, and saved to XML