### PR TITLE
Update tokens incrementally in Chat window

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagesPanel.kt
@@ -28,7 +28,7 @@ class MessagesPanel(private val project: Project, private val chatSession: ChatS
     if (messageToUpdate != null) {
       val singleMessagePanel = messageToUpdate.getComponent(0) as? SingleMessagePanel
       val contextFilesPanel = messageToUpdate.getComponent(1) as? ContextFilesPanel
-      singleMessagePanel?.updateContentWith(message)
+      singleMessagePanel?.updateContentWith(message.actualMessage())
       contextFilesPanel?.updateContentWith(message.contextFiles)
     } else {
       addChatMessageAsComponent(message)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
@@ -36,7 +36,7 @@ class SingleMessagePanel(
   }
 
   fun updateContentWith(text: String) {
-    val trimmedText = text.removeBlockSuffixAndTrim()
+    val trimmedText = text.trimEnd { c -> c == '`' || c.isWhitespace() }
     val isGrowing =
         trimmedText.contains(lastTrimmedText) && trimmedText.length > lastTrimmedText.length
     if (isGrowing) {
@@ -52,14 +52,6 @@ class SingleMessagePanel(
         addOrUpdateText(renderedHtml)
       }
     }
-  }
-
-  private fun String.removeBlockSuffixAndTrim(): String {
-    var lastIndex = this.length - 1
-    while (lastIndex >= 0 && (this[lastIndex] == '`' || this[lastIndex].isWhitespace())) {
-      lastIndex--
-    }
-    return this.substring(0, lastIndex + 1)
   }
 
   fun addOrUpdateCode(code: String, language: String?) {


### PR DESCRIPTION
Related to #509
Fixes #886

This commit aims to reduce CPU usage when using the Chat window when Cody is responding.

Changes:

1. Bug #886 is fixed.
2. The chat is now updated only when the number of tokens grows. It sometimes happens that Cody responds few times with the identical text (in streaks, even 2-3 times) or responds in a different order. Such responses are now ignored, so the panel is not unnecessarily refreshed.
3. The code block visible in the chat (which is an underlying virtual editor) is now updated incrementally. Each response from Cody adds a few tokens at the end of the document instead of replace-all strategy.

## Test Plan

* Ask a question that will display a code block (e.g. "write hello world in 10 different languages").
* The chat looks clean and does not have excessive paragraphs with "``" symbols.

## Demo

Before:

![Selection_094](https://github.com/sourcegraph/jetbrains/assets/5013708/36786770-289c-4ecb-acbe-a8632114cec8)

After:

![Selection_096](https://github.com/sourcegraph/jetbrains/assets/5013708/0b4719ec-109d-4532-ba0d-5ae29a5cab06)


-----

~~WIP (it's working 80% of the time, i've added some details below)~~

~~ToDos/ToDiscuss:~~

* ~~Responses with new tokens are not always in a logical order or may be redundant (e.g., may go "backwards" or respond with identical response 2-3 times). This explains why the code is implemented this way, not otherwise, meaning a new token causes the entire UI to be overwritten. This also introduces interesting behaviour: when responses are not in logical order, tokens can disappear for a short time.~~
* ~~All the code has been written with this "feature" in mind (e.g. replace everything and don't worry about the logical order). This is root of the performance issues.~~