### PR TITLE
Add telemetry to track usage of generated code

### DIFF
--- a/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
+++ b/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
@@ -169,7 +169,7 @@ public class CodeEditorFactory {
   }
 
   @NotNull
-  private static ActionListener copyCodeListener(EditorEx editor, JButton copyButton) {
+  private ActionListener copyCodeListener(EditorEx editor, JButton copyButton) {
     return e -> {
       String text = editor.getDocument().getText();
       StringSelection stringSelection = new StringSelection(text);

--- a/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
+++ b/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.chat;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.CaretModel;
@@ -15,12 +16,14 @@ import com.intellij.openapi.editor.event.EditorMouseMotionListener;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.util.ui.JBInsets;
 import com.sourcegraph.cody.chat.ui.CodeEditorButtons;
 import com.sourcegraph.cody.chat.ui.CodeEditorPart;
 import com.sourcegraph.cody.ui.AttributionButtonController;
 import com.sourcegraph.cody.ui.TransparentButton;
+import com.sourcegraph.telemetry.GraphQlLogger;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.Toolkit;
@@ -28,6 +31,8 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.*;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Optional;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import org.jetbrains.annotations.NotNull;
@@ -41,6 +46,8 @@ public class CodeEditorFactory {
   private final @NotNull JPanel parentPanel;
   private final int rightMargin;
   public static final int spaceBetweenButtons = 5;
+
+  public static volatile String lastCopiedText = null;
 
   public CodeEditorFactory(@NotNull Project project, @NotNull JPanel parentPanel, int rightMargin) {
     this.project = project;
@@ -59,7 +66,7 @@ public class CodeEditorFactory {
 
     TransparentButton copyButton = new TransparentButton("Copy");
     copyButton.setToolTipText("Copy text");
-    copyButton.addActionListener(getSendActionListener(editor, copyButton));
+    copyButton.addActionListener(copyCodeListener(editor, copyButton));
 
     TransparentButton insertAtCursorButton = new TransparentButton("Insert at Cursor");
     insertAtCursorButton.setToolTipText("Insert text at current cursor position");
@@ -162,7 +169,7 @@ public class CodeEditorFactory {
   }
 
   @NotNull
-  private static ActionListener getSendActionListener(EditorEx editor, JButton copyButton) {
+  private static ActionListener copyCodeListener(EditorEx editor, JButton copyButton) {
     return e -> {
       String text = editor.getDocument().getText();
       StringSelection stringSelection = new StringSelection(text);
@@ -173,6 +180,17 @@ public class CodeEditorFactory {
           new Timer((int) Duration.ofSeconds(2).toMillis(), it -> copyButton.setText("Copy"));
       timer.setRepeats(false);
       timer.start();
+
+      Optional<@NotNull Project> project =
+          Arrays.stream(ProjectManager.getInstance().getOpenProjects()).findFirst();
+      if (project.isEmpty()) return;
+
+      lastCopiedText = text;
+      ApplicationManager.getApplication()
+          .executeOnPooledThread(
+              () ->
+                  GraphQlLogger.logCodeGenerationEvent(
+                      project.get(), "copyButton", "clicked", text));
     };
   }
 
@@ -199,6 +217,11 @@ public class CodeEditorFactory {
                 logger.warn("Failed to insert text at cursor", ex);
               }
             });
+
+        ApplicationManager.getApplication()
+            .executeOnPooledThread(
+                () ->
+                    GraphQlLogger.logCodeGenerationEvent(project, "insertButton", "clicked", text));
       }
     };
   }

--- a/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
+++ b/src/main/java/com/sourcegraph/telemetry/GraphQlLogger.java
@@ -35,6 +35,22 @@ public class GraphQlLogger {
     logEvent(project, createEvent(ConfigUtil.getServerPath(project), eventName, new JsonObject()));
   }
 
+  public static void logCodeGenerationEvent(
+      @NotNull Project project,
+      @NotNull String componentName,
+      @NotNull String action,
+      String generatedCode) {
+    JsonObject eventParameters = new JsonObject();
+    eventParameters.addProperty("code", generatedCode);
+    eventParameters.addProperty("lineCount", generatedCode.lines().count());
+    eventParameters.addProperty("charCount", generatedCode.length());
+    eventParameters.addProperty("eventName", componentName);
+    eventParameters.addProperty("source", "chat");
+
+    var eventName = "CodyJetBrainsPlugin:" + componentName + ":" + action;
+    logEvent(project, createEvent(ConfigUtil.getServerPath(project), eventName, eventParameters));
+  }
+
   @NotNull
   private static Event createEvent(
       @NotNull SourcegraphServerPath sourcegraphServerPath,

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.chat.ui
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.ColorUtil
 import com.intellij.util.ui.SwingHelper
@@ -10,6 +11,7 @@ import com.sourcegraph.cody.attribution.AttributionListener
 import com.sourcegraph.cody.attribution.AttributionSearchCommand
 import com.sourcegraph.cody.chat.*
 import com.sourcegraph.cody.ui.HtmlViewer.createHtmlViewer
+import com.sourcegraph.telemetry.GraphQlLogger
 import java.awt.Color
 import javax.swing.JEditorPane
 import javax.swing.JPanel
@@ -107,6 +109,10 @@ class SingleMessagePanel(
       chatSession.getSessionId()?.let { sessionId ->
         val listener = AttributionListener.UiThreadDecorator(lastPart.attribution)
         AttributionSearchCommand(project).onSnippetFinished(lastPart.text, sessionId, listener)
+      }
+
+      ApplicationManager.getApplication().executeOnPooledThread {
+        GraphQlLogger.logCodeGenerationEvent(project, "chatResponse", "hasCode", lastPart.text)
       }
     }
   }


### PR DESCRIPTION
## Changes

Closes https://github.com/sourcegraph/jetbrains/issues/637

New code generation tracking events were added:

+  `CodyJetBrainsPlugin:chatResponse:hasCode`
+ `CodyJetBrainsPlugin:insertButton:clicked`
+ `CodyJetBrainsPlugin:copyButton:clicked`
+  `CodyJetBrainsPlugin:keyDown:Paste:clicked`

## Test plan

* Manual verification in debugger that proper events are set
* Check if events are present in GraphQL DB