### PR TITLE
Fixes `userContextFiles`

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -35,7 +35,7 @@ data class ExtensionMessage(
     val chatID: String? = null,
     val isTranscriptError: Boolean? = null,
     val customPrompts: List<List<Any>>? = null,
-    val context: List<ContextFile>? = null,
+    val userContextFiles: List<ContextFile>? = null,
     val errors: String?,
     val query: String? = null,
     val configFeatures: ConfigFeatures? = null,

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -202,8 +202,8 @@ private constructor(
   fun receiveWebviewExtensionMessage(message: ExtensionMessage) {
     when (message.type) {
       ExtensionMessage.Type.USER_CONTEXT_FILES -> {
-        if (message.context is List<*>) {
-          this.chatPanel.promptPanel.setContextFilesSelector(message.context)
+        if (message.userContextFiles is List<*>) {
+          this.chatPanel.promptPanel.setContextFilesSelector(message.userContextFiles)
         }
       }
       else -> {


### PR DESCRIPTION
The recent changes to the agent (https://github.com/sourcegraph/cody/pull/3142) broke the API - this is a fix.


## Test plan
1. write @ in the chat
2. the files appear
