### PR TITLE
Fixes currentUserCodySubscription

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
@@ -41,6 +41,10 @@ class EndOfTrialNotificationScheduler private constructor(val project: Project) 
                 agent.server
                     .getCurrentUserCodySubscription()
                     .completeOnTimeout(null, 4, TimeUnit.SECONDS)
+                    .exceptionally { e ->
+                      logger.warn("Error while getting currentUserCodySubscription ", e)
+                      null
+                    }
                     .get()
 
             if (currentUserCodySubscription == null) {


### PR DESCRIPTION
Fixes #681.

## Test plan
1. modify agent (https://sourcegraph.com/-/editor?remote_url=github.com%2Fsourcegraph%2Fcody&branch=main&file=lib%2Fshared%2Fsrc%2Fsourcegraph-api%2Fgraphql%2Fqueries.ts&start_row=14&start_col=0&end_row=25&end_col=2&editor=JetBrains&version=v5.3.1544) so that the error appears (e.g. typo in `codySubscription`)
2. runIde with dotcom account 
