### PR TITLE
Fix null pointer exception during autocomplete

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
@@ -162,14 +162,10 @@ class CodyEditorFactoryListener : EditorFactoryListener {
             Position(selectionStartPosition.line, selectionStartPosition.column),
             Position(selectionEndPosition.line, selectionEndPosition.column))
       }
-      val carets = editor.caretModel.allCarets
-      if (carets.isNotEmpty()) {
-        val caret = carets[0]
-        val position = Position(caret.logicalPosition.line, caret.logicalPosition.column)
-        // A single-offset caret is a selection where end == start.
-        return Range(position, position)
-      }
-      return null
+      val caret = editor.caretModel.allCarets.firstOrNull() ?: return null
+      val position = Position(caret.logicalPosition.line, caret.logicalPosition.column)
+      // A single-offset caret is a selection where end == start.
+      return Range(position, position)
     }
 
     // Sends a textDocument/didChange notification to the agent server.


### PR DESCRIPTION
## Changes

Fixes https://github.com/sourcegraph/jetbrains/issues/877 and similar.

I _think_ that `NPE` could happen because `editor.caretModel.allCarets` model is mutable under the hood, and possibly changed by IntelliJ in the meantime. That fix should address the issue.

## Test plan

I cannot reproduce an issue locally so it's hard to proceed with a meaningful test.