### PR TITLE
Fix InvalidPathException during URI conversion

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -34,7 +34,7 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
 
     CodyAgentService.withAgent(
         source.getProject(),
-        agent -> agent.getServer().textDocumentDidClose(TextDocument.fromPath(file)));
+        agent -> agent.getServer().textDocumentDidClose(TextDocument.fromVirtualFile(file)));
   }
 
   public static void fileOpened(Project project, CodyAgent codyAgent, @NotNull VirtualFile file) {
@@ -43,7 +43,7 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
             .runReadAction(
                 (Computable<Document>) () -> FileDocumentManager.getInstance().getDocument(file));
     if (document != null) {
-      TextDocument textDocument = TextDocument.fromPath(file, document.getText());
+      TextDocument textDocument = TextDocument.fromVirtualFile(file, document.getText());
       codyAgent.getServer().textDocumentDidOpen(textDocument);
     }
 

--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -34,7 +34,7 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
 
     CodyAgentService.withAgent(
         source.getProject(),
-        agent -> agent.getServer().textDocumentDidClose(TextDocument.fromPath(file.getPath())));
+        agent -> agent.getServer().textDocumentDidClose(TextDocument.fromPath(file)));
   }
 
   public static void fileOpened(Project project, CodyAgent codyAgent, @NotNull VirtualFile file) {
@@ -43,7 +43,7 @@ public class CodyFileEditorListener implements FileEditorManagerListener {
             .runReadAction(
                 (Computable<Document>) () -> FileDocumentManager.getInstance().getDocument(file));
     if (document != null) {
-      TextDocument textDocument = TextDocument.fromPath(file.getPath(), document.getText());
+      TextDocument textDocument = TextDocument.fromPath(file, document.getText());
       codyAgent.getServer().textDocumentDidOpen(textDocument);
     }
 

--- a/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
@@ -54,7 +54,7 @@ public final class CodyFocusChangeListener implements FocusChangeListener, Start
             Thread.sleep(100);
           } catch (InterruptedException ignored) {
           }
-          agent.getServer().textDocumentDidFocus(TextDocument.fromPath(file.getPath()));
+          agent.getServer().textDocumentDidFocus(TextDocument.fromPath(file));
         });
 
     CodyAgentCodebase.getInstance(project).onFileOpened(project, file);

--- a/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFocusChangeListener.java
@@ -54,7 +54,7 @@ public final class CodyFocusChangeListener implements FocusChangeListener, Start
             Thread.sleep(100);
           } catch (InterruptedException ignored) {
           }
-          agent.getServer().textDocumentDidFocus(TextDocument.fromPath(file));
+          agent.getServer().textDocumentDidFocus(TextDocument.fromVirtualFile(file));
         });
 
     CodyAgentCodebase.getInstance(project).onFileOpened(project, file);

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocument.kt
@@ -14,7 +14,7 @@ private constructor(
 
     @JvmStatic
     @JvmOverloads
-    fun fromPath(
+    fun fromVirtualFile(
         file: VirtualFile,
         content: String? = null,
         selection: Range? = null

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocument.kt
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody.agent.protocol
 
+import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.agent.protocol.util.Rfc3986UriEncoder
-import java.nio.file.Paths
 
 class TextDocument
 private constructor(
@@ -14,9 +14,12 @@ private constructor(
 
     @JvmStatic
     @JvmOverloads
-    fun fromPath(path: String, content: String? = null, selection: Range? = null): TextDocument {
-      val uri = Paths.get(path).toUri().toString()
-      val rfc3986Uri = Rfc3986UriEncoder.encode(uri)
+    fun fromPath(
+        file: VirtualFile,
+        content: String? = null,
+        selection: Range? = null
+    ): TextDocument {
+      val rfc3986Uri = Rfc3986UriEncoder.encode(file.url)
       return TextDocument(rfc3986Uri, content, selection)
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
@@ -175,7 +175,7 @@ class CodyEditorFactoryListener : EditorFactoryListener {
         afterUpdate: () -> Unit = {}
     ) {
       val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return
-      val document = TextDocument.fromPath(file, editor.document.text, getSelection(editor))
+      val document = TextDocument.fromVirtualFile(file, editor.document.text, getSelection(editor))
       val project = editor.project ?: return
 
       if (hasFileChanged) {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyEditorFactoryListener.kt
@@ -175,7 +175,7 @@ class CodyEditorFactoryListener : EditorFactoryListener {
         afterUpdate: () -> Unit = {}
     ) {
       val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return
-      val document = TextDocument.fromPath(file.path, editor.document.text, getSelection(editor))
+      val document = TextDocument.fromPath(file, editor.document.text, getSelection(editor))
       val project = editor.project ?: return
 
       if (hasFileChanged) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/609

## Changes

I replaced manual path conversion of `file: VirtualFile` from:

```kotlin
Paths.get(file .path).toUri().toString()
```

to:

```kotlin
file.url
```

During manual tests it seems to be giving proper results, and I would argue that more correct ones than before.
E.g. if accessing file inside a jar protocol is now `jar` instead of `file`.

## Test plan

Unfortunately I do not have a local reproduction, but I completely eliminate the code path which was problematic