### PR TITLE
Hotfix: Fix URL in error submitter

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -68,7 +68,7 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
       if (text.lines().size != 1) "$label:\n```text\n$text\n```" else "$label: ```$text```"
 
   private fun getEncodedUrl(error: CodyError): String =
-      "https://github.com/exigow/issue-template-test/issues/new" +
+      "https://github.com/sourcegraph/jetbrains/issues/new" +
           "?template=bug_report.yml" +
           "&labels=bug,team/jetbrains" +
           "&projects=sourcegraph/381" +


### PR DESCRIPTION
I didn't notice that the URL points to a different, test repository. It should be okay now.