### PR TITLE
Rename SessionId to ConnectionId

### DIFF
--- a/src/main/java/com/sourcegraph/cody/attribution/AttributionSearchCommand.kt
+++ b/src/main/java/com/sourcegraph/cody/attribution/AttributionSearchCommand.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.CurrentConfigFeatures
 import com.sourcegraph.cody.agent.protocol.AttributionSearchParams
 import com.sourcegraph.cody.agent.protocol.AttributionSearchResponse
-import com.sourcegraph.cody.chat.SessionId
+import com.sourcegraph.cody.chat.ConnectionId
 import com.sourcegraph.cody.chat.ui.CodeEditorPart
 import java.util.*
 import java.util.function.BiFunction
@@ -22,11 +22,15 @@ class AttributionSearchCommand(private val project: Project) {
    * and triggers attribution search (if enabled). Once attribution returns, the
    * [CodeEditorPart.attributionListener] is updated.
    */
-  fun onSnippetFinished(snippet: String, sessionId: SessionId, listener: AttributionListener) {
+  fun onSnippetFinished(
+      snippet: String,
+      connectionId: ConnectionId,
+      listener: AttributionListener
+  ) {
     if (attributionEnabled()) {
       CodyAgentService.withAgent(project) { agent ->
         ApplicationManager.getApplication().invokeLater { listener.onAttributionSearchStart() }
-        val params = AttributionSearchParams(id = sessionId, snippet = snippet)
+        val params = AttributionSearchParams(id = connectionId, snippet = snippet)
         agent.server.attributionSearch(params).handle(updateEditor(listener))
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -43,6 +43,7 @@ class CodyAgentService(project: Project) : Disposable {
       }
 
       if (!project.isDisposed) {
+        AgentChatSessionService.getInstance(project).restoreAllSessions(agent)
         FileEditorManager.getInstance(project).openFiles.forEach { file ->
           CodyFileEditorListener.fileOpened(project, agent, file)
         }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -30,11 +30,11 @@ import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
 import com.sourcegraph.telemetry.GraphQlLogger
-import org.slf4j.LoggerFactory
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import org.slf4j.LoggerFactory
 
 class AgentChatSession
 private constructor(
@@ -130,7 +130,8 @@ private constructor(
 
       try {
         val request =
-            agent.server.chatSubmitMessage(ChatSubmitMessageParams(connectionId.get().get(), message))
+            agent.server.chatSubmitMessage(
+                ChatSubmitMessageParams(connectionId.get().get(), message))
 
         GraphQlLogger.logCodyEvent(project, "chat-question", "submitted")
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -261,7 +261,7 @@ private constructor(
     chatPanel.registerCancellationToken(newCancellationToken)
   }
 
-  fun fetchLlms() {
+  private fun fetchLlms() {
     if (chatModelProviderFromState != null) {
       return
     }
@@ -342,8 +342,8 @@ private constructor(
               ChatModelsResponse.ChatModelProvider(
                   default = it.model == null,
                   codyProOnly = false,
-                  provider = it.provider ?: "Unknown",
-                  title = it.title ?: "Unknown",
+                  provider = it.provider ?: "Default",
+                  title = it.title ?: "Default",
                   model = it.model ?: "")
             }
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -6,10 +6,22 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.intellij.xml.util.XmlStringUtil
 import com.jetbrains.rd.util.AtomicReference
-import com.sourcegraph.cody.agent.*
-import com.sourcegraph.cody.agent.protocol.*
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.ExtensionMessage
+import com.sourcegraph.cody.agent.WebviewMessage
+import com.sourcegraph.cody.agent.WebviewReceiveMessageParams
+import com.sourcegraph.cody.agent.protocol.ChatMessage
+import com.sourcegraph.cody.agent.protocol.ChatModelsParams
+import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
+import com.sourcegraph.cody.agent.protocol.ChatRestoreParams
+import com.sourcegraph.cody.agent.protocol.ChatSubmitMessageParams
+import com.sourcegraph.cody.agent.protocol.ContextFile
+import com.sourcegraph.cody.agent.protocol.Speaker
 import com.sourcegraph.cody.chat.ui.ChatPanel
+import com.sourcegraph.cody.chat.ui.LlmDropdownData
 import com.sourcegraph.cody.commands.CommandId
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.RateLimitStateManager
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.ChatState
@@ -18,26 +30,26 @@ import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
 import com.sourcegraph.telemetry.GraphQlLogger
-import java.util.*
+import org.slf4j.LoggerFactory
+import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
-import org.slf4j.LoggerFactory
 
 class AgentChatSession
 private constructor(
     private val project: Project,
-    newSessionId: CompletableFuture<SessionId>,
+    newConnectionId: CompletableFuture<ConnectionId>,
     private val internalId: String = UUID.randomUUID().toString(),
-    chatModelProviderFromState: ChatModelsResponse.ChatModelProvider? = null,
+    private val chatModelProviderFromState: ChatModelsResponse.ChatModelProvider? = null,
 ) : ChatSession {
   /**
    * There are situations (like startup of the chat) when we want to show UI immediately, but we
    * have not established connection with the agent yet. This is why we use CompletableFuture to
-   * store the sessionId.
+   * store the connectionId.
    */
-  private val sessionId: AtomicReference<CompletableFuture<SessionId>> =
-      AtomicReference(newSessionId)
+  private val connectionId: AtomicReference<CompletableFuture<ConnectionId>> =
+      AtomicReference(newConnectionId)
   private val chatPanel: ChatPanel =
       ChatPanel(project, chatSession = this, chatModelProviderFromState)
   private val cancellationToken = AtomicReference(CancellationToken())
@@ -45,7 +57,7 @@ private constructor(
 
   init {
     cancellationToken.get().dispose()
-    newSessionId.thenAccept { sessionId -> chatPanel.updateWithSessionId(sessionId) }
+    fetchLlms()
   }
 
   fun restoreAgentSession(
@@ -66,15 +78,17 @@ private constructor(
             chatModelProvider?.model,
             messagesToReload,
             UUID.randomUUID().toString())
-    val newSessionId = agent.server.chatRestore(restoreParams)
-    sessionId.getAndSet(newSessionId)
+    val newConnectionId = agent.server.chatRestore(restoreParams)
+    connectionId.getAndSet(newConnectionId)
+    fetchLlms()
   }
 
   fun getPanel(): ChatPanel = chatPanel
 
-  override fun getSessionId(): SessionId? = sessionId.get().getNow(null)
+  override fun getConnectionId(): ConnectionId? = connectionId.get().getNow(null)
 
-  fun hasSessionId(thatSessionId: SessionId): Boolean = getSessionId() == thatSessionId
+  fun hasConnectionId(thatConnectionId: ConnectionId): Boolean =
+      getConnectionId() == thatConnectionId
 
   override fun getInternalId(): String = internalId
 
@@ -116,7 +130,7 @@ private constructor(
 
       try {
         val request =
-            agent.server.chatSubmitMessage(ChatSubmitMessageParams(sessionId.get().get(), message))
+            agent.server.chatSubmitMessage(ChatSubmitMessageParams(connectionId.get().get(), message))
 
         GraphQlLogger.logCodyEvent(project, "chat-question", "submitted")
 
@@ -201,7 +215,7 @@ private constructor(
   override fun sendWebviewMessage(message: WebviewMessage) {
     CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
       agent.server.webviewReceiveMessage(
-          WebviewReceiveMessageParams(this.sessionId.get().get(), message))
+          WebviewReceiveMessageParams(this.connectionId.get().get(), message))
     }
   }
 
@@ -246,20 +260,40 @@ private constructor(
     chatPanel.registerCancellationToken(newCancellationToken)
   }
 
+  fun fetchLlms() {
+    if (chatModelProviderFromState != null) {
+      return
+    }
+
+    CodyAgentService.withAgent(project) { agent ->
+      val chatModels = agent.server.chatModels(ChatModelsParams(connectionId.get().get()))
+      val response =
+          chatModels.completeOnTimeout(null, 4, TimeUnit.SECONDS).get() ?: return@withAgent
+
+      val activeAccountType = CodyAuthenticationManager.instance.getActiveAccount(project)
+      val isCurrentUserFree =
+          if (activeAccountType?.isDotcomAccount() == true) {
+            agent.server.isCurrentUserPro().completeOnTimeout(false, 4, TimeUnit.SECONDS).get() ==
+                false
+          } else false
+      chatPanel.updateLlmDropdownModels(LlmDropdownData(response.models, isCurrentUserFree))
+    }
+  }
+
   companion object {
     private val logger = LoggerFactory.getLogger(AgentChatSession::class.java)
 
     @RequiresEdt
     fun createNew(project: Project): AgentChatSession {
-      val sessionId = createNewPanel(project) { it.server.chatNew() }
-      val chatSession = AgentChatSession(project, sessionId)
+      val connectionId = createNewPanel(project) { it.server.chatNew() }
+      val chatSession = AgentChatSession(project, connectionId)
       AgentChatSessionService.getInstance(project).addSession(chatSession)
       return chatSession
     }
 
     @RequiresEdt
     fun createFromCommand(project: Project, commandId: CommandId): AgentChatSession {
-      val sessionId =
+      val connectionId =
           createNewPanel(project) { agent: CodyAgent ->
             when (commandId) {
               CommandId.Explain -> agent.server.commandsExplain()
@@ -272,7 +306,7 @@ private constructor(
         GraphQlLogger.logCodyEvent(project, "command:${commandId.displayName}", "submitted")
       }
 
-      val chatSession = AgentChatSession(project, sessionId)
+      val chatSession = AgentChatSession(project, connectionId)
 
       chatSession.createCancellationToken(
           onCancel = { chatSession.sendWebviewMessage(WebviewMessage(command = "abort")) },
@@ -301,7 +335,7 @@ private constructor(
     fun createFromState(project: Project, state: ChatState): AgentChatSession {
       val agentChatSession = CompletableFuture<AgentChatSession>()
       createNewPanel(project) { codyAgent ->
-        val innerSessionId = codyAgent.server.chatNew()
+        val newConnectionId = codyAgent.server.chatNew()
         val modelFromState =
             state.llm?.let {
               ChatModelsResponse.ChatModelProvider(
@@ -313,7 +347,7 @@ private constructor(
             }
 
         val chatSession =
-            AgentChatSession(project, innerSessionId, state.internalId!!, modelFromState)
+            AgentChatSession(project, newConnectionId, state.internalId!!, modelFromState)
         val chatMessages =
             state.messages.map { message ->
               val parsed =
@@ -338,7 +372,7 @@ private constructor(
 
         AgentChatSessionService.getInstance(project).addSession(chatSession)
         agentChatSession.complete(chatSession)
-        innerSessionId
+        newConnectionId
       }
       return agentChatSession.completeOnTimeout(null, 15, TimeUnit.SECONDS).get()
     }
@@ -346,8 +380,8 @@ private constructor(
     private fun createNewPanel(
         project: Project,
         newPanelAction: (CodyAgent) -> CompletableFuture<String>
-    ): CompletableFuture<SessionId> {
-      val result = CompletableFuture<SessionId>()
+    ): CompletableFuture<ConnectionId> {
+      val result = CompletableFuture<ConnectionId>()
       CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
         newPanelAction(agent).whenComplete { value, throwable ->
           if (throwable != null) result.completeExceptionally(throwable) else result.complete(value)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.history.state.ChatState
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -32,6 +33,10 @@ class AgentChatSessionService(private val project: Project) {
 
   fun getSession(connectionId: ConnectionId): AgentChatSession? =
       chatSessions.find { it.hasConnectionId(connectionId) }
+
+  fun restoreAllSessions(agent: CodyAgent) {
+    chatSessions.forEach { it.restoreAgentSession(agent) }
+  }
 
   companion object {
     @JvmStatic

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
@@ -30,8 +30,8 @@ class AgentChatSessionService(private val project: Project) {
     return session ?: AgentChatSession.createFromState(project, state)
   }
 
-  fun getSession(sessionId: SessionId): AgentChatSession? =
-      chatSessions.find { it.hasSessionId(sessionId) }
+  fun getSession(connectionId: ConnectionId): AgentChatSession? =
+      chatSessions.find { it.hasConnectionId(connectionId) }
 
   companion object {
     @JvmStatic

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ChatSession.kt
@@ -6,11 +6,11 @@ import com.sourcegraph.cody.agent.WebviewMessage
 import com.sourcegraph.cody.agent.protocol.ContextFile
 import com.sourcegraph.cody.vscode.CancellationToken
 
-typealias SessionId = String
+typealias ConnectionId = String
 
 interface ChatSession {
 
-  fun getSessionId(): SessionId?
+  fun getConnectionId(): ConnectionId?
 
   fun sendWebviewMessage(message: WebviewMessage)
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -6,13 +6,10 @@ import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.util.IconUtil
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.PromptPanel
-import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.WebviewMessage
-import com.sourcegraph.cody.agent.WebviewReceiveMessageParams
 import com.sourcegraph.cody.agent.protocol.ChatMessage
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.chat.ChatSession
-import com.sourcegraph.cody.chat.SessionId
 import com.sourcegraph.cody.config.CodyAccount.Companion.isEnterpriseAccount
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.context.ui.EnhancedContextPanel
@@ -34,7 +31,7 @@ class ChatPanel(
 
   val promptPanel: PromptPanel = PromptPanel(project, chatSession)
   private val llmDropdown =
-      LLMDropdown(project, onSetSelectedItem = ::setLlmForAgentSession, chatModelProviderFromState)
+      LlmDropdown(project, onSetSelectedItem = ::setLlmForAgentSession, chatModelProviderFromState)
   private val messagesPanel = MessagesPanel(project, chatSession)
   private val chatPanel = ChatScrollPane(messagesPanel)
 
@@ -111,23 +108,17 @@ class ChatPanel(
     stopGeneratingButton.addActionListener { cancellationToken.abort() }
   }
 
-  fun updateWithSessionId(sessionId: SessionId) {
-    llmDropdown.fetchAndUpdateModels(sessionId)
+  fun updateLlmDropdownModels(llmDropdownData: LlmDropdownData) {
+    llmDropdown.updateModels(llmDropdownData)
   }
 
   private fun setLlmForAgentSession(chatModelProvider: ChatModelsResponse.ChatModelProvider) {
-    val sessionId = chatSession.getSessionId() ?: return
-
-    CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
-      val activeAccountType = CodyAuthenticationManager.instance.getActiveAccount(project)
-      if (activeAccountType.isEnterpriseAccount()) {
-        agent.server.webviewReceiveMessage(
-            WebviewReceiveMessageParams(sessionId, WebviewMessage(command = "chatModel")))
-      } else {
-        agent.server.webviewReceiveMessage(
-            WebviewReceiveMessageParams(
-                sessionId, WebviewMessage(command = "chatModel", model = chatModelProvider.model)))
-      }
+    val activeAccountType = CodyAuthenticationManager.instance.getActiveAccount(project)
+    if (activeAccountType.isEnterpriseAccount()) {
+      chatSession.sendWebviewMessage(WebviewMessage(command = "chatModel"))
+    } else {
+      chatSession.sendWebviewMessage(
+          WebviewMessage(command = "chatModel", model = chatModelProvider.model))
     }
 
     HistoryService.getInstance(project)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.chat.ui
 
 import com.intellij.icons.AllIcons
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.util.IconUtil
@@ -109,7 +110,7 @@ class ChatPanel(
   }
 
   fun updateLlmDropdownModels(llmDropdownData: LlmDropdownData) {
-    llmDropdown.updateModels(llmDropdownData)
+    ApplicationManager.getApplication().invokeLater { llmDropdown.updateModels(llmDropdownData) }
   }
 
   private fun setLlmForAgentSession(chatModelProvider: ChatModelsResponse.ChatModelProvider) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
@@ -9,7 +9,12 @@ import com.sourcegraph.cody.agent.protocol.ChatMessage
 import com.sourcegraph.cody.agent.protocol.Speaker
 import com.sourcegraph.cody.attribution.AttributionListener
 import com.sourcegraph.cody.attribution.AttributionSearchCommand
-import com.sourcegraph.cody.chat.*
+import com.sourcegraph.cody.chat.ChatSession
+import com.sourcegraph.cody.chat.CodeEditorFactory
+import com.sourcegraph.cody.chat.MessageContentCreatorFromMarkdownNodes
+import com.sourcegraph.cody.chat.extractCodeAndLanguage
+import com.sourcegraph.cody.chat.findNodeAfterLastCodeBlock
+import com.sourcegraph.cody.chat.isCodeBlock
 import com.sourcegraph.cody.ui.HtmlViewer.createHtmlViewer
 import com.sourcegraph.telemetry.GraphQlLogger
 import java.awt.Color
@@ -113,9 +118,9 @@ class SingleMessagePanel(
   fun onPartFinished() {
     val lastPart = lastMessagePart
     if (lastPart is CodeEditorPart) {
-      chatSession.getSessionId()?.let { sessionId ->
+      chatSession.getConnectionId()?.let { connectionId ->
         val listener = AttributionListener.UiThreadDecorator(lastPart.attribution)
-        AttributionSearchCommand(project).onSnippetFinished(lastPart.text, sessionId, listener)
+        AttributionSearchCommand(project).onSnippetFinished(lastPart.text, connectionId, listener)
       }
 
       ApplicationManager.getApplication().executeOnPooledThread {

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -18,7 +18,11 @@ import com.sourcegraph.cody.api.SourcegraphApiRequests
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.LLMState
 import com.sourcegraph.cody.initialization.Activity
-import com.sourcegraph.config.*
+import com.sourcegraph.config.AccessTokenStorage
+import com.sourcegraph.config.CodyApplicationService
+import com.sourcegraph.config.CodyProjectService
+import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.config.UserLevelConfig
 import java.util.concurrent.CompletableFuture
 
 class SettingsMigration : Activity {
@@ -92,7 +96,7 @@ class SettingsMigration : Activity {
         .filter { it.llm == null }
         .forEach {
           val (model, provider, title) =
-              modelToProviderAndTitle.getOrDefault(it.model, Triple("", "Unknown", "Unknown"))
+              modelToProviderAndTitle.getOrDefault(it.model, Triple("", "Default", "Default"))
           val llmState = LLMState()
           llmState.provider = provider
           llmState.title = title

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -16,7 +16,9 @@ class ChatState : BaseState() {
 
   @get:OptionTag(tag = "updatedAt", nameAttribute = "") var updatedAt: String? by string()
 
-  @get:OptionTag(tag = "model", nameAttribute = "") var model: String? by string()
+  @Deprecated("Use `llm` instead.")
+  @get:OptionTag(tag = "model", nameAttribute = "")
+  var model: String? by string()
 
   @get:OptionTag(tag = "llm", nameAttribute = "") var llm: LLMState? by property()
 

--- a/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.ui
 import com.intellij.ui.CellRendererPanel
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
-import com.sourcegraph.cody.chat.ui.LLMDropdown
+import com.sourcegraph.cody.chat.ui.LlmDropdown
 import java.awt.BorderLayout
 import java.awt.Component
 import javax.swing.BorderFactory
@@ -12,7 +12,7 @@ import javax.swing.JLabel
 import javax.swing.JList
 import javax.swing.JPanel
 
-class LLMComboBoxRenderer(private val llmDropdown: LLMDropdown) : DefaultListCellRenderer() {
+class LlmComboBoxRenderer(private val llmDropdown: LlmDropdown) : DefaultListCellRenderer() {
 
   var isCurrentUserFree: Boolean = false
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -118,4 +118,4 @@ popup.remove-chat=Remove Chat
 popup.remove-all-chats=Remove All Chats
 PromptPanel.ask-cody.message=Message (type @ to include specific files as context)
 PromptPanel.ask-cody.follow-up-message=Follow-up message (type @ to include specific files as context)
-LLMDropdown.disabled.text=Start a new chat to change the model
+LlmDropdown.disabled.text=Start a new chat to change the model


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/868.

In the scope of this PR:
- I renamed `SessionId` to `ConnectionId` as the new name better reflects the type.
- I moved some pieces of code closer to the `AgentChatSession` (making `ConnectionId` usage cleaner)
- I reverted the removal of restore all (I removed it accidentally)
- I fixed the issue with the history ordering 


## Test plan

### Chat History
1. Having chat history with non-today periods only
2. Write to the new chat
3. Review the history 

Expected: "Today" is the first entry
