### PR TITLE
Add pr-auditor

### DIFF
--- a/.github/workflows/pr-auditor.yml
+++ b/.github/workflows/pr-auditor.yml
@@ -1,0 +1,27 @@
+# See https://docs.sourcegraph.com/dev/background-information/ci#pr-auditor
+name: pr-auditor
+on:
+  pull_request_target:
+    types: [ closed, edited, opened, synchronize, ready_for_review ]
+  workflow_dispatch:
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'sourcegraph/pr-auditor'
+      - uses: actions/setup-go@v4
+        with: { go-version: '1.21' }
+
+      - run: './check-pr.sh'
+        env:
+          GITHUB_EVENT_PATH: ${{ env.GITHUB_EVENT_PATH }}
+          GITHUB_TOKEN: ${{ secrets.PR_AUDITOR_TOKEN }}
+          GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  report_failure:
+    needs: check-pr
+    if: ${{ failure() }}
+    uses: sourcegraph/sourcegraph/.github/workflows/report-job-failure.yml@main
+    secrets: inherit


### PR DESCRIPTION
Since Jetbrains releases to the public it is subject to SOC2 controls
## Test plan
Workflow is copied from `sourcegraph/sourcegraph` and has previously been verified