### PR TITLE
Fix url case in add repository

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/AddRepositoryDialog.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/AddRepositoryDialog.kt
@@ -79,7 +79,7 @@ class AddRepositoryDialog(
                   .children()
                   .toList()
                   .filterIsInstance<ContextTreeRemoteRepoNode>()
-                  .none { it.codebaseName == codebaseName }
+                  .none { it.codebaseName == codebaseName?.lowercase() }
             }
 
     return listOfNotNull(
@@ -94,7 +94,7 @@ class AddRepositoryDialog(
   }
 
   override fun doOKAction() {
-    addAction(repoUrlInputField.text)
+    addAction(repoUrlInputField.text.lowercase())
     close(OK_EXIT_CODE, true)
   }
 


### PR DESCRIPTION

## Test plan


### Remote urls letter case
1. Try to add the same remote repo url but with upper/mixed-casing

expected: dialog reports that the repo already exists
