### PR TITLE
 Do not remove deprecated llm (`model`) from the persistence model

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -21,8 +21,16 @@ data class ChatModelsResponse(val models: List<ChatModelProvider>) {
         }
 
     fun displayName(): String = buildString {
-      append(title ?: "Default")
-      provider?.let { append(" by $provider") }
+      if (title == null) {
+        if (model.isNotBlank()) {
+          append(model)
+        } else {
+          append("Default")
+        }
+      } else {
+        append(title)
+        provider?.let { append(" by $provider") }
+      }
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -342,8 +342,8 @@ private constructor(
               ChatModelsResponse.ChatModelProvider(
                   default = it.model == null,
                   codyProOnly = false,
-                  provider = it.provider ?: "Default",
-                  title = it.title ?: "Default",
+                  provider = it.provider,
+                  title = it.title,
                   model = it.model ?: "")
             }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -109,6 +109,8 @@ class SettingsMigration : Activity {
       mapOf(
           "Claude 2 by Anthropic" to Triple("anthropic/claude-2", "Anthropic", "claude 2"),
           "Claude 2.0 by Anthropic" to Triple("anthropic/claude-2.0", "Anthropic", "Claude 2.0"),
+          "Claude 2.1 by Anthropic" to
+              Triple("anthropic/claude-2.1", "Anthropic", "Claude 2.1 Preview"),
           "Claude 2.1 Preview by Anthropic" to
               Triple("anthropic/claude-2.1", "Anthropic", "Claude 2.1 Preview"),
           "Claude Instant by Anthropic" to

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -96,13 +96,12 @@ class SettingsMigration : Activity {
         .filter { it.llm == null }
         .forEach {
           val (model, provider, title) =
-              modelToProviderAndTitle.getOrDefault(it.model, Triple("", "Default", "Default"))
+              modelToProviderAndTitle.getOrDefault(it.model, Triple(it.model, null, null))
           val llmState = LLMState()
-          llmState.provider = provider
-          llmState.title = title
           llmState.model = model
+          llmState.title = title
+          llmState.provider = provider
           it.llm = llmState
-          it.model = null
         }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -107,6 +107,7 @@ class SettingsMigration : Activity {
 
   private val modelToProviderAndTitle =
       mapOf(
+          "Claude 2 by Anthropic" to Triple("anthropic/claude-2", "Anthropic", "claude 2"),
           "Claude 2.0 by Anthropic" to Triple("anthropic/claude-2.0", "Anthropic", "Claude 2.0"),
           "Claude 2.1 Preview by Anthropic" to
               Triple("anthropic/claude-2.1", "Anthropic", "Claude 2.1 Preview"),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/965.

## Test plan
1. with 5.3.1544, delete `"RunOnceActivity.CodyHistoryLlmMigration": "true",` entry from `workspace.xml` if present
2. create multiple chats with each llm
3. having THESE changes run the same project 

expected: the models are (migrated and) DISPLAYED correctly 
