### PR TITLE
Do not report missing current subscription in the grpahql

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
@@ -41,6 +41,10 @@ class EndOfTrialNotificationScheduler private constructor(val project: Project) 
                 agent.server
                     .getCurrentUserCodySubscription()
                     .completeOnTimeout(null, 4, TimeUnit.SECONDS)
+                    .exceptionally { e ->
+                      logger.warn("Error while getting currentUserCodySubscription ", e)
+                      null
+                    }
                     .get()
 
             if (currentUserCodySubscription == null) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/680

## Changes

This is basically a revert of: https://github.com/sourcegraph/jetbrains/pull/956/files#diff-b7ff7beb63f64b17a428cea37d5bda205b8da643b407f7a03fa49d3bfbd547f7

I'm adding it back because I get the confirmation from @chrsmith that i is possible (and expected) that `codySubscription` is missing for some users so we should not report this as a problem to the users.

## Test plan

Unfortunately there is no easy way to test this change.