### PR TITLE
Fix formatting for single line completions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ platformType=IC
 platformVersion=2022.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=Git4Idea,PerforceDirectPlugin
+platformPlugins=Git4Idea,PerforceDirectPlugin,java
 # Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
 javaVersion=11
 # Gradle Releases -> https://github.com/gradle/gradle/releases

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -45,13 +45,13 @@ import com.sourcegraph.utils.CodyFormatter
 import difflib.Delta
 import difflib.DiffUtils
 import difflib.Patch
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
 /** Responsible for triggering and clearing inline code completions (the autocomplete feature). */
 @Service
@@ -373,14 +373,19 @@ class CodyAutocompleteManager {
       val renderer =
           CodyAutocompleteSingleLineRenderer(
               completionText.lines().first(), items, editor, AutocompleteRendererType.INLINE)
-      inlayModel.addInlineElement(offset, true, renderer)
+      inlayModel.addInlineElement(offset, /* relatesToPrecedingText = */ true, renderer)
     }
     val lines = completionText.lines()
     if (lines.size > 1) {
       val text =
           (if (startsInline) lines.drop(1) else lines).dropWhile { it.isBlank() }.joinToString("\n")
       val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
-      inlayModel.addBlockElement(offset, true, false, Int.MAX_VALUE, renderer)
+      inlayModel.addBlockElement(
+          /* offset = */ offset,
+          /* relatesToPrecedingText = */ true,
+          /* showAbove = */ false,
+          /* priority = */ Int.MAX_VALUE,
+          /* renderer = */ renderer)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -28,20 +28,11 @@ class CodyFormatter {
           PsiFileFactory.getInstance(project)
               .createFileFromText("TEMP", file.fileType, appendedString)
 
+      fun endOffset() = offset + psiFile.endOffset - document.textLength
       val codeStyleManager = CodeStyleManager.getInstance(project)
+      codeStyleManager.reformatText(psiFile, offset + 1, endOffset())
 
-      var i = offset
-      var startRefactoringPosition = offset
-      while ((document.text.elementAt(i - 1) == ' ' ||
-          document.text.elementAt(i - 1) == '\n' ||
-          document.text.elementAt(i - 1) == '\t') && i > 0) {
-        startRefactoringPosition = i
-        i--
-      }
-      var endOffset = offset + psiFile.endOffset - document.textLength
-      codeStyleManager.reformatText(psiFile, startRefactoringPosition, endOffset)
-      endOffset = offset + psiFile.endOffset - document.textLength
-      return psiFile.text.substring(startRefactoringPosition, endOffset)
+      return psiFile.text.substring(offset, endOffset())
     }
   }
 }

--- a/src/test/kotlin/utils/CodyFormatterTest.kt
+++ b/src/test/kotlin/utils/CodyFormatterTest.kt
@@ -1,16 +1,16 @@
 package utils
 
-import com.intellij.ide.highlighter.JavaFileType
-import com.intellij.psi.PsiFileFactory
+import com.intellij.openapi.util.TextRange
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.sourcegraph.utils.CodyFormatter
 import junit.framework.TestCase
 
 class CodyFormatterTest : BasePlatformTestCase() {
+  private val argsString = "String[] args"
   private val testFileContent =
       """|
          |public class HelloWorld {
-         |    public static void main(String[] args) {
+         |    public static void main(${argsString}) {
          |        System.out.println("Hello World!");
          |        // MAIN
          |    }
@@ -18,24 +18,41 @@ class CodyFormatterTest : BasePlatformTestCase() {
          |}"""
           .trimMargin()
 
+  private var argListOffset = testFileContent.indexOf(argsString)
   private var insideMainOffset = testFileContent.indexOf("// MAIN")
   private var insideClassOffset = testFileContent.indexOf("// CLASS")
 
-  private fun formatText(text: String, offset: Int): String {
-    val psiFactory = PsiFileFactory.getInstance(project)
-    val psiFile =
-        psiFactory.createFileFromText("FORMATTING_TEST", JavaFileType.INSTANCE, testFileContent)
+  private fun formatText(
+      toFormat: String,
+      offset: Int,
+      range: TextRange? = null,
+      fileContent: String = testFileContent
+  ): String {
+    val psiFile = myFixture.addFileToProject("CodyFormatterTest.java", fileContent)
     return CodyFormatter.formatStringBasedOnDocument(
-        text, myFixture.project, psiFile.viewProvider.document, offset)
+        toFormat,
+        myFixture.project,
+        psiFile.viewProvider.document,
+        range ?: TextRange(offset, offset),
+        offset)
   }
 
   fun `test single line formatting`() {
     TestCase.assertEquals("int x = 2;", formatText("int   x =   2;", insideMainOffset))
   }
 
+  fun `test single line formatting with overlapping range`() {
+    val range = TextRange(argListOffset, argListOffset + argsString.length)
+    // 'String[]   args' is existing text in the editor, so we do not want to reformat it, but we
+    // want to format the rest
+    TestCase.assertEquals(
+        "String[]   args, int n", formatText("String[]   args,   int   n", range.endOffset))
+  }
+
   fun `test single line formatting to multiline`() {
     TestCase.assertEquals(
-        """|public static int fib(int n) {
+        """|
+           |    public static int fib(int n) {
            |        if (n <= 1) {
            |            return n;
            |        }
@@ -45,5 +62,24 @@ class CodyFormatterTest : BasePlatformTestCase() {
         formatText(
             "public static int fib(int n) { if (n <= 1) { return n; } return fib(n-1) + fib(n-2);  }",
             insideClassOffset))
+  }
+
+  fun `test fix for IJ formatter bug`() {
+    val existingLine = "    public static void test()    "
+    val completion = "$existingLine  { }"
+    val testFileContent =
+        """|public class HelloWorld {
+           |$existingLine
+           |}"""
+            .trimMargin()
+
+    val rangeStart = testFileContent.indexOf(existingLine)
+    val rangeEnd = rangeStart + existingLine.length
+
+    TestCase.assertEquals(
+        """|    public static void test()    {
+           |    }"""
+            .trimMargin(),
+        formatText(completion, rangeEnd, TextRange(rangeStart, rangeEnd), testFileContent))
   }
 }

--- a/src/test/kotlin/utils/CodyFormatterTest.kt
+++ b/src/test/kotlin/utils/CodyFormatterTest.kt
@@ -1,0 +1,49 @@
+package utils
+
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.psi.PsiFileFactory
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.sourcegraph.utils.CodyFormatter
+import junit.framework.TestCase
+
+class CodyFormatterTest : BasePlatformTestCase() {
+  private val testFileContent =
+      """|
+         |public class HelloWorld {
+         |    public static void main(String[] args) {
+         |        System.out.println("Hello World!");
+         |        // MAIN
+         |    }
+         |    // CLASS
+         |}"""
+          .trimMargin()
+
+  private var insideMainOffset = testFileContent.indexOf("// MAIN")
+  private var insideClassOffset = testFileContent.indexOf("// CLASS")
+
+  private fun formatText(text: String, offset: Int): String {
+    val psiFactory = PsiFileFactory.getInstance(project)
+    val psiFile =
+        psiFactory.createFileFromText("FORMATTING_TEST", JavaFileType.INSTANCE, testFileContent)
+    return CodyFormatter.formatStringBasedOnDocument(
+        text, myFixture.project, psiFile.viewProvider.document, offset)
+  }
+
+  fun `test single line formatting`() {
+    TestCase.assertEquals("int x = 2;", formatText("int   x =   2;", insideMainOffset))
+  }
+
+  fun `test single line formatting to multiline`() {
+    TestCase.assertEquals(
+        """|public static int fib(int n) {
+           |        if (n <= 1) {
+           |            return n;
+           |        }
+           |        return fib(n - 1) + fib(n - 2);
+           |    }"""
+            .trimMargin(),
+        formatText(
+            "public static int fib(int n) { if (n <= 1) { return n; } return fib(n-1) + fib(n-2);  }",
+            insideClassOffset))
+  }
+}


### PR DESCRIPTION
Fixes  https://github.com/sourcegraph/jetbrains/issues/987

## Changes

Fixed formatting (previously non-existing) for single line completions, simplified the code, and added the tests.

## Test plan

Automatic tests for formatter were added.
Additionally manual QA was done using `TESTING.MD` section `Single-line autocomplete' and `Multi-line autocomplete`