### PR TITLE
Add instructions for updating cody version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,28 @@ Take the steps below _before_ [running JetBrains plugin with agent](#developing-
       Note: After [#56254](https://github.com/sourcegraph/sourcegraph/issues/56254) is resolved this step is not needed
       anymore.
 
+## Updating Cody version
+
+To upgrade Cody to the newer version you need to update the `cody.commit` hash in `gradle.properties`.
+After doing that:
+
+1. Run `git diff --name-status OLD_HASH..NEW_HASH -- agent`  
+   It will print you a list of files changed between updates.  
+   Changes in tests or bindings might require adjustments in the jetbrains codebase, so please inspect those carefully.
+2. Check if the main features are working before sending it for the full QA.  
+   Please pay special attention to areas with potential changes indicated by point 1):
+    * autocomplete
+    * chat
+    * chat history
+    * context fixes in chat responses
+    * @-files in chat prompt
+    * enhanced remote context
+    * commands from context menu and commands tab
+    * login / account switch
+
+   You don't need to cover all corner cases and do a full QA, but make sure basic features still work.  
+   Cody version updates tends to break them completely or not at all, so it should allow us to catch most issues early.
+
 ## Publishing a New Release
 
 We plan to make releases every other Monday. Nightly version can be released as often as there is a need.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Take the steps below _before_ [running JetBrains plugin with agent](#developing-
 To upgrade Cody to the newer version you need to update the `cody.commit` hash in `gradle.properties`.
 After doing that:
 
-1. Run `git diff --name-status OLD_HASH..NEW_HASH -- agent`  
+1. Run on the `sourcegraph/cody` repo: `git diff --name-status OLD_HASH..NEW_HASH -- agent`  
    It will print you a list of files changed between updates.  
    Changes in tests or bindings might require adjustments in the jetbrains codebase, so please inspect those carefully.
 2. Check if the main features are working before sending it for the full QA.  

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,7 +205,7 @@ tasks {
     return destinationDir
   }
 
-  val codyCommit = "c8f5355a88783cce6bf1ac0088c73917e2a29d94"
+  val codyCommit = properties("cody.commit")
   fun downloadCody(): File {
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
     val destination = githubArchiveCache.resolve("$codyCommit.zip")

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
+cody.commit=c8f5355a88783cce6bf1ac0088c73917e2a29d94


### PR DESCRIPTION
## Changes

Added a new doc section:

----------------------------------
## Updating Cody version

To upgrade Cody to the newer version you need to update the `cody.commit` hash in `gradle.properties`.
After doing that:

1. Run `git diff --name-status OLD_HASH..NEW_HASH -- agent`  
   It will print you a list of files changed between updates.  
   Changes in tests or bindings might require adjustments in the jetbrains codebase, so please inspect those carefully.
2. Check if the main features are working before sending it for the full QA.  
   Please pay special attention to areas with potential changes indicated by point 1):
    * autocomplete
    * chat
    * chat history
    * context fixes in chat responses
    * @-files in chat prompt
    * enhanced remote context
    * commands from context menu and commands tab
    * login / account switch

   You don't need to cover all corner cases and do a full QA, but make sure basic features still work.  
   Cody version updates tends to break them completely or not at all, so it should allow us to catch most issues early.

----------------------------------

## Test plan
None, just a doc change.