### PR TITLE
Fix URI to Path conversion code

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
@@ -1,11 +1,18 @@
 package com.sourcegraph.cody.agent.protocol
 
-import com.google.gson.*
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonSerializer
+import com.intellij.openapi.vfs.StandardFileSystems
+import com.intellij.openapi.vfs.VfsUtil
 import java.io.File
 import java.lang.reflect.Type
 import java.net.URI
 import java.nio.file.Path
-import java.nio.file.Paths
+import kotlin.io.path.toPath
 
 typealias ContextFileSource =
     String // One of: embeddings, user, keyword, editor, filename, search, unified, selection,
@@ -59,8 +66,11 @@ data class ContextItemFile(
 
   fun isLocal() = repoName == null
 
-  fun getPath(): Path {
-    return Paths.get(uri.path).toAbsolutePath()
+  fun getPath(): Path? {
+    val newUri = uri.toString().substringBefore("?")
+    val fileProtocol = StandardFileSystems.FILE_PROTOCOL_PREFIX
+    val uriWithFileProtocol = if (newUri.startsWith(fileProtocol)) newUri else fileProtocol + newUri
+    return VfsUtil.toUri(uriWithFileProtocol)?.toPath()
   }
 
   fun getLinkActionText(projectPath: String?): String {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -95,7 +95,7 @@ class ContextFilesPanel(
 
   private fun openInEditor(contextItemFile: ContextItemFile) {
     val logicalLine = contextItemFile.range?.start?.line ?: 0
-    val contextFilePath = contextItemFile.getPath()
+    val contextFilePath = contextItemFile.getPath() ?: return
     ApplicationManager.getApplication().executeOnPooledThread {
       val findFileByNioFile = LocalFileSystem.getInstance().findFileByNioFile(contextFilePath)
       if (findFileByNioFile != null) {

--- a/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ContextItemTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ContextItemTest.kt
@@ -1,9 +1,10 @@
 package com.sourcegraph.cody.agent.protocol
 
+import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import java.net.URI
-import junit.framework.TestCase
 
-class ContextItemTest : TestCase() {
+class ContextItemTest : BasePlatformTestCase() {
   private val localContextItemFile =
       ContextItemFile(
           uri =
@@ -34,5 +35,24 @@ class ContextItemTest : TestCase() {
   fun `testGetLinkActionText - remote file`() {
     val linkActionText = remoteContextItemFile.getLinkActionText(projectPath = null)
     assertEquals("jetbrains TESTING.md:49-56", linkActionText)
+  }
+
+  fun `test getPath`() {
+    fun contextFilePath(path: String) = ContextItemFile(uri = URI.create(path)).getPath().toString()
+
+    if (SystemInfoRt.isWindows) {
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("file:///c:/a/b/c/d.java"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("file://c:/a/b/c/d.java"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("file:///c:/a/b/c/d.java?#"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("file://c:/a/b/c/d.java?#"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("/c:/a/b/c/d.java"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("c:/a/b/c/d.java"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("c:/a/b/c/d.java?#"))
+      assertEquals("c:\\a\\b\\c\\d.java", contextFilePath("c:/a/b/c/d.java?#"))
+    } else {
+      assertEquals("/a/b/c/d.java", contextFilePath("/a/b/c/d.java"))
+      assertEquals("/a/b/c/d.java", contextFilePath("/a/b/c/d.java?#"))
+      assertEquals("/a/b/c/d.java", contextFilePath("file:///a/b/c/d.java"))
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/995

## Changes

Fixed URI to Path conversion code + added tests

## Test plan

Unit tests added + manual testing by clicking on the response context links on Windows and MacOs.