### PR TITLE
Bump cody version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=c8f5355a88783cce6bf1ac0088c73917e2a29d94
+cody.commit=b66ee05d2f81df0fda5d6c9f1b292696c163c3bc


### PR DESCRIPTION
## Test plan

Full manual QA will be needed.
I ran basic tests according to our [Updating Cody version](https://github.com/sourcegraph/jetbrains/blob/main/CONTRIBUTING.md#updating-cody-version) guide.