### PR TITLE
Removed experimental user setting for inline edits

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -11,7 +11,6 @@ data class CodyApplicationSettings(
     var isCodyAutocompleteEnabled: Boolean = true,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
-    var isCodyExperimentalInlineEditEnabled: Boolean = false,
     var isGetStartedNotificationDismissed: Boolean = false,
     var isNotLoggedInNotificationDismissed: Boolean = false,
     var anonymousUserId: String? = null,
@@ -31,7 +30,6 @@ data class CodyApplicationSettings(
     this.isCodyAutocompleteEnabled = state.isCodyAutocompleteEnabled
     this.isCodyDebugEnabled = state.isCodyDebugEnabled
     this.isCodyVerboseDebugEnabled = state.isCodyVerboseDebugEnabled
-    this.isCodyExperimentalInlineEditEnabled = state.isCodyExperimentalInlineEditEnabled
     this.isGetStartedNotificationDismissed = state.isGetStartedNotificationDismissed
     this.isNotLoggedInNotificationDismissed = state.isNotLoggedInNotificationDismissed
     this.anonymousUserId = state.anonymousUserId

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -9,7 +9,6 @@ data class SettingsModel(
     var isCodyAutocompleteEnabled: Boolean = true,
     var isCodyDebugEnabled: Boolean = false,
     var isCodyVerboseDebugEnabled: Boolean = false,
-    var isCodyExperimentalInlineEditEnabled: Boolean = false,
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Color? = null,
     var isLookupAutocompleteEnabled: Boolean = true,

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -49,12 +49,6 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
               .bindSelected(settingsModel::isCodyVerboseDebugEnabled)
         }
         row {
-          checkBox("Enable experimental inline edits")
-              .comment("Enables experimental edit-code and document-code features")
-              .enabledIf(enableCodyCheckbox.selected)
-              .bindSelected(settingsModel::isCodyExperimentalInlineEditEnabled)
-        }
-        row {
           checkBox("Accept non-trusted certificates")
               .enabledIf(enableCodyCheckbox.selected)
               .bindSelected(settingsModel::shouldAcceptNonTrustedCertificatesAutomatically)
@@ -106,8 +100,6 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
     settingsModel.isCodyAutocompleteEnabled = codyApplicationSettings.isCodyAutocompleteEnabled
     settingsModel.isCodyDebugEnabled = codyApplicationSettings.isCodyDebugEnabled
     settingsModel.isCodyVerboseDebugEnabled = codyApplicationSettings.isCodyVerboseDebugEnabled
-    settingsModel.isCodyExperimentalInlineEditEnabled =
-        codyApplicationSettings.isCodyExperimentalInlineEditEnabled
     settingsModel.isCustomAutocompleteColorEnabled =
         codyApplicationSettings.isCustomAutocompleteColorEnabled
     settingsModel.customAutocompleteColor =
@@ -142,8 +134,6 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
     codyApplicationSettings.isCodyAutocompleteEnabled = settingsModel.isCodyAutocompleteEnabled
     codyApplicationSettings.isCodyDebugEnabled = settingsModel.isCodyDebugEnabled
     codyApplicationSettings.isCodyVerboseDebugEnabled = settingsModel.isCodyVerboseDebugEnabled
-    codyApplicationSettings.isCodyExperimentalInlineEditEnabled =
-        settingsModel.isCodyExperimentalInlineEditEnabled
     codyApplicationSettings.isCustomAutocompleteColorEnabled =
         settingsModel.isCustomAutocompleteColorEnabled
     codyApplicationSettings.customAutocompleteColor = settingsModel.customAutocompleteColor?.rgb

--- a/src/main/kotlin/com/sourcegraph/cody/edit/DocumentCodeActionHandler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/DocumentCodeActionHandler.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.project.DumbAware
 import com.sourcegraph.cody.autocomplete.action.CodyAction
-import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
 
 class DocumentCodeAction : EditorAction(DocumentCodeActionHandler()), CodyAction, DumbAware
@@ -17,8 +16,7 @@ class DocumentCodeActionHandler : EditorActionHandler() {
   private val logger = Logger.getInstance(DocumentCodeActionHandler::class.java)
 
   override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
-    return CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
-        ConfigUtil.isExperimentalInlineEditEnabled()
+    return CodyEditorUtil.isEditorValidForAutocomplete(editor)
   }
 
   override fun doExecute(editor: Editor, where: Caret?, dataContext: DataContext?) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCodeActionHandler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCodeActionHandler.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.editor.actionSystem.EditorActionHandler
 import com.intellij.openapi.project.DumbAware
 import com.sourcegraph.cody.autocomplete.action.CodyAction
-import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
 
 class EditCodeAction : EditorAction(EditCodeActionHandler()), CodyAction, DumbAware
@@ -17,8 +16,7 @@ class EditCodeActionHandler : EditorActionHandler() {
   private val logger = Logger.getInstance(EditCodeActionHandler::class.java)
 
   override fun isEnabledForCaret(editor: Editor, caret: Caret, dataContext: DataContext?): Boolean {
-    return CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
-        ConfigUtil.isExperimentalInlineEditEnabled()
+    return CodyEditorUtil.isEditorValidForAutocomplete(editor)
   }
 
   override fun doExecute(editor: Editor, where: Caret?, dataContext: DataContext?) {

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -130,10 +130,6 @@ object ConfigUtil {
   @JvmStatic fun isCodyDebugEnabled(): Boolean = CodyApplicationSettings.instance.isCodyDebugEnabled
 
   @JvmStatic
-  fun isExperimentalInlineEditEnabled(): Boolean =
-      CodyApplicationSettings.instance.isCodyExperimentalInlineEditEnabled
-
-  @JvmStatic
   fun isCodyVerboseDebugEnabled(): Boolean =
       CodyApplicationSettings.instance.isCodyVerboseDebugEnabled
 


### PR DESCRIPTION
We now have an environment-variable based feature flag, so the setting is no longer needed nor helpful.

## Test plan

Locally tested, and all unit tests pass. This work is helping speed up delivery of the integration tests.
