### PR TITLE
Refactor restore logic

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.agent
 
 import com.sourcegraph.cody.agent.protocol.*
+import com.sourcegraph.cody.chat.ConnectionId
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
@@ -73,11 +74,11 @@ interface CodyAgentServer {
   @JsonRequest("command/execute")
   fun commandExecute(params: CommandExecuteParams): CompletableFuture<Any?>
 
-  @JsonRequest("commands/explain") fun commandsExplain(): CompletableFuture<String>
+  @JsonRequest("commands/explain") fun commandsExplain(): CompletableFuture<ConnectionId>
 
-  @JsonRequest("commands/test") fun commandsTest(): CompletableFuture<String>
+  @JsonRequest("commands/test") fun commandsTest(): CompletableFuture<ConnectionId>
 
-  @JsonRequest("commands/smell") fun commandsSmell(): CompletableFuture<String>
+  @JsonRequest("commands/smell") fun commandsSmell(): CompletableFuture<ConnectionId>
 
   @JsonRequest("commands/document") fun commandsDocument(): CompletableFuture<EditTask>
 
@@ -92,7 +93,8 @@ interface CodyAgentServer {
   @JsonRequest("chat/models")
   fun chatModels(params: ChatModelsParams): CompletableFuture<ChatModelsResponse>
 
-  @JsonRequest("chat/restore") fun chatRestore(params: ChatRestoreParams): CompletableFuture<String>
+  @JsonRequest("chat/restore")
+  fun chatRestore(params: ChatRestoreParams): CompletableFuture<ConnectionId>
 
   @JsonRequest("attribution/search")
   fun attributionSearch(


### PR DESCRIPTION
This is a minor refactor needed for https://github.com/sourcegraph/jetbrains/pull/1096.

It extracts the chat restore logic so it is doable to send the restore request without restoring the full session (with panels, etc).

## Test plan
1. Restore works properly
