### PR TITLE
Add repo dialog will accept repo names which don't contain a /

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/AddRepositoryDialog.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/AddRepositoryDialog.kt
@@ -36,8 +36,34 @@ class AddRepositoryDialog(
     setValidationDelay(100)
   }
 
+  private var validatedInput: String? = null
+  private var validatedRepoName: CodebaseName? = null
+
+  /**
+   * Converts [rawInput] to a repo name. If a matching remote repository exists, returns the
+   * repo name, otherwise `null`.
+   */
+  @Synchronized
+  fun validateRepoExists(rawInput: String): CodebaseName? {
+    if (rawInput == validatedInput) {
+      return validatedRepoName
+    }
+    validatedInput = rawInput
+    val candidates = mutableListOf(CodebaseName(rawInput))
+    try {
+      candidates.add(convertGitCloneURLToCodebaseNameOrError(rawInput))
+    } catch (e: Exception) {
+      // We will validate only the raw input, as-is.
+    }
+    val repos = RemoteRepoUtils.getRepositories(project, candidates)
+      .completeOnTimeout(emptyList(), 15, TimeUnit.SECONDS)
+      .get()
+    validatedRepoName = repos.firstOrNull()?.let { CodebaseName(it.name) }
+    return validatedRepoName
+  }
+
   override fun doValidateAll(): List<ValidationInfo> {
-    val text = repoUrlInputField.text.lowercase()
+    val text = repoUrlInputField.text
 
     fun validateNonEmpty() =
         DialogValidationUtils.custom(
@@ -46,33 +72,18 @@ class AddRepositoryDialog(
               text.isNotBlank()
             }
 
-    fun validateValidUrl() =
-        DialogValidationUtils.custom(
-            repoUrlInputField,
-            CodyBundle.getString("context-panel.add-repo-dialog.error-invalid-url")) {
-              val url = if (text.startsWith("http")) text else "http://$text"
-              runCatching { URL(url) }.isSuccess
-            }
-
     fun validateRepoExists() =
         DialogValidationUtils.custom(
             repoUrlInputField,
             CodyBundle.getString("context-panel.add-repo-dialog.error-no-repo")) {
-              val codebaseName =
-                  runCatching { convertGitCloneURLToCodebaseNameOrError(text) }.getOrNull()
-              codebaseName ?: return@custom false
-              !RemoteRepoUtils.getRepositories(project, listOf(codebaseName))
-                  .completeOnTimeout(null, 2, TimeUnit.SECONDS)
-                  .get()
-                  .isNullOrEmpty()
+              validateRepoExists(text) != null
             }
 
     fun validateRepoNotAddedYet() =
         DialogValidationUtils.custom(
             repoUrlInputField,
             CodyBundle.getString("context-panel.add-repo-dialog.error-repo-already-added")) {
-              val codebaseName =
-                  runCatching { convertGitCloneURLToCodebaseNameOrError(text) }.getOrNull()
+              val codebaseName = runCatching { validateRepoExists(text) }.getOrNull()
               remoteContextNode
                   .children()
                   .toList()
@@ -82,9 +93,8 @@ class AddRepositoryDialog(
 
     return listOfNotNull(
         validateNonEmpty()
-            ?: validateValidUrl()
-            ?: validateRepoNotAddedYet()
-            ?: validateRepoExists())
+            ?: validateRepoExists()
+            ?: validateRepoNotAddedYet())
   }
 
   override fun getValidationThreadToUse(): Alarm.ThreadToUse {
@@ -92,7 +102,8 @@ class AddRepositoryDialog(
   }
 
   override fun doOKAction() {
-    runCatching { convertGitCloneURLToCodebaseNameOrError(repoUrlInputField.text.lowercase()) }
+    // validateRepoExists caches the validation result, so this should not fail.
+    runCatching { validateRepoExists(repoUrlInputField.text) }
         .getOrNull()
         ?.let { codebaseName -> addAction(codebaseName) }
     close(OK_EXIT_CODE, true)

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -114,4 +114,13 @@ class ConvertUtilTest : TestCase() {
                 "git@github.com:philipp-spiess/philippspiess.com.git")
             .value)
   }
+
+  // sourcegraph/jetbrains#1194 the add repository dialog has a fallback when the user enters a repo name
+  // instead of a clone URL. If changing the failure behavior here, ensure the add repository dialog can still
+  // add "literal" repo names successfully.
+  fun `converting "URLs" without protocols, paths should throw`() {
+    assertThrows(Exception::class.java, "Cody could not extract repo name from clone URL host") {
+      convertGitCloneURLToCodebaseNameOrError("cool-repo-name")
+    }
+  }
 }

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -115,8 +115,10 @@ class ConvertUtilTest : TestCase() {
             .value)
   }
 
-  // sourcegraph/jetbrains#1194 the add repository dialog has a fallback when the user enters a repo name
-  // instead of a clone URL. If changing the failure behavior here, ensure the add repository dialog can still
+  // sourcegraph/jetbrains#1194 the add repository dialog has a fallback when the user enters a repo
+  // name
+  // instead of a clone URL. If changing the failure behavior here, ensure the add repository dialog
+  // can still
   // add "literal" repo names successfully.
   fun `converting "URLs" without protocols, paths should throw`() {
     assertThrows(Exception::class.java, "Cody could not extract repo name from clone URL host") {

--- a/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/vcs/ConvertUtilTest.kt
@@ -116,10 +116,8 @@ class ConvertUtilTest : TestCase() {
   }
 
   // sourcegraph/jetbrains#1194 the add repository dialog has a fallback when the user enters a repo
-  // name
-  // instead of a clone URL. If changing the failure behavior here, ensure the add repository dialog
-  // can still
-  // add "literal" repo names successfully.
+  // name instead of a clone URL. If changing the failure behavior here, ensure the add repository
+  // dialog can still add "literal" repo names successfully.
   fun `converting "URLs" without protocols, paths should throw`() {
     assertThrows(Exception::class.java, "Cody could not extract repo name from clone URL host") {
       convertGitCloneURLToCodebaseNameOrError("cool-repo-name")


### PR DESCRIPTION
This speculatively asks the remote to match the raw user input *and* the user input with the clone URL to repo name heuristic applied to it.

VSCode does not have this issue because repos are picked from a list retrieved from the remote, instead of input manually.

Fixes #1194

## Test plan

Tested manually:

- Breaking in `validateRepoExists` and check that we do fetch repo IDs for repo names without `/`, eg `foo`
- Check remotes like `ssh@github.com:sourcegraph/jetbrains` still work
- Check duplicate checks are still insensitive to exact input syntax, eg `ssh@github.com:sourcegraph/jetbrains` is detected as a duplicate of `github:sourcegraph/jetbrains` and `https://github.com/sourcegraph/jetbrains.git`, etc.