### PR TITLE
Fix fixups callbacks and lifecycle management

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=6b36b9abaf161277f4b7783649c2617e2dd1f97d
+cody.commit=3830c3addf712d57b84390cf464844827def44b1

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -2,11 +2,12 @@ package com.sourcegraph.cody.agent;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.editor.Editor;
-import com.sourcegraph.cody.agent.protocol.*;
+import com.sourcegraph.cody.agent.protocol.DebugMessage;
+import com.sourcegraph.cody.agent.protocol.EditTask;
+import com.sourcegraph.cody.agent.protocol.TextDocumentEditParams;
+import com.sourcegraph.cody.agent.protocol.WorkspaceEditParams;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.jetbrains.annotations.NotNull;
@@ -21,96 +22,46 @@ public class CodyAgentClient {
 
   private static final Logger logger = Logger.getInstance(CodyAgentClient.class);
 
-  @Nullable public Editor editor;
-
   // Callback that is invoked when the agent sends a "chat/updateMessageInProgress" notification.
-  @Nullable public Consumer<WebviewPostMessageParams> onNewMessage;
+  @Nullable Consumer<WebviewPostMessageParams> onNewMessage;
 
   // Callback that is invoked when the agent sends a "setConfigFeatures" message.
-  @Nullable public ConfigFeaturesObserver onSetConfigFeatures;
+  @Nullable ConfigFeaturesObserver onSetConfigFeatures;
 
   // Callback that is invoked on webview messages which aren't handled by onNewMessage or
   // onSetConfigFeatures
-  @Nullable public Consumer<WebviewPostMessageParams> onReceivedWebviewMessage;
+  @Nullable Consumer<WebviewPostMessageParams> onReceivedWebviewMessage;
 
   // Callback for the "editTask/didUpdate" notification from the agent.
-  @Nullable private Consumer<EditTask> onEditTaskDidUpdate;
+  @Nullable Consumer<EditTask> onEditTaskDidUpdate;
 
   // Callback for the "editTask/didDelete" notification from the agent.
-  @Nullable private Consumer<EditTask> onEditTaskDidDelete;
+  @Nullable Consumer<EditTask> onEditTaskDidDelete;
 
   // Callback for the "textDocument/edit" request from the agent.
-  @Nullable private Consumer<TextDocumentEditParams> onTextDocumentEdit;
+  @Nullable Consumer<TextDocumentEditParams> onTextDocumentEdit;
 
   // Callback for the "workspace/edit" request from the agent.
-  @Nullable private Consumer<WorkspaceEditParams> onWorkspaceEdit;
-
-  public void setOnEditTaskDidUpdate(@Nullable Consumer<EditTask> callback) {
-    onEditTaskDidUpdate = callback;
-  }
-
-  public void setOnEditTaskDidDelete(@Nullable Consumer<EditTask> callback) {
-    onEditTaskDidDelete = callback;
-  }
+  @Nullable Consumer<WorkspaceEditParams> onWorkspaceEdit;
 
   @JsonNotification("editTask/didUpdate")
-  public void editTaskDidUpdate(EditTask params) {
-    onEventThread(
-        () -> {
-          if (onEditTaskDidUpdate != null) {
-            onEditTaskDidUpdate.accept(params);
-          } else {
-            logger.warn("No callback registered for editTask/didUpdate");
-          }
-          return null;
-        });
+  public CompletableFuture<Void> editTaskDidUpdate(EditTask params) {
+    return acceptOnEventThread("editTask/didUpdate", onEditTaskDidUpdate, params);
   }
 
   @JsonNotification("editTask/didDelete")
-  public void editTaskDidDelete(EditTask params) {
-    onEventThread(
-        () -> {
-          if (onEditTaskDidDelete != null) {
-            onEditTaskDidDelete.accept(params);
-          } else {
-            logger.warn("No callback registered for editTask/didDelete");
-          }
-          return null;
-        });
-  }
-
-  public void setOnTextDocumentEdit(@Nullable Consumer<TextDocumentEditParams> callback) {
-    onTextDocumentEdit = callback;
+  public CompletableFuture<Void> editTaskDidDelete(EditTask params) {
+    return acceptOnEventThread("editTask/didDelete", onEditTaskDidDelete, params);
   }
 
   @JsonRequest("textDocument/edit")
-  public CompletableFuture<Boolean> textDocumentEdit(TextDocumentEditParams params) {
-    return onEventThread(
-        () -> {
-          if (onTextDocumentEdit != null) {
-            onTextDocumentEdit.accept(params);
-          } else {
-            logger.warn("No callback registered for textDocument/edit");
-          }
-          return true;
-        });
-  }
-
-  public void setOnWorkspaceEdit(@Nullable Consumer<WorkspaceEditParams> callback) {
-    onWorkspaceEdit = callback;
+  public CompletableFuture<Void> textDocumentEdit(TextDocumentEditParams params) {
+    return acceptOnEventThread("textDocument/edit", onTextDocumentEdit, params);
   }
 
   @JsonRequest("workspace/edit")
-  public CompletableFuture<Boolean> workspaceEdit(WorkspaceEditParams params) {
-    return onEventThread(
-        () -> {
-          if (onWorkspaceEdit != null) {
-            onWorkspaceEdit.accept(params);
-          } else {
-            logger.warn("No callback registered for workspace/edit");
-          }
-          return true;
-        });
+  public CompletableFuture<Void> workspaceEdit(WorkspaceEditParams params) {
+    return acceptOnEventThread("workspace/edit", onWorkspaceEdit, params);
   }
 
   /**
@@ -118,13 +69,19 @@ public class CodyAgentClient {
    * helper for handlers that require access to the IntelliJ editor, for example to read the text
    * contents of the open editor.
    */
-  private <T> @NotNull CompletableFuture<T> onEventThread(Supplier<T> handler) {
-    CompletableFuture<T> result = new CompletableFuture<>();
+  private <T> @NotNull CompletableFuture<Void> acceptOnEventThread(
+      String name, @Nullable Consumer<T> callback, T params) {
+    CompletableFuture<Void> result = new CompletableFuture<>();
     ApplicationManager.getApplication()
         .invokeLater(
             () -> {
               try {
-                result.complete(handler.get());
+                if (callback != null) {
+                  callback.accept(params);
+                  result.complete(null);
+                } else {
+                  result.completeExceptionally(new Exception("No callback registered for " + name));
+                }
               } catch (Exception e) {
                 result.completeExceptionally(e);
               }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyFileEditorListener
 import com.sourcegraph.cody.chat.AgentChatSessionService
 import com.sourcegraph.cody.config.CodyApplicationSettings
+import com.sourcegraph.cody.edit.FixupService
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
@@ -40,6 +41,24 @@ class CodyAgentService(project: Project) : Disposable {
               .getSession(params.id)
               ?.receiveWebviewExtensionMessage(params.message)
         }
+      }
+
+      agent.client.onEditTaskDidUpdate = Consumer { task ->
+        FixupService.getInstance(project).getSessionForTask(task)?.update(task)
+      }
+
+      agent.client.onEditTaskDidDelete = Consumer { task ->
+        FixupService.getInstance(project).getSessionForTask(task)?.taskDeleted()
+      }
+
+      agent.client.onWorkspaceEdit = Consumer { params ->
+        // TODO: We should change the protocol and send `taskId` as part of `WorkspaceEditParam`
+        // and then use method like `getSessionForTask` instead of this one
+        FixupService.getInstance(project).getActiveSession()?.performWorkspaceEdit(params)
+      }
+
+      agent.client.onTextDocumentEdit = Consumer { params ->
+        // TODO: This one is missing
       }
 
       if (!project.isDisposed) {

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CodyAgentClientTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CodyAgentClientTest.kt
@@ -1,8 +1,7 @@
-package com.sourcegraph.cody.cody.agent
+package com.sourcegraph.cody.agent
 
 import com.intellij.testFramework.PlatformTestUtil
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import com.sourcegraph.cody.agent.*
 import java.util.concurrent.locks.ReentrantLock
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -15,6 +14,7 @@ class CodyAgentClientTest : BasePlatformTestCase() {
   }
 
   @Volatile var lastMessage: ConfigFeatures? = null
+
   // Use lock/condition to synchronize between observer being invoked
   // and the test being able to assert.
   val lock = ReentrantLock()

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
@@ -1,8 +1,5 @@
-package com.sourcegraph.cody.cody.agent
+package com.sourcegraph.cody.agent
 
-import com.sourcegraph.cody.agent.ConfigFeatures
-import com.sourcegraph.cody.agent.ConfigFeaturesObserver
-import com.sourcegraph.cody.agent.CurrentConfigFeatures
 import java.util.concurrent.CopyOnWriteArrayList
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.until


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1136

## Changes

* Callbacks initialization moved to `onStartup` method so it will survive agent restarts
* Minor cleanup and refactoring of code structure

## Test plan

Manual testing