### PR TITLE
Switch to `chatID`-agnostic `chat/models` API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=8f8218cfb76689e195d3d80fbd6adb14458f3396
+cody.commit=89722171622c5e6df5356b1dd4fad7ad9afe18d1

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/CancelParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/CancelParams.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class CancelParams(val id: String)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsParams.kt
@@ -1,3 +1,8 @@
 package com.sourcegraph.cody.agent.protocol
 
-data class ChatModelsParams(val id: String)
+data class ChatModelsParams(val modelUsage: String)
+
+enum class ModelUsage(val value: String) {
+  CHAT("chat"),
+  EDIT("edit")
+}

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -4,7 +4,6 @@ import com.sourcegraph.cody.Icons
 import javax.swing.Icon
 
 data class ChatModelsResponse(val models: List<ChatModelProvider>) {
-
   data class ChatModelProvider(
       val default: Boolean,
       val codyProOnly: Boolean,

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSetModelParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatSetModelParams.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class ChatSetModelParams(val id: String, val model: String)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ExportChatsBackgroundable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ExportChatsBackgroundable.kt
@@ -7,9 +7,12 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.agent.protocol.ChatMessage
+import com.sourcegraph.cody.agent.protocol.Speaker
 import com.sourcegraph.cody.chat.AgentChatSession.Companion.restoreChatSession
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.MessageState
 import com.sourcegraph.cody.initialization.EndOfTrialNotificationScheduler
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
@@ -35,7 +38,19 @@ class ExportChatsBackgroundable(
             .filter { chat -> if (internalId != null) chat.internalId == internalId else true }
 
     chats.forEachIndexed { index, chatState ->
-      restoreChatSession(agent, chatState)
+      val chatMessages =
+          chatState.messages.map { message ->
+            val parsed =
+                when (val speaker = message.speaker) {
+                  MessageState.SpeakerState.HUMAN -> Speaker.HUMAN
+                  MessageState.SpeakerState.ASSISTANT -> Speaker.ASSISTANT
+                  else -> error("unrecognized speaker $speaker")
+                }
+
+            ChatMessage(speaker = parsed, message.text)
+          }
+
+      restoreChatSession(agent, chatMessages, chatModelProvider = null, chatState.internalId!!)
       indicator.fraction = ((index + 1.0) / (chats.size + 1.0))
 
       if (indicator.isCanceled) {


### PR DESCRIPTION
Cody part: https://github.com/sourcegraph/cody/pull/3588

## Test plan
1. LLM selection works
2. Chat restore works (proper llm is selected and used)
