### PR TITLE
Add toggle action for enabling inline edits

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -22,6 +22,7 @@ data class CodyApplicationSettings(
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = true,
+    var isInlineEditionEnabled: Boolean = false
 ) : PersistentStateComponent<CodyApplicationSettings> {
   override fun getState(): CodyApplicationSettings = this
 
@@ -41,6 +42,8 @@ data class CodyApplicationSettings(
     this.isOnboardingGuidanceDismissed = state.isOnboardingGuidanceDismissed
     this.shouldAcceptNonTrustedCertificatesAutomatically =
         state.shouldAcceptNonTrustedCertificatesAutomatically
+    this.shouldCheckForUpdates = state.shouldCheckForUpdates
+    this.isInlineEditionEnabled = state.isInlineEditionEnabled
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EnableInlineEditsAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EnableInlineEditsAction.kt
@@ -1,0 +1,15 @@
+package com.sourcegraph.cody.edit
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareToggleAction
+import com.sourcegraph.cody.config.CodyApplicationSettings
+
+class EnableInlineEditsAction : DumbAwareToggleAction() {
+  override fun isSelected(e: AnActionEvent): Boolean {
+    return CodyApplicationSettings.instance.isInlineEditionEnabled
+  }
+
+  override fun setSelected(e: AnActionEvent, state: Boolean) {
+    CodyApplicationSettings.instance.isInlineEditionEnabled = state
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.startup.StartupActivity
 import com.sourcegraph.cody.CodyFocusChangeListener
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.auth.SelectOneOfTheAccountsAsActive
+import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.config.SettingsMigration
 import com.sourcegraph.cody.config.ui.CheckUpdatesTask
 import com.sourcegraph.cody.statusbar.CodyStatusService
@@ -39,7 +40,8 @@ class PostStartupActivity : StartupActivity.DumbAware {
   // TODO: This should go away (along with the feature flag) once Inline Edits are stable/released.
   private fun initializeInlineEdits() {
     ApplicationManager.getApplication().invokeLater {
-      if (ConfigUtil.isFeatureFlagEnabled("cody.feature.inline-edits")) {
+      if (ConfigUtil.isFeatureFlagEnabled("cody.feature.inline-edits") ||
+          CodyApplicationSettings.instance.isInlineEditionEnabled) {
         val actionManager = ActionManager.getInstance()
         (actionManager.getAction("CodyEditorActions") as? DefaultActionGroup)?.apply {
           pushFrontAction(actionManager, "cody.documentCodeAction", this)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -220,14 +220,19 @@
 
         <!-- Inline editor actions -->
         <action
-            id="cody.editCodeAction"
-            class="com.sourcegraph.cody.edit.EditCodeAction"
-            text="Edit Code"/>
+                id="cody.editCodeAction"
+                class="com.sourcegraph.cody.edit.EditCodeAction"
+                text="Edit Code"/>
 
         <action
-            id="cody.documentCodeAction"
-            class="com.sourcegraph.cody.edit.DocumentCodeAction"
-            text="Document Code"/>
+                id="cody.documentCodeAction"
+                class="com.sourcegraph.cody.edit.DocumentCodeAction"
+                text="Document Code"/>
+
+        <action
+                id="cody.enableInlineEditsActions"
+                class="com.sourcegraph.cody.edit.EnableInlineEditsAction"
+                text="Enable Inline Edits"/>
 
         <!-- TODO: Custom commands -->
 


### PR DESCRIPTION
## Changes

I added action which allow user to enable inline edits.
To do it:
1. Hit `shift shift`
2. Start typing "Enable Inline Edits"
3. When "Enable Inline Edits" action will be visible and selected hit `Enter` to toggle it on
4. Restart IDE

You need to do it only once, your choice wll be saved for later.
You can disable it the same way.

## Test plan

Manual verification that it works, it's internal action

![image](https://github.com/sourcegraph/jetbrains/assets/1519649/f894cadc-1000-4937-ac1f-a2b4c7d10878)
