### PR TITLE
Set default LLM to the last one used

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -14,6 +14,7 @@ import com.sourcegraph.cody.chat.ChatSession
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.context.ui.EnhancedContextPanel
 import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.LLMState
 import com.sourcegraph.cody.ui.ChatScrollPane
 import com.sourcegraph.cody.vscode.CancellationToken
 import java.awt.BorderLayout
@@ -109,6 +110,7 @@ class ChatPanel(
     }
 
     HistoryService.getInstance(project)
-        .updateChatLlmProvider(chatSession.getInternalId(), chatModelProvider)
+        .updateChatLlmProvider(
+            chatSession.getInternalId(), LLMState.fromChatModel(chatModelProvider))
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -48,7 +48,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, val di
       LlmDropdown(
           modelUsage = ModelUsage.EDIT,
           project = controller.project,
-          onSetSelectedItem = controller::setCurrentModel,
+          onSetSelectedItem = {},
           chatModelProviderFromState = null)
 
   // History navigation helper
@@ -181,9 +181,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, val di
     @RequiresEdt
     override fun doOKAction() {
       val text = instructionsField.text
-      val chatModelProvider = llmDropdown.item
       super.doOKAction()
-      controller.setCurrentModel(chatModelProvider)
       if (text.isNotBlank()) {
         addToHistory(text)
         val project = editor.project
@@ -193,7 +191,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, val di
           return
         }
         controller.addSession(
-            EditSession(controller, editor, project, editor.document, text, chatModelProvider))
+            EditSession(controller, editor, project, editor.document, text, llmDropdown.item))
       }
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.EditTask
 import com.sourcegraph.config.ConfigUtil.isCodyEnabled
 import com.sourcegraph.utils.CodyEditorUtil
@@ -19,8 +18,6 @@ class FixupService(val project: Project) : Disposable {
   // We only use this for multiplexing task updates from the Agent to concurrent sessions.
   // TODO: Consider doing the multiplexing in CodyAgentClient instead.
   private var activeSessions: MutableMap<String, FixupSession> = mutableMapOf()
-
-  private var lastSelectedModel: ChatModelsResponse.ChatModelProvider? = null
 
   // Sessions for which we have not yet received a task ID, but may receive an edit anyway.
   private var pendingSessions: MutableSet<FixupSession> = mutableSetOf()
@@ -51,10 +48,6 @@ class FixupService(val project: Project) : Disposable {
       return false
     }
     return true
-  }
-
-  fun setCurrentModel(model: ChatModelsResponse.ChatModelProvider) {
-    lastSelectedModel = model
   }
 
   fun getLastPrompt(): String = lastPrompt

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.protocol.ChatMessage
-import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.Speaker
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.history.state.ChatState
@@ -29,17 +28,8 @@ class HistoryService(private val project: Project) :
   }
 
   @Synchronized
-  fun updateChatLlmProvider(
-      internalId: String,
-      chatModelProvider: ChatModelsResponse.ChatModelProvider
-  ) {
-    val found = getOrCreateChat(internalId)
-    found.llm =
-        LLMState().also {
-          it.model = chatModelProvider.model
-          it.title = chatModelProvider.title
-          it.provider = chatModelProvider.provider
-        }
+  fun updateChatLlmProvider(internalId: String, llmState: LLMState) {
+    getOrCreateChat(internalId).llm = llmState
   }
 
   @Synchronized
@@ -76,6 +66,20 @@ class HistoryService(private val project: Project) :
   @Synchronized
   fun getDefaultContextReadOnly(): EnhancedContextState? {
     return copyEnhancedContextState(state.defaultEnhancedContext)
+  }
+
+  @Synchronized
+  fun getDefaultLlm(): LLMState? {
+    val defaultLlm = LLMState()
+    defaultLlm.copyFrom(state.defaultLlm ?: return null)
+    return defaultLlm
+  }
+
+  @Synchronized
+  fun setDefaultLlm(defaultLlm: LLMState) {
+    val newDefaultLlm = LLMState()
+    newDefaultLlm.copyFrom(defaultLlm)
+    state.defaultLlm = newDefaultLlm
   }
 
   @Synchronized

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
@@ -7,6 +7,8 @@ class HistoryState : BaseState() {
 
   @get:OptionTag(tag = "chats", nameAttribute = "") var chats: MutableList<ChatState> by list()
 
+  @get:OptionTag(tag = "defaultLlm", nameAttribute = "") var defaultLlm: LLMState? by property()
+
   @get:OptionTag(tag = "defaultEnhancedContext", nameAttribute = "")
   var defaultEnhancedContext: EnhancedContextState? by property()
 }

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -3,10 +3,23 @@ package com.sourcegraph.cody.history.state
 import com.intellij.openapi.components.BaseState
 import com.intellij.util.xmlb.annotations.OptionTag
 import com.intellij.util.xmlb.annotations.Tag
+import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 
 @Tag("llm")
 class LLMState : BaseState() {
   @get:OptionTag(tag = "model", nameAttribute = "") var model: String? by string()
+
   @get:OptionTag(tag = "title", nameAttribute = "") var title: String? by string()
+
   @get:OptionTag(tag = "provider", nameAttribute = "") var provider: String? by string()
+
+  companion object {
+    fun fromChatModel(chatModelProvider: ChatModelsResponse.ChatModelProvider): LLMState {
+      return LLMState().also {
+        it.model = chatModelProvider.model
+        it.title = chatModelProvider.title
+        it.provider = chatModelProvider.provider
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Changes

User LLM selection is now saved and used for subsequest chats/edits.
TODO: new API for commands is needed to suport the same.

## Test plan

Manual tests according to QA guide