### PR TITLE
Change release script to determine next version based on tags

### DIFF
--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -13,10 +13,10 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-LAST_MAJOR_MINOR_ZERO_RELEASE=$(gh release list --repo sourcegraph/jetbrains --limit 20 --exclude-drafts | sed 's/Latest//' | sed 's/Pre-release//' | awk '$2 ~ /v[0-9]+\.[0-9]+\.[0-9]+$/ { print $2, $3; exit }')
-MAJOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f1)
-MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f2)
-PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | awk '{ print $1 }' | sed 's/v//' | cut -d. -f3)
+LAST_MAJOR_MINOR_ZERO_RELEASE=$(git tag -l | grep "v\d*\\.\d*\\.\d*" | uniq | sort | tail -1)
+MAJOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f1)
+MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f2)
+PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f3)
 
 NEXT_RELEASE_ARG="$1"
 # Check the argument and take appropriate action

--- a/scripts/push-git-tag-for-next-release.sh
+++ b/scripts/push-git-tag-for-next-release.sh
@@ -53,4 +53,4 @@ fi
 bash "$SCRIPT_DIR/verify-release.sh"
 TAG="v$NEXT_VERSION"
 echo "$TAG"
-git tag -fa "$TAG" -m "$TAG" && git push -f origin "$TAG"
+git tag -a "$TAG" -m "$TAG" && git push origin "$TAG"


### PR DESCRIPTION
## Changes

1. Do not force push to release tags/branches (if you need to changes something after release use patch release)
2. Do not use official GH releases to determine versions, as we no longer create those for the QA/nightly

## Test plan

N/A