### PR TITLE
Update `updatedAtTime` only on sending a message instead of receiving it (fixes #1248)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -17,8 +17,8 @@ import com.sourcegraph.cody.commands.ui.CommandsTabPanel
 import com.sourcegraph.cody.config.CodyAccount
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.history.ChatHistoryPanel
 import com.sourcegraph.cody.history.HistoryService
-import com.sourcegraph.cody.history.HistoryTree
 import com.sourcegraph.cody.history.state.ChatState
 import java.awt.CardLayout
 import javax.swing.JComponent
@@ -32,7 +32,7 @@ class CodyToolWindowContent(private val project: Project) {
 
   private var codyOnboardingGuidancePanel: CodyOnboardingGuidancePanel? = null
   private val signInWithSourcegraphPanel = SignInWithSourcegraphPanel(project)
-  private val historyTree = HistoryTree(project, ::selectChat, ::removeChat, ::removeAllChats)
+  private val chatHistoryPanel = ChatHistoryPanel(project, ::selectChat, ::removeChat, ::removeAllChats)
   private val tabbedPane = TabbedPaneWrapper(CodyAgentService.getInstance(project))
   private val currentChatSession: AtomicReference<AgentChatSession?> = AtomicReference(null)
 
@@ -54,7 +54,7 @@ class CodyToolWindowContent(private val project: Project) {
 
   init {
     tabbedPane.insertSimpleTab("Chat", chatContainerPanel, CHAT_TAB_INDEX)
-    tabbedPane.insertSimpleTab("Chat History", historyTree, HISTORY_TAB_INDEX)
+    tabbedPane.insertSimpleTab("Chat History", chatHistoryPanel, HISTORY_TAB_INDEX)
     tabbedPane.insertSimpleTab("Commands", commandsPanel, COMMANDS_TAB_INDEX)
 
     allContentPanel.add(tabbedPane.component, MAIN_PANEL, CHAT_PANEL_INDEX)
@@ -99,7 +99,7 @@ class CodyToolWindowContent(private val project: Project) {
     }
   }
 
-  @RequiresEdt fun refreshHistoryTree() = historyTree.rebuildTree()
+  @RequiresEdt fun refreshChatHistoryPanel() = chatHistoryPanel.rebuildTree()
 
   @RequiresEdt
   fun refreshPanelsVisibility() {

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -32,7 +32,8 @@ class CodyToolWindowContent(private val project: Project) {
 
   private var codyOnboardingGuidancePanel: CodyOnboardingGuidancePanel? = null
   private val signInWithSourcegraphPanel = SignInWithSourcegraphPanel(project)
-  private val chatHistoryPanel = ChatHistoryPanel(project, ::selectChat, ::removeChat, ::removeAllChats)
+  private val chatHistoryPanel =
+      ChatHistoryPanel(project, ::selectChat, ::removeChat, ::removeAllChats)
   private val tabbedPane = TabbedPaneWrapper(CodyAgentService.getInstance(project))
   private val currentChatSession: AtomicReference<AgentChatSession?> = AtomicReference(null)
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -253,10 +253,6 @@ private constructor(
 
           ChatMessage(speaker = parsed, message.text)
         }
-    this.messages.addAll(chatMessages)
-    chatMessages.forEachIndexed { index, chatMessage ->
-      chatPanel.addOrUpdateMessage(chatMessage, index)
-    }
 
     val newConnectionId =
         restoreChatSession(agent, chatMessages, chatModelProviderFromState, state.internalId!!)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -82,7 +82,7 @@ private constructor(
             text,
             displayText,
         )
-    addMessageAtIndex(humanMessage, index = messages.count())
+    addMessageAtIndex(humanMessage, index = messages.count(), shouldUpdateTime = true)
 
     val responsePlaceholder =
         ChatMessage(
@@ -220,7 +220,11 @@ private constructor(
   }
 
   @RequiresEdt
-  private fun addMessageAtIndex(message: ChatMessage, index: Int) {
+  private fun addMessageAtIndex(
+      message: ChatMessage,
+      index: Int,
+      shouldUpdateTime: Boolean = false
+  ) {
     val messageToUpdate = messages.getOrNull(index)
     if (messageToUpdate != null) {
       messages[index] = message
@@ -229,7 +233,7 @@ private constructor(
     }
 
     chatPanel.addOrUpdateMessage(message, index)
-    HistoryService.getInstance(project).updateChatMessages(internalId, messages)
+    HistoryService.getInstance(project).updateChatMessages(internalId, messages, shouldUpdateTime)
   }
 
   @RequiresEdt
@@ -295,18 +299,21 @@ private constructor(
           })
 
       chatSession.addMessageAtIndex(
-          ChatMessage(
-              Speaker.HUMAN,
-              commandId.displayName,
-          ),
-          chatSession.messages.count())
+          message =
+              ChatMessage(
+                  speaker = Speaker.HUMAN,
+                  text = commandId.displayName,
+              ),
+          index = chatSession.messages.count(),
+          shouldUpdateTime = true)
       chatSession.addMessageAtIndex(
-          ChatMessage(
-              Speaker.ASSISTANT,
-              text = "",
-              displayText = "",
-          ),
-          chatSession.messages.count())
+          message =
+              ChatMessage(
+                  Speaker.ASSISTANT,
+                  text = "",
+                  displayText = "",
+              ),
+          index = chatSession.messages.count())
       AgentChatSessionService.getInstance(project).addSession(chatSession)
       return chatSession
     }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -82,7 +82,7 @@ private constructor(
             text,
             displayText,
         )
-    addMessageAtIndex(humanMessage, index = messages.count(), shouldUpdateTime = true)
+    addMessageAtIndex(humanMessage, index = messages.count())
 
     val responsePlaceholder =
         ChatMessage(
@@ -220,11 +220,7 @@ private constructor(
   }
 
   @RequiresEdt
-  private fun addMessageAtIndex(
-      message: ChatMessage,
-      index: Int,
-      shouldUpdateTime: Boolean = false
-  ) {
+  private fun addMessageAtIndex(message: ChatMessage, index: Int) {
     val messageToUpdate = messages.getOrNull(index)
     if (messageToUpdate != null) {
       messages[index] = message
@@ -233,7 +229,7 @@ private constructor(
     }
 
     chatPanel.addOrUpdateMessage(message, index)
-    HistoryService.getInstance(project).updateChatMessages(internalId, messages, shouldUpdateTime)
+    HistoryService.getInstance(project).updateChatMessages(internalId, messages)
   }
 
   @RequiresEdt
@@ -257,6 +253,11 @@ private constructor(
 
           ChatMessage(speaker = parsed, message.text)
         }
+    this.messages.addAll(chatMessages)
+    chatMessages.forEachIndexed { index, chatMessage ->
+      chatPanel.addOrUpdateMessage(chatMessage, index)
+    }
+
     val newConnectionId =
         restoreChatSession(agent, chatMessages, chatModelProviderFromState, state.internalId!!)
     connectionId.getAndSet(newConnectionId)
@@ -304,8 +305,7 @@ private constructor(
                   speaker = Speaker.HUMAN,
                   text = commandId.displayName,
               ),
-          index = chatSession.messages.count(),
-          shouldUpdateTime = true)
+          index = chatSession.messages.count())
       chatSession.addMessageAtIndex(
           message =
               ChatMessage(

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -62,7 +62,7 @@ class SettingsMigration : Activity {
         .filter { it.accountId == null }
         .forEach { it.accountId = activeAccountId }
     // required because this activity is executed later than tool window creation
-    CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) { refreshHistoryTree() }
+    CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) { refreshChatHistoryPanel() }
   }
 
   private fun refreshAccountsIds(project: Project) {

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/AccountSettingChangeListener.kt
@@ -34,7 +34,7 @@ class AccountSettingChangeListener(project: Project) : ChangeListener(project) {
               CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
                 refreshPanelsVisibility()
                 refreshMyAccountTab()
-                refreshHistoryTree()
+                refreshChatHistoryPanel()
               }
             }
 

--- a/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
@@ -140,7 +140,9 @@ class ChatHistoryPanel(
       }
     } else {
       val currentPeriodText = DurationGroupFormatter.format(chat.getUpdatedTimeAt())
-      val currentPeriod = root.periods().find { it.periodText == currentPeriodText } ?: return
+      val currentPeriod =
+          root.periods().find { it.periodText == currentPeriodText }
+              ?: PeriodNode(currentPeriodText)
       val leafWithChangedPeriod =
           root
               .periods()

--- a/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
@@ -41,7 +41,7 @@ import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreePath
 import javax.swing.tree.TreeSelectionModel
 
-class HistoryTree(
+class ChatHistoryPanel(
     private val project: Project,
     private val onSelect: (ChatState) -> Unit,
     private val onRemove: (ChatState) -> Unit,

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -37,9 +37,17 @@ class HistoryService(private val project: Project) :
     val found = getOrCreateChat(internalId)
     if (found.messages.size < chatMessages.size) {
       found.setUpdatedTimeAt(LocalDateTime.now())
-      found.messages = chatMessages.map(::convertToMessageState).toMutableList()
-      synchronized(listeners) { listeners.forEach { it(found) } }
     }
+
+    chatMessages.map(::convertToMessageState).forEachIndexed { index, messageState ->
+      val messageToUpdate = found.messages.getOrNull(index)
+      if (messageToUpdate != null) {
+        found.messages[index] = messageState
+      } else {
+        found.messages.add(messageState)
+      }
+    }
+    synchronized(listeners) { listeners.forEach { it(found) } }
   }
 
   @Synchronized

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -37,9 +37,9 @@ class HistoryService(private val project: Project) :
     val found = getOrCreateChat(internalId)
     if (found.messages.size < chatMessages.size) {
       found.setUpdatedTimeAt(LocalDateTime.now())
+      found.messages = chatMessages.map(::convertToMessageState).toMutableList()
+      synchronized(listeners) { listeners.forEach { it(found) } }
     }
-    found.messages = chatMessages.map(::convertToMessageState).toMutableList()
-    synchronized(listeners) { listeners.forEach { it(found) } }
   }
 
   @Synchronized

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -33,10 +33,14 @@ class HistoryService(private val project: Project) :
   }
 
   @Synchronized
-  fun updateChatMessages(internalId: String, chatMessages: List<ChatMessage>) {
+  fun updateChatMessages(
+      internalId: String,
+      chatMessages: List<ChatMessage>,
+      shouldUpdateTime: Boolean
+  ) {
     val found = getOrCreateChat(internalId)
     found.messages = chatMessages.map(::convertToMessageState).toMutableList()
-    if (chatMessages.lastOrNull()?.speaker == Speaker.HUMAN) {
+    if (shouldUpdateTime) {
       found.setUpdatedTimeAt(LocalDateTime.now())
     }
     synchronized(listeners) { listeners.forEach { it(found) } }

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -33,16 +33,12 @@ class HistoryService(private val project: Project) :
   }
 
   @Synchronized
-  fun updateChatMessages(
-      internalId: String,
-      chatMessages: List<ChatMessage>,
-      shouldUpdateTime: Boolean
-  ) {
+  fun updateChatMessages(internalId: String, chatMessages: List<ChatMessage>) {
     val found = getOrCreateChat(internalId)
-    found.messages = chatMessages.map(::convertToMessageState).toMutableList()
-    if (shouldUpdateTime) {
+    if (found.messages.size < chatMessages.size) {
       found.setUpdatedTimeAt(LocalDateTime.now())
     }
+    found.messages = chatMessages.map(::convertToMessageState).toMutableList()
     synchronized(listeners) { listeners.forEach { it(found) } }
   }
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -70,7 +70,7 @@ UpgradeToCodyProNotification.title.upgrade=You've used up your autocompletes for
 UpgradeToCodyProNotification.title.explain=Thank you for using Cody so heavily today!
 UpgradeToCodyProNotification.content.upgrade=\
   <html>\
-    You''ve used all autocomplete suggestions for the month. \
+    You've used all autocomplete suggestions for the month. \
     Upgrade to Cody Pro for unlimited autocompletes, chats, and commands.<br><br>\
     (Already upgraded to Pro? Restart your IDE for changes to take effect)\
   </html>


### PR DESCRIPTION
Fixes #1248.

## Test plan

See the issue for specific steps.

1. Having two chats in the Chat History panel.
2. Restart IDE.
3. Go to Chat History panel and restore the older one.
4. Go to Chat History

Expected:
The restored chat remains as the last one in the list (it is not bumped to the top).
