### PR TITLE
add claude 3 as free default

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -467,7 +467,7 @@ To open the context menu:
 
 1. Login to Cody Free account
 2. Create new chat
-3. User doesn't see model dropdown
+3. User sees model dropdown, but non-default LLM is disabled
 4. Default model is Claude 3 Sonnet
 
 ### Pro account after trial

--- a/TESTING.md
+++ b/TESTING.md
@@ -443,16 +443,18 @@ To open the context menu:
 
 1. Login to Cody Pro account
 2. Create new chat
-3. User is able to change default LLM
-4. Change model to ChatGPT 4
-5. Send message
+3. Default model for new Pro users is Claude 3 Sonnet
+   - Default model for existing Pro users is their previously selected model
+4. User is able to change default LLM
+5. Change model to ChatGPT 4
+6. Send message
    > What model are you?
-6. User should get the response that model is ChatGPT
-7. Change account to different one and then back to your pro account
-8. Open `What model are you?` chat from the history
-9. Send again message
+7. User should get the response that model is ChatGPT
+8. Change account to different one and then back to your pro account
+9. Open `What model are you?` chat from the history
+10. Send again message
    > What model are you?
-10. User should again get the response that model is ChatGPT
+11. User should again get the response that model is ChatGPT
 
 #### Commands
 
@@ -466,6 +468,7 @@ To open the context menu:
 1. Login to Cody Free account
 2. Create new chat
 3. User doesn't see model dropdown
+4. Default model is Claude 3 Sonnet
 
 ### Pro account after trial
 


### PR DESCRIPTION
Adds Claude 3 Sonnet as the default model for Free users (and new Pro users). 

## Test plan

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
Passing CI