### PR TITLE
Add edit and document commands in the Commands tab

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
+++ b/src/main/java/com/sourcegraph/cody/CodyFileEditorListener.java
@@ -1,54 +1,48 @@
 package com.sourcegraph.cody;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.cody.agent.CodyAgent;
 import com.sourcegraph.cody.agent.CodyAgentCodebase;
 import com.sourcegraph.cody.agent.CodyAgentService;
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument;
-import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class CodyFileEditorListener implements FileEditorManagerListener {
   @Override
   public void fileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-    if (!ConfigUtil.isCodyEnabled()) {
-      return;
-    }
-
-    CodyAgentService.withAgent(
-        source.getProject(), agent -> fileOpened(source.getProject(), agent, file));
+    CodyAgentService.withAgent(source.getProject(), agent -> fileOpened(source, agent, file));
   }
 
   @Override
   public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-    if (!ConfigUtil.isCodyEnabled()) {
-      return;
-    }
-
+    var protocolTextFile = ProtocolTextDocument.fromVirtualFile(source, file);
     CodyAgentService.withAgent(
-        source.getProject(),
-        agent ->
-            agent.getServer().textDocumentDidClose(ProtocolTextDocument.fromVirtualFile(file)));
+        source.getProject(), agent -> agent.getServer().textDocumentDidClose(protocolTextFile));
   }
 
-  public static void fileOpened(Project project, CodyAgent codyAgent, @NotNull VirtualFile file) {
-    Document document =
-        ApplicationManager.getApplication()
-            .runReadAction(
-                (Computable<Document>) () -> FileDocumentManager.getInstance().getDocument(file));
-    if (document != null) {
-      ProtocolTextDocument textDocument =
-          ProtocolTextDocument.fromVirtualFile(file, document.getText());
-      codyAgent.getServer().textDocumentDidOpen(textDocument);
-    }
+  public static void fileOpened(
+      @NotNull FileEditorManager source, CodyAgent codyAgent, @NotNull VirtualFile file) {
+    var project = source.getProject();
+    ApplicationManager.getApplication()
+        .invokeLater(
+            () -> {
+              var textDocument = ProtocolTextDocument.fromVirtualFile(source, file);
+              codyAgent.getServer().textDocumentDidOpen(textDocument);
+              CodyAgentCodebase.getInstance(project).onFileOpened(file);
+            });
+  }
 
-    CodyAgentCodebase.getInstance(project).onFileOpened(project, file);
+  public static void editorChanged(@NotNull Editor editor) {
+    var project = editor.getProject();
+    var file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+    if (project != null && file != null) {
+      var fileEditorManager = FileEditorManager.getInstance(project);
+      CodyAgentService.withAgent(project, agent -> fileOpened(fileEditorManager, agent, file));
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentCodebase.kt
@@ -18,14 +18,14 @@ class CodyAgentCodebase(val project: Project) {
   private var inferredUrl: CompletableFuture<String> = CompletableFuture()
 
   init {
-    onFileOpened(project, null)
+    onFileOpened(null)
   }
 
   fun getUrl(): CompletableFuture<String> =
       if (settings.remoteUrl != null) CompletableFuture.completedFuture(settings.remoteUrl)
       else inferredUrl
 
-  fun onFileOpened(project: Project, file: VirtualFile?) {
+  fun onFileOpened(file: VirtualFile?) {
     ApplicationManager.getApplication().executeOnPooledThread {
       val repositoryName = RepoUtil.findRepositoryName(project, file)
       if (repositoryName != null && inferredUrl.getNow(null) != repositoryName) {

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -58,13 +58,14 @@ class CodyAgentService(project: Project) : Disposable {
       }
 
       agent.client.onTextDocumentEdit = Consumer { params ->
-        // TODO: This one is missing
+        FixupService.getInstance(project).getActiveSession()?.performInlineEdits(params.edits)
       }
 
       if (!project.isDisposed) {
         AgentChatSessionService.getInstance(project).restoreAllSessions(agent)
-        FileEditorManager.getInstance(project).openFiles.forEach { file ->
-          CodyFileEditorListener.fileOpened(project, agent, file)
+        val fileEditorManager = FileEditorManager.getInstance(project)
+        fileEditorManager.openFiles.forEach { file ->
+          CodyFileEditorListener.fileOpened(fileEditorManager, agent, file)
         }
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -1,5 +1,8 @@
 package com.sourcegraph.cody.agent.protocol
 
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.agent.protocol.util.Rfc3986UriEncoder
 
@@ -12,15 +15,33 @@ private constructor(
 
   companion object {
 
+    private fun getSelection(editor: Editor): Range? {
+      val selectionModel = editor.selectionModel
+      val selectionStartPosition =
+          selectionModel.selectionStartPosition?.let { editor.visualToLogicalPosition(it) }
+      val selectionEndPosition =
+          selectionModel.selectionEndPosition?.let { editor.visualToLogicalPosition(it) }
+      if (selectionStartPosition != null && selectionEndPosition != null) {
+        return Range(
+            Position(selectionStartPosition.line, selectionStartPosition.column),
+            Position(selectionEndPosition.line, selectionEndPosition.column))
+      }
+      val caret = editor.caretModel.allCarets.firstOrNull() ?: return null
+      val position = Position(caret.logicalPosition.line, caret.logicalPosition.column)
+      // A single-offset caret is a selection where end == start.
+      return Range(position, position)
+    }
+
     @JvmStatic
     @JvmOverloads
     fun fromVirtualFile(
+        fileEditorManager: FileEditorManager,
         file: VirtualFile,
-        content: String? = null,
-        selection: Range? = null
     ): ProtocolTextDocument {
       val rfc3986Uri = Rfc3986UriEncoder.encode(file.url)
-      return ProtocolTextDocument(rfc3986Uri, content, selection)
+      val text = FileDocumentManager.getInstance().getDocument(file)?.text
+      val selection = fileEditorManager.selectedTextEditor?.let { getSelection(it) }
+      return ProtocolTextDocument(rfc3986Uri, text, selection)
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -3,7 +3,6 @@ package com.sourcegraph.cody.chat.actions
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
-import com.sourcegraph.cody.autocomplete.CodyEditorFactoryListener
 import com.sourcegraph.cody.chat.AgentChatSession
 import com.sourcegraph.cody.commands.CommandId
 
@@ -12,12 +11,9 @@ abstract class BaseCommandAction : BaseChatAction() {
   abstract val myCommandId: CommandId
 
   override fun doAction(project: Project) {
-
     FileEditorManager.getInstance(project).selectedTextEditor?.let {
-      CodyEditorFactoryListener.Util.informAgentAboutEditorChange(it, hasFileChanged = false) {
-        CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
-          switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
-        }
+      CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
+        switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/commands/CommandId.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/commands/CommandId.kt
@@ -1,7 +1,9 @@
 package com.sourcegraph.cody.commands
 
-enum class CommandId(val displayName: String, val mnemonic: Char) {
-  Explain("Explain Code", 'E'),
-  Smell("Smell Code", 'S'),
-  Test("Generate Test", 'T')
+import java.awt.event.KeyEvent
+
+enum class CommandId(val displayName: String, val mnemonic: Int) {
+  Explain("Explain Code", KeyEvent.VK_E),
+  Smell("Smell Code", KeyEvent.VK_S),
+  Test("Generate Test", KeyEvent.VK_T)
 }

--- a/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
@@ -1,6 +1,12 @@
 package com.sourcegraph.cody.commands.ui
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.ex.ActionManagerEx
+import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBPanelWithEmptyText
@@ -20,7 +26,9 @@ class CommandsTabPanel(
 
   init {
     layout = BoxLayout(this, BoxLayout.Y_AXIS)
-    CommandId.values().forEach { command -> addButton(command) }
+    CommandId.values().forEach { command -> addCommandButton(command) }
+    addInlineEditActionButton("cody.editCodeAction")
+    addInlineEditActionButton("cody.documentCodyAction")
   }
 
   private fun executeCommandWithContext(commandId: CommandId) {
@@ -31,19 +39,34 @@ class CommandsTabPanel(
     }
   }
 
-  private fun addButton(commandId: CommandId) {
-    val button = JButton(commandId.displayName)
-    val indexOfFirst = commandId.displayName.indexOfFirst { it == commandId.mnemonic }
-    if (indexOfFirst >= 0) {
-      button.displayedMnemonicIndex = indexOfFirst
-    } else {
-      button.setMnemonic(commandId.mnemonic)
+  private fun addInlineEditActionButton(actionId: String) {
+    val action = ActionManagerEx.getInstanceEx().getAction(actionId)
+    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
+    val dataContext = (editor as? EditorEx)?.dataContext ?: return
+
+    addButton(action.templatePresentation.text, action.templatePresentation.mnemonic) {
+      val managerEx = ActionManagerEx.getInstanceEx()
+      val event =
+          AnActionEvent(null, dataContext, ActionPlaces.UNKNOWN, Presentation(), managerEx, 0)
+      if (!ActionUtil.lastUpdateAndCheckDumb(action, event, false)) {
+        return@addButton
+      }
+      ActionUtil.performActionDumbAwareWithCallbacks(action, event)
     }
+  }
+
+  private fun addCommandButton(commandId: CommandId) {
+    addButton(commandId.displayName, commandId.mnemonic) { executeCommandWithContext(commandId) }
+  }
+
+  private fun addButton(displayName: String, mnemonic: Int, action: () -> Unit) {
+    val button = JButton(displayName)
+    button.setMnemonic(mnemonic)
     button.alignmentX = Component.CENTER_ALIGNMENT
     button.maximumSize = Dimension(Int.MAX_VALUE, button.getPreferredSize().height)
     val buttonUI = DarculaButtonUI.createUI(button) as ButtonUI
     button.setUI(buttonUI)
-    button.addActionListener { executeCommandWithContext(commandId) }
+    button.addActionListener { event -> action() }
     add(button)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/commands/ui/CommandsTabPanel.kt
@@ -10,8 +10,9 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBPanelWithEmptyText
-import com.sourcegraph.cody.autocomplete.CodyEditorFactoryListener
 import com.sourcegraph.cody.commands.CommandId
+import com.sourcegraph.cody.config.CodyApplicationSettings
+import com.sourcegraph.config.ConfigUtil
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.GridLayout
@@ -27,46 +28,39 @@ class CommandsTabPanel(
   init {
     layout = BoxLayout(this, BoxLayout.Y_AXIS)
     CommandId.values().forEach { command -> addCommandButton(command) }
-    addInlineEditActionButton("cody.editCodeAction")
-    addInlineEditActionButton("cody.documentCodyAction")
-  }
 
-  private fun executeCommandWithContext(commandId: CommandId) {
-    FileEditorManager.getInstance(project).selectedTextEditor?.let {
-      CodyEditorFactoryListener.Util.informAgentAboutEditorChange(it, hasFileChanged = false) {
-        executeCommand(commandId)
-      }
+    if (ConfigUtil.isFeatureFlagEnabled("cody.feature.inline-edits") ||
+        CodyApplicationSettings.instance.isInlineEditionEnabled) {
+      addInlineEditActionButton("cody.editCodeAction")
+      addInlineEditActionButton("cody.documentCodeAction")
     }
   }
 
   private fun addInlineEditActionButton(actionId: String) {
     val action = ActionManagerEx.getInstanceEx().getAction(actionId)
-    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
-    val dataContext = (editor as? EditorEx)?.dataContext ?: return
-
     addButton(action.templatePresentation.text, action.templatePresentation.mnemonic) {
+      val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return@addButton
+      val dataContext = (editor as? EditorEx)?.dataContext ?: return@addButton
       val managerEx = ActionManagerEx.getInstanceEx()
       val event =
           AnActionEvent(null, dataContext, ActionPlaces.UNKNOWN, Presentation(), managerEx, 0)
-      if (!ActionUtil.lastUpdateAndCheckDumb(action, event, false)) {
-        return@addButton
-      }
       ActionUtil.performActionDumbAwareWithCallbacks(action, event)
     }
   }
 
   private fun addCommandButton(commandId: CommandId) {
-    addButton(commandId.displayName, commandId.mnemonic) { executeCommandWithContext(commandId) }
+    addButton(commandId.displayName, commandId.mnemonic) { executeCommand(commandId) }
   }
 
   private fun addButton(displayName: String, mnemonic: Int, action: () -> Unit) {
     val button = JButton(displayName)
-    button.setMnemonic(mnemonic)
+    button.mnemonic = mnemonic
+    button.displayedMnemonicIndex = displayName.indexOfFirst { it.code == mnemonic }
     button.alignmentX = Component.CENTER_ALIGNMENT
     button.maximumSize = Dimension(Int.MAX_VALUE, button.getPreferredSize().height)
     val buttonUI = DarculaButtonUI.createUI(button) as ButtonUI
     button.setUI(buttonUI)
-    button.addActionListener { event -> action() }
+    button.addActionListener { action() }
     add(button)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupSession.kt
@@ -116,7 +116,7 @@ abstract class FixupSession(
   private fun workAroundUninitializedCodebase() {
     val file = FileDocumentManager.getInstance().getFile(document)
     if (file != null) {
-      CodyAgentCodebase.getInstance(project).onFileOpened(project, file)
+      CodyAgentCodebase.getInstance(project).onFileOpened(file)
     } else {
       logger.warn("No virtual file associated with $document")
     }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1265

## Changes

* Fixes for proper notifications about document change, which now always include proper selection/caret position
* Fixed race in document change notifications for Commands
* Added commands for Edit and Document inline edits
 
## Test plan

Manual QA of the commands tab + full QA due to severe changes in how we handle document change notifications