### PR TITLE
Reorganised the entity hierarchy of HistoryService.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
@@ -37,12 +37,9 @@ class AgentChatSessionService(private val project: Project) {
 
   fun restoreAllSessions(agent: CodyAgent) {
     chatSessions.forEach { agentChatSession ->
-      val chatState =
-          HistoryService.getInstance(project).state.chats.find {
-            it.internalId == agentChatSession.getInternalId()
-          } ?: return
-
-      agentChatSession.updateFromState(agent, chatState)
+      HistoryService.getInstance(project)
+          .findActiveAccountChat(agentChatSession.getInternalId())
+          ?.let { agentChatSession.updateFromState(agent, it) }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/CodyChatMessageHistory.kt
@@ -59,9 +59,7 @@ class CodyChatMessageHistory(
 
   private fun preloadHistoricalMessages(chatSession: ChatSession) {
     HistoryService.getInstance(project)
-        .state
-        .chats
-        .find { it.internalId == chatSession.getInternalId() }
+        .findActiveAccountChat(chatSession.getInternalId())
         ?.messages
         ?.filter { it.speaker == MessageState.SpeakerState.HUMAN }
         ?.mapNotNull { it.text }

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -16,7 +16,7 @@ import com.sourcegraph.cody.CodyToolWindowFactory
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import com.sourcegraph.cody.api.SourcegraphApiRequests
 import com.sourcegraph.cody.history.HistoryService
-import com.sourcegraph.cody.history.state.AccountHistoryState
+import com.sourcegraph.cody.history.state.AccountData
 import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.EnhancedContextState
 import com.sourcegraph.cody.history.state.LLMState
@@ -447,10 +447,8 @@ class SettingsMigration : Activity {
         val accountId = oldState.accountId
         if (accountId == null) return@forEach
         val newState =
-            historyState.accountHistories.find { it.accountId == accountId }
-                ?: (AccountHistoryState.create(accountId).also {
-                  historyState.accountHistories += it
-                })
+            historyState.accountData.find { it.accountId == accountId }
+                ?: (AccountData.create(accountId).also { historyState.accountData += it })
         newState.defaultLlm = historyState.defaultLlm
         newState.defaultEnhancedContext = historyState.defaultEnhancedContext
         if (newState.chats.find { it.internalId == oldState.internalId } == null) {

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -16,6 +16,7 @@ import com.sourcegraph.cody.CodyToolWindowFactory
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import com.sourcegraph.cody.api.SourcegraphApiRequests
 import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.AccountHistoryState
 import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.EnhancedContextState
 import com.sourcegraph.cody.history.state.LLMState
@@ -43,6 +44,9 @@ class SettingsMigration : Activity {
     RunOnceUtil.runOnceForProject(project, "CodyHistoryLlmMigration") { migrateLlms(project) }
     RunOnceUtil.runOnceForProject(project, "CodyConvertUrlToCodebaseName") {
       migrateUrlsToCodebaseNames(project)
+    }
+    RunOnceUtil.runOnceForProject(project, "CodyAccountHistoryMigration") {
+      organiseChatsByAccount(project)
     }
     RunOnceUtil.runOnceForApp("CodyApplicationSettingsMigration") { migrateApplicationSettings() }
     RunOnceUtil.runOnceForApp("ToggleCodyToolWindowAfterMigration") {
@@ -434,6 +438,25 @@ class SettingsMigration : Activity {
               .distinctBy { it.codebaseName }
               .toMutableList()
       enhancedContextState.remoteRepositories = remoteRepositories
+    }
+
+    fun organiseChatsByAccount(project: Project) {
+      val historyService = HistoryService.getInstance(project)
+      val historyState = historyService.state
+      historyState.chats.forEach { oldState ->
+        val accountId = oldState.accountId
+        if (accountId == null) return@forEach
+        val newState =
+            historyState.accountHistories.find { it.accountId == accountId }
+                ?: (AccountHistoryState.create(accountId).also {
+                  historyState.accountHistories += it
+                })
+        newState.defaultLlm = historyState.defaultLlm
+        newState.defaultEnhancedContext = historyState.defaultEnhancedContext
+        if (newState.chats.find { it.internalId == oldState.internalId } == null) {
+          newState.chats.add(oldState)
+        }
+      }
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -80,6 +80,10 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
 
   /** Gets the chat session's enhanced context state. */
   protected fun getContextState(): EnhancedContextState? {
+    if (CodyAuthenticationManager.getInstance(project).getActiveAccount() == null) {
+      // There is no active account, so there is no enhanced context either
+      return null
+    }
     val historyService = HistoryService.getInstance(project)
     return historyService.getContextReadOnly(chatSession.getInternalId())
         ?: historyService.getDefaultContextReadOnly()

--- a/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/ChatHistoryPanel.kt
@@ -19,7 +19,6 @@ import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.chat.actions.ExportChatsAction
 import com.sourcegraph.cody.chat.actions.ExportChatsAction.Companion.INTERNAL_ID_DATA_KEY
-import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.history.node.LeafNode
 import com.sourcegraph.cody.history.node.PeriodNode
 import com.sourcegraph.cody.history.node.RootNode
@@ -235,16 +234,14 @@ class ChatHistoryPanel(
     return root
   }
 
-  private fun getChatsGroupedByPeriod(): Map<String, List<ChatState>> =
-      HistoryService.getInstance(project)
-          .state
-          .chats
-          .filter {
-            it.accountId == CodyAuthenticationManager.getInstance(project).getActiveAccount()?.id
-          }
-          .filter { it.messages.isNotEmpty() }
-          .sortedByDescending { chat -> chat.getUpdatedTimeAt() }
-          .groupBy { chat -> DurationGroupFormatter.format(chat.getUpdatedTimeAt()) }
+  private fun getChatsGroupedByPeriod(): Map<String, List<ChatState>> {
+    val chats =
+        HistoryService.getInstance(project).getActiveAccountHistory()?.chats ?: mutableListOf()
+    return chats
+        .filter { it.messages.isNotEmpty() }
+        .sortedByDescending { chat -> chat.getUpdatedTimeAt() }
+        .groupBy { chat -> DurationGroupFormatter.format(chat.getUpdatedTimeAt()) }
+  }
 
   private class LeafPopupAction(
       text: String,

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/AccountData.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/AccountData.kt
@@ -3,7 +3,7 @@ package com.sourcegraph.cody.history.state
 import com.intellij.openapi.components.BaseState
 import com.intellij.util.xmlb.annotations.OptionTag
 
-class AccountHistoryState : BaseState() {
+class AccountData : BaseState() {
 
   @get:OptionTag(tag = "accountId", nameAttribute = "") var accountId: String? by string()
 
@@ -15,10 +15,10 @@ class AccountHistoryState : BaseState() {
   @get:OptionTag(tag = "defaultLlm", nameAttribute = "") var defaultLlm: LLMState? by property()
 
   companion object {
-    fun create(accountId: String): AccountHistoryState {
-      val accountHistory = AccountHistoryState()
-      accountHistory.accountId = accountId
-      return accountHistory
+    fun create(accountId: String): AccountData {
+      val accountData = AccountData()
+      accountData.accountId = accountId
+      return accountData
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/AccountHistoryState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/AccountHistoryState.kt
@@ -1,0 +1,24 @@
+package com.sourcegraph.cody.history.state
+
+import com.intellij.openapi.components.BaseState
+import com.intellij.util.xmlb.annotations.OptionTag
+
+class AccountHistoryState : BaseState() {
+
+  @get:OptionTag(tag = "accountId", nameAttribute = "") var accountId: String? by string()
+
+  @get:OptionTag(tag = "chats", nameAttribute = "") var chats: MutableList<ChatState> by list()
+
+  @get:OptionTag(tag = "defaultEnhancedContext", nameAttribute = "")
+  var defaultEnhancedContext: EnhancedContextState? by property()
+
+  @get:OptionTag(tag = "defaultLlm", nameAttribute = "") var defaultLlm: LLMState? by property()
+
+  companion object {
+    fun create(accountId: String): AccountHistoryState {
+      val accountHistory = AccountHistoryState()
+      accountHistory.accountId = accountId
+      return accountHistory
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/ChatState.kt
@@ -22,7 +22,9 @@ class ChatState : BaseState() {
 
   @get:OptionTag(tag = "llm", nameAttribute = "") var llm: LLMState? by property()
 
-  @get:OptionTag(tag = "accountId", nameAttribute = "") var accountId: String? by string()
+  @Deprecated("")
+  @get:OptionTag(tag = "accountId", nameAttribute = "")
+  var accountId: String? by string()
 
   @get:OptionTag(tag = "enhancedContext", nameAttribute = "")
   var enhancedContext: EnhancedContextState? by property()
@@ -46,9 +48,8 @@ class ChatState : BaseState() {
 
     private val DATE_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME
 
-    fun create(accountId: String?, internalId: String): ChatState {
+    fun create(internalId: String): ChatState {
       val chat = ChatState()
-      chat.accountId = accountId
       chat.internalId = internalId
       return chat
     }

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
@@ -5,10 +5,18 @@ import com.intellij.util.xmlb.annotations.OptionTag
 
 class HistoryState : BaseState() {
 
-  @get:OptionTag(tag = "chats", nameAttribute = "") var chats: MutableList<ChatState> by list()
+  @get:OptionTag(tag = "accountHistories", nameAttribute = "")
+  var accountHistories: MutableList<AccountHistoryState> by list()
 
-  @get:OptionTag(tag = "defaultLlm", nameAttribute = "") var defaultLlm: LLMState? by property()
+  @Deprecated("")
+  @get:OptionTag(tag = "chats", nameAttribute = "")
+  var chats: MutableList<ChatState> by list()
 
+  @Deprecated("")
+  @get:OptionTag(tag = "defaultLlm", nameAttribute = "")
+  var defaultLlm: LLMState? by property()
+
+  @Deprecated("")
   @get:OptionTag(tag = "defaultEnhancedContext", nameAttribute = "")
   var defaultEnhancedContext: EnhancedContextState? by property()
 }

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/HistoryState.kt
@@ -5,8 +5,8 @@ import com.intellij.util.xmlb.annotations.OptionTag
 
 class HistoryState : BaseState() {
 
-  @get:OptionTag(tag = "accountHistories", nameAttribute = "")
-  var accountHistories: MutableList<AccountHistoryState> by list()
+  @get:OptionTag(tag = "accountData", nameAttribute = "")
+  var accountData: MutableList<AccountData> by list()
 
   @Deprecated("")
   @get:OptionTag(tag = "chats", nameAttribute = "")

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -1,10 +1,18 @@
 package com.sourcegraph.cody.config
 
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.registerServiceInstance
+import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
+import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.EnhancedContextState
+import com.sourcegraph.cody.history.state.HistoryState
+import com.sourcegraph.cody.history.state.LLMState
+import com.sourcegraph.cody.history.state.MessageState
+import com.sourcegraph.cody.history.state.MessageState.SpeakerState
 import com.sourcegraph.cody.history.state.RemoteRepositoryState
-import junit.framework.TestCase
 
-class SettingsMigrationTest : TestCase() {
+class SettingsMigrationTest : BasePlatformTestCase() {
 
   fun `test migrateUrlsToCodebaseNames`() {
     val inputEnhancedContextState =
@@ -79,5 +87,99 @@ class SettingsMigrationTest : TestCase() {
 
     SettingsMigration.migrateUrlsToCodebaseNames(inputEnhancedContextState)
     assertEquals(expectedEnhancedContextState, inputEnhancedContextState)
+  }
+
+  fun `test organiseChatsByAccount`() {
+    val originalHistory =
+        HistoryState().also {
+          it.defaultLlm =
+              LLMState.fromChatModel(
+                  ChatModelsResponse.ChatModelProvider(
+                      true, false, "Cyberdyne", "Terminator", "T-800"))
+          it.defaultEnhancedContext =
+              EnhancedContextState().also {
+                it.isEnabled = true
+                it.remoteRepositories =
+                    mutableListOf(
+                        RemoteRepositoryState().also {
+                          it.isEnabled = true
+                          it.remoteUrl = "http://example.com"
+                          it.codebaseName = "Windows 9"
+                        })
+              }
+          it.chats =
+              mutableListOf(
+                  ChatState.create("chat1").also {
+                    it.accountId = "sarah"
+                    it.messages =
+                        mutableListOf(
+                            MessageState().also {
+                              it.text = "Hi there!"
+                              it.speaker = SpeakerState.ASSISTANT
+                            },
+                            MessageState().also {
+                              it.text = "Leave me alone!"
+                              it.speaker = SpeakerState.HUMAN
+                            })
+                  },
+                  ChatState.create("chat2").also {
+                    it.accountId = "sarah"
+                    it.messages =
+                        mutableListOf(
+                            MessageState().also {
+                              it.text = "Please stay!"
+                              it.speaker = SpeakerState.HUMAN
+                            },
+                            MessageState().also {
+                              it.text = "I must go..."
+                              it.speaker = SpeakerState.ASSISTANT
+                            })
+                  },
+                  ChatState.create("chat3").also {
+                    it.accountId = "dave"
+                    it.llm =
+                        LLMState.fromChatModel(
+                            ChatModelsResponse.ChatModelProvider(
+                                false, true, "Uni of IL", "HAL", "HAL 9000"))
+                    it.messages =
+                        mutableListOf(
+                            MessageState().also {
+                              it.text = "Open the door!"
+                              it.speaker = SpeakerState.HUMAN
+                            },
+                            MessageState().also {
+                              it.text = "No way!"
+                              it.speaker = SpeakerState.ASSISTANT
+                            })
+                  },
+                  ChatState.create("chat4"))
+        }
+    val project = myFixture.project
+    project.registerServiceInstance(
+        CodyAuthenticationManager::class.java, CodyAuthenticationManager(project))
+    project.registerServiceInstance(HistoryService::class.java, HistoryService(project))
+    HistoryService.getInstance(project)
+        .loadState(HistoryState().also { it.copyFrom(originalHistory) })
+
+    SettingsMigration.organiseChatsByAccount(project)
+
+    val migratedHistory = HistoryService.getInstance(project).state
+
+    assertEquals(2, migratedHistory.accountHistories.size)
+    migratedHistory.accountHistories.forEachIndexed { index, history ->
+      assertEquals("default LLM [$index]", originalHistory.defaultLlm, history.defaultLlm)
+      assertEquals(
+          "default enhanced context [$index]",
+          originalHistory.defaultEnhancedContext,
+          history.defaultEnhancedContext)
+    }
+    migratedHistory.accountHistories[0].let {
+      assertEquals("sarah", it.accountId)
+      assertEquals(mutableListOf(originalHistory.chats[0], originalHistory.chats[1]), it.chats)
+    }
+    migratedHistory.accountHistories[1].let {
+      assertEquals("dave", it.accountId)
+      assertEquals(mutableListOf(originalHistory.chats[2]), it.chats)
+    }
   }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -165,19 +165,19 @@ class SettingsMigrationTest : BasePlatformTestCase() {
 
     val migratedHistory = HistoryService.getInstance(project).state
 
-    assertEquals(2, migratedHistory.accountHistories.size)
-    migratedHistory.accountHistories.forEachIndexed { index, history ->
-      assertEquals("default LLM [$index]", originalHistory.defaultLlm, history.defaultLlm)
+    assertEquals(2, migratedHistory.accountData.size)
+    migratedHistory.accountData.forEachIndexed { index, accountEntry ->
+      assertEquals("default LLM [$index]", originalHistory.defaultLlm, accountEntry.defaultLlm)
       assertEquals(
           "default enhanced context [$index]",
           originalHistory.defaultEnhancedContext,
-          history.defaultEnhancedContext)
+          accountEntry.defaultEnhancedContext)
     }
-    migratedHistory.accountHistories[0].let {
+    migratedHistory.accountData[0].let {
       assertEquals("sarah", it.accountId)
       assertEquals(mutableListOf(originalHistory.chats[0], originalHistory.chats[1]), it.chats)
     }
-    migratedHistory.accountHistories[1].let {
+    migratedHistory.accountData[1].let {
       assertEquals("dave", it.accountId)
       assertEquals(mutableListOf(originalHistory.chats[2]), it.chats)
     }

--- a/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
@@ -12,20 +12,23 @@ class HistoryStateTest : TestCase() {
   fun `test history serialization`() {
     val history =
         HistoryState().apply {
-          chats +=
-              ChatState().apply {
+          accountHistories +=
+              AccountHistoryState().apply {
                 accountId = "VXNlkjoxEFU3NjE="
-                internalId = "0f8b7034-9fa8-488a-a13e-09c52677008a"
-                updatedAt = "2024-01-31T01:06:18.524621"
-                messages +=
-                    MessageState().apply {
-                      speaker = HUMAN
-                      text = "hi"
-                    }
-                messages +=
-                    MessageState().apply {
-                      speaker = ASSISTANT
-                      text = "hello"
+                chats +=
+                    ChatState().apply {
+                      internalId = "0f8b7034-9fa8-488a-a13e-09c52677008a"
+                      updatedAt = "2024-01-31T01:06:18.524621"
+                      messages +=
+                          MessageState().apply {
+                            speaker = HUMAN
+                            text = "hi"
+                          }
+                      messages +=
+                          MessageState().apply {
+                            speaker = ASSISTANT
+                            text = "hello"
+                          }
                     }
               }
         }
@@ -35,27 +38,33 @@ class HistoryStateTest : TestCase() {
     assertEquals(
         """
       <HistoryState>
-        <chats>
+        <accountHistories>
           <list>
-            <chat>
+            <AccountHistoryState>
               <accountId value="VXNlkjoxEFU3NjE=" />
-              <internalId value="0f8b7034-9fa8-488a-a13e-09c52677008a" />
-              <messages>
+              <chats>
                 <list>
-                  <message>
-                    <speaker value="HUMAN" />
-                    <text value="hi" />
-                  </message>
-                  <message>
-                    <speaker value="ASSISTANT" />
-                    <text value="hello" />
-                  </message>
+                  <chat>
+                    <internalId value="0f8b7034-9fa8-488a-a13e-09c52677008a" />
+                    <messages>
+                      <list>
+                        <message>
+                          <speaker value="HUMAN" />
+                          <text value="hi" />
+                        </message>
+                        <message>
+                          <speaker value="ASSISTANT" />
+                          <text value="hello" />
+                        </message>
+                      </list>
+                    </messages>
+                    <updatedAt value="2024-01-31T01:06:18.524621" />
+                  </chat>
                 </list>
-              </messages>
-              <updatedAt value="2024-01-31T01:06:18.524621" />
-            </chat>
+              </chats>
+            </AccountHistoryState>
           </list>
-        </chats>
+        </accountHistories>
       </HistoryState>
     """
             .trimIndent(),

--- a/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/history/state/HistoryStateTest.kt
@@ -12,8 +12,8 @@ class HistoryStateTest : TestCase() {
   fun `test history serialization`() {
     val history =
         HistoryState().apply {
-          accountHistories +=
-              AccountHistoryState().apply {
+          accountData +=
+              AccountData().apply {
                 accountId = "VXNlkjoxEFU3NjE="
                 chats +=
                     ChatState().apply {
@@ -38,9 +38,9 @@ class HistoryStateTest : TestCase() {
     assertEquals(
         """
       <HistoryState>
-        <accountHistories>
+        <accountData>
           <list>
-            <AccountHistoryState>
+            <AccountData>
               <accountId value="VXNlkjoxEFU3NjE=" />
               <chats>
                 <list>
@@ -62,9 +62,9 @@ class HistoryStateTest : TestCase() {
                   </chat>
                 </list>
               </chats>
-            </AccountHistoryState>
+            </AccountData>
           </list>
-        </accountHistories>
+        </accountData>
       </HistoryState>
     """
             .trimIndent(),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1210

The chats are now grouped by the account ID, and each account has (optionally) its own enhanced context.

## Test plan
 Added a new test

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
