### PR TITLE
Use the DumbAwareBGTAction interface to silence the update thread warning.

### DIFF
--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -1,10 +1,8 @@
 package com.sourcegraph.cody
 
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CustomShortcutSet
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBList
 import com.intellij.ui.components.JBScrollPane
@@ -20,6 +18,7 @@ import com.sourcegraph.cody.chat.ui.SendButton
 import com.sourcegraph.cody.ui.AutoGrowingTextArea
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.awt.Dimension
 import java.awt.event.*
 import javax.swing.DefaultListModel
@@ -115,11 +114,7 @@ class PromptPanel(project: Project, private val chatSession: ChatSession) : JLay
           }
         })
     for (shortcut in listOf(ENTER, UP, DOWN, TAB)) { // key listeners
-      object : DumbAwareAction() {
-            override fun actionPerformed(e: AnActionEvent) {
-              didUseShortcut(shortcut)
-            }
-          }
+      SimpleDumbAwareBGTAction { didUseShortcut(shortcut) }
           .registerCustomShortcutSet(shortcut, textArea)
     }
 

--- a/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
+++ b/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
@@ -6,7 +6,6 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
@@ -19,6 +18,7 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager;
 import com.sourcegraph.cody.initialization.Activity;
 import com.sourcegraph.cody.statusbar.CodyManageAccountsAction;
 import com.sourcegraph.common.NotificationGroups;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import org.jetbrains.annotations.NotNull;
 
 public class CodyAuthNotificationActivity implements Activity {
@@ -52,7 +52,7 @@ public class CodyAuthNotificationActivity implements Activity {
             NotificationType.WARNING);
 
     AnAction openCodySidebar =
-        new DumbAwareAction("Open Cody") {
+        new DumbAwareBGTAction("Open Cody") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             notification.expire();
@@ -67,7 +67,7 @@ public class CodyAuthNotificationActivity implements Activity {
         };
 
     AnAction neverShowAgainAction =
-        new DumbAwareAction("Never Show Again") {
+        new DumbAwareBGTAction("Never Show Again") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             notification.expire();

--- a/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
+++ b/src/main/java/com/sourcegraph/config/OpenPluginSettingsAction.java
@@ -2,13 +2,13 @@ package com.sourcegraph.config;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ShowSettingsUtil;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.util.NlsActions;
 import com.sourcegraph.cody.config.ui.AccountConfigurable;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class OpenPluginSettingsAction extends DumbAwareAction {
+public class OpenPluginSettingsAction extends DumbAwareBGTAction {
   public OpenPluginSettingsAction() {
     super();
   }

--- a/src/main/java/com/sourcegraph/find/FindPopupPanel.java
+++ b/src/main/java/com/sourcegraph/find/FindPopupPanel.java
@@ -8,7 +8,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ide.CopyPasteManager;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.ui.OnePixelSplitter;
@@ -18,6 +17,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.components.BorderLayoutPanel;
 import com.sourcegraph.Icons;
 import com.sourcegraph.common.NotificationGroups;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import com.sourcegraph.find.browser.BrowserAndLoadingPanel;
 import com.sourcegraph.find.browser.JSToJavaBridgeRequestHandler;
 import com.sourcegraph.find.browser.JavaToJSBridge;
@@ -111,7 +111,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
             "Your IDE doesn't support JCEF. You won't be able to use \"Find with Sourcegraph\". If you believe this is an error, please raise this at support@sourcegraph.com, specifying your OS and IDE version.",
             NotificationType.ERROR);
     AnAction copyEmailAddressAction =
-        new DumbAwareAction("Copy Support Email Address") {
+        new DumbAwareBGTAction("Copy Support Email Address") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             CopyPasteManager.getInstance()
@@ -120,7 +120,7 @@ public class FindPopupPanel extends BorderLayoutPanel implements Disposable {
           }
         };
     AnAction dismissAction =
-        new DumbAwareAction("Dismiss") {
+        new DumbAwareBGTAction("Dismiss") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
             notification.expire();

--- a/src/main/java/com/sourcegraph/find/PreviewPanel.java
+++ b/src/main/java/com/sourcegraph/find/PreviewPanel.java
@@ -10,10 +10,10 @@ import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.impl.ContextMenuPopupHandler;
 import com.intellij.openapi.editor.impl.EditorImpl;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBPanelWithEmptyText;
 import com.sourcegraph.Icons;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import com.sourcegraph.website.CopyAction;
 import com.sourcegraph.website.FileActionBase;
 import com.sourcegraph.website.OpenFileAction;
@@ -135,7 +135,8 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
   private ActionGroup createActionGroup() {
     DefaultActionGroup group = new DefaultActionGroup();
     group.add(
-        new DumbAwareAction("Open File in Editor", "Open file in editor", Icons.SourcegraphLogo) {
+        new DumbAwareBGTAction(
+            "Open File in Editor", "Open file in editor", Icons.SourcegraphLogo) {
           @Override
           public void actionPerformed(@NotNull AnActionEvent e) {
             try {
@@ -159,7 +160,7 @@ public class PreviewPanel extends JBPanelWithEmptyText implements Disposable {
     NO_PREVIEW_AVAILABLE,
   }
 
-  class SimpleEditorFileAction extends DumbAwareAction {
+  class SimpleEditorFileAction extends DumbAwareBGTAction {
     final FileActionBase action;
     final Editor editor;
 

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.history.VcsFileRevision;
@@ -14,6 +13,7 @@ import com.intellij.vcs.log.VcsLogDataKeys;
 import com.intellij.vcsUtil.VcsUtil;
 import com.sourcegraph.common.BrowserOpener;
 import com.sourcegraph.common.ErrorNotification;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.vcs.RepoUtil;
 import com.sourcegraph.vcs.RevisionContext;
@@ -22,8 +22,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
 /** JetBrains IDE action to open a selected revision in Sourcegraph. */
-@SuppressWarnings("MissingActionUpdateThread")
-public class OpenRevisionAction extends DumbAwareAction {
+public class OpenRevisionAction extends DumbAwareBGTAction {
   private final Logger logger = Logger.getInstance(this.getClass());
 
   @Override

--- a/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -8,11 +8,11 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.sourcegraph.common.BrowserOpener;
+import com.sourcegraph.common.ui.DumbAwareBGTAction;
 import com.sourcegraph.find.SourcegraphVirtualFile;
 import com.sourcegraph.vcs.RepoInfo;
 import com.sourcegraph.vcs.RepoUtil;
@@ -22,7 +22,7 @@ import java.util.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public abstract class SearchActionBase extends DumbAwareAction {
+public abstract class SearchActionBase extends DumbAwareBGTAction {
   public void actionPerformedMode(@NotNull AnActionEvent event, @NotNull Scope scope) {
     final Project project = event.getProject();
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
@@ -1,10 +1,10 @@
 package com.sourcegraph.cody.agent.action
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class CodyAgentRestartAction : DumbAwareAction("Restart Cody Agent") {
+class CodyAgentRestartAction : DumbAwareBGTAction("Restart Cody Agent") {
   override fun actionPerformed(event: AnActionEvent) {
     event.project?.let { CodyAgentService.getInstance(it).restartAgent(it) }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
@@ -2,16 +2,16 @@ package com.sourcegraph.cody.auth.ui
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformCoreDataKeys
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowFactory
 import com.sourcegraph.cody.config.CodyPersistentAccountsHost
 import com.sourcegraph.cody.config.signInWithSourcegrapDialog
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 import com.sourcegraph.config.ConfigUtil
 
 class SignInWithEnterpriseInstanceAction(
     private val defaultServer: String = ConfigUtil.DOTCOM_URL
-) : DumbAwareAction("Sign in with Sourcegraph") {
+) : DumbAwareBGTAction("Sign in with Sourcegraph") {
   override fun actionPerformed(e: AnActionEvent) {
     val project = e.project ?: return
     val accountsHost = CodyPersistentAccountsHost(project)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/OpenChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/OpenChatAction.kt
@@ -1,12 +1,12 @@
 package com.sourcegraph.cody.chat
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.CodyToolWindowFactory
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class OpenChatAction : DumbAwareAction() {
+class OpenChatAction : DumbAwareBGTAction() {
 
   override fun actionPerformed(event: AnActionEvent) {
     val project = event.project ?: return

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -1,9 +1,7 @@
 package com.sourcegraph.cody.chat.ui
 
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.OpenFileDescriptor
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.concurrency.annotations.RequiresEdt
@@ -17,6 +15,7 @@ import com.sourcegraph.cody.chat.ChatUIConstants.ASSISTANT_MESSAGE_GRADIENT_WIDT
 import com.sourcegraph.cody.chat.ChatUIConstants.TEXT_MARGIN
 import com.sourcegraph.cody.ui.AccordionSection
 import com.sourcegraph.common.BrowserOpener.openInBrowser
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.awt.BorderLayout
 import java.awt.Insets
 import javax.swing.JPanel
@@ -74,16 +73,13 @@ class ContextFilesPanel(
 
   @RequiresEdt
   private fun createFileWithLinkPanel(contextItemFile: ContextItemFile): JPanel {
-    val anAction =
-        object : DumbAwareAction() {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            if (contextItemFile.isLocal()) {
-              openInEditor(contextItemFile)
-            } else {
-              openInBrowser(project, contextItemFile.uri)
-            }
-          }
-        }
+    val anAction = SimpleDumbAwareBGTAction {
+      if (contextItemFile.isLocal()) {
+        openInEditor(contextItemFile)
+      } else {
+        openInBrowser(project, contextItemFile.uri)
+      }
+    }
 
     val goToFile = ContextFileActionLink(project, contextItemFile, anAction)
     val panel = JPanel(BorderLayout())

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/RemoteRepoPopupController.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/RemoteRepoPopupController.kt
@@ -12,7 +12,6 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.ex.FocusChangeListener
 import com.intellij.openapi.editor.highlighter.EditorHighlighterFactory
 import com.intellij.openapi.keymap.KeymapUtil
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -28,6 +27,7 @@ import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.context.RemoteRepoFileType
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 import com.sourcegraph.utils.CodyEditorUtil
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -124,7 +124,7 @@ class RemoteRepoPopupController(val project: Project) {
             .createPopup()
 
     val okAction =
-        object : DumbAwareAction() {
+        object : DumbAwareBGTAction() {
           override fun actionPerformed(event: AnActionEvent) {
             unregisterCustomShortcutSet(popup.content)
             popup.closeOk(event.inputEvent)

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyManageAccountsAction.kt
@@ -2,10 +2,10 @@ package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
-import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.config.ui.AccountConfigurable
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class CodyManageAccountsAction : DumbAwareAction("Manage Accounts") {
+class CodyManageAccountsAction : DumbAwareBGTAction("Manage Accounts") {
   override fun actionPerformed(e: AnActionEvent) {
     ShowSettingsUtil.getInstance().showSettingsDialog(e.project, AccountConfigurable::class.java)
   }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyOpenSettingsAction.kt
@@ -2,10 +2,10 @@ package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.options.ShowSettingsUtil
-import com.intellij.openapi.project.DumbAwareAction
 import com.sourcegraph.cody.config.ui.CodyConfigurable
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class CodyOpenSettingsAction : DumbAwareAction("Open Settings") {
+class CodyOpenSettingsAction : DumbAwareBGTAction("Open Settings") {
   override fun actionPerformed(e: AnActionEvent) {
     ShowSettingsUtil.getInstance().showSettingsDialog(e.project, CodyConfigurable::class.java)
   }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/OpenLogAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/OpenLogAction.kt
@@ -6,11 +6,11 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications.Bus
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VfsUtil
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class OpenLogAction : DumbAwareAction("Open Log To Troubleshoot Issue") {
+class OpenLogAction : DumbAwareBGTAction("Open Log To Troubleshoot Issue") {
 
   override fun actionPerformed(e: AnActionEvent) {
     val project = e.project

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
@@ -2,9 +2,9 @@ package com.sourcegraph.cody.statusbar
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.common.ui.DumbAwareBGTAction
 
-class ReportCodyBugAction : DumbAwareAction("Open GitHub To Report Cody Issue") {
+class ReportCodyBugAction : DumbAwareBGTAction("Open GitHub To Report Cody Issue") {
   override fun actionPerformed(p0: AnActionEvent) {
     BrowserUtil.open("https://github.com/sourcegraph/jetbrains/issues/new?template=bug_report.yml")
   }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/AutoGrowingTextArea.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/AutoGrowingTextArea.kt
@@ -2,14 +2,13 @@ package com.sourcegraph.cody.ui
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaTextAreaUI
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CustomShortcutSet
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.actionSystem.ShortcutSet
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.components.JBTextArea
 import com.intellij.util.ui.UIUtil
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.awt.Dimension
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
@@ -86,12 +85,9 @@ class AutoGrowingTextArea(private val minRows: Int, maxRows: Int, outerPanel: JC
         KeyboardShortcut(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.META_DOWN_MASK), null)
     val insertEnterShortcut: ShortcutSet =
         CustomShortcutSet(ctrlEnter, shiftEnter, metaEnter, altOrOptionEnter)
-    val insertEnterAction: AnAction =
-        object : DumbAwareAction() {
-          override fun actionPerformed(e: AnActionEvent) {
-            promptInput.insert("\n", promptInput.caretPosition)
-          }
-        }
+    val insertEnterAction: AnAction = SimpleDumbAwareBGTAction {
+      promptInput.insert("\n", promptInput.caretPosition)
+    }
     insertEnterAction.registerCustomShortcutSet(insertEnterShortcut, promptInput)
     return promptInput
   }

--- a/src/main/kotlin/com/sourcegraph/common/BrowserErrorNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/BrowserErrorNotification.kt
@@ -4,11 +4,10 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ide.CopyPasteManager
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.awt.datatransfer.StringSelection
 import java.net.URI
 
@@ -21,18 +20,11 @@ object BrowserErrorNotification {
             "Opening an external browser is not supported. You can still copy the URL to your clipboard and open it manually.",
             NotificationType.WARNING)
     val copyUrlAction: AnAction =
-        object : DumbAwareAction("Copy URL") {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            CopyPasteManager.getInstance().setContents(StringSelection(uri.toString()))
-            notification.expire()
-          }
+        SimpleDumbAwareBGTAction("Copy URL") {
+          CopyPasteManager.getInstance().setContents(StringSelection(uri.toString()))
+          notification.expire()
         }
-    val dismissAction: AnAction =
-        object : DumbAwareAction("Dismiss") {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            notification.expire()
-          }
-        }
+    val dismissAction: AnAction = SimpleDumbAwareBGTAction("Dismiss") { notification.expire() }
     notification.setIcon(Icons.CodyLogo)
     notification.addAction(copyUrlAction)
     notification.addAction(dismissAction)

--- a/src/main/kotlin/com/sourcegraph/common/ErrorNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ErrorNotification.kt
@@ -4,20 +4,14 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.Notifications
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 
 object ErrorNotification {
   fun show(project: Project?, errorMessage: String) {
     val notification = create(errorMessage)
-    val dismissAction: AnAction =
-        object : DumbAwareAction("Dismiss") {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            notification.expire()
-          }
-        }
+    val dismissAction: AnAction = SimpleDumbAwareBGTAction("Dismiss") { notification.expire() }
     notification.addAction(dismissAction)
     Notifications.Bus.notify(notification)
     notification.notify(project)

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -5,11 +5,12 @@ import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.RateLimitError
 import com.sourcegraph.common.BrowserOpener.openInBrowser
+import com.sourcegraph.common.ui.DumbAwareBGTAction
+import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.util.concurrent.atomic.AtomicReference
 
 class UpgradeToCodyProNotification
@@ -19,7 +20,7 @@ private constructor(title: String, content: String, shouldShowUpgradeOption: Boo
   init {
     icon = Icons.CodyLogo
     val learnMoreAction: AnAction =
-        object : DumbAwareAction("Learn more") {
+        object : DumbAwareBGTAction("Learn more") {
           override fun actionPerformed(anActionEvent: AnActionEvent) {
             val learnMoreLink =
                 when {
@@ -31,16 +32,11 @@ private constructor(title: String, content: String, shouldShowUpgradeOption: Boo
             hideBalloon()
           }
         }
-    val dismissAction: AnAction =
-        object : DumbAwareAction("Dismiss") {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            hideBalloon()
-          }
-        }
+    val dismissAction: AnAction = SimpleDumbAwareBGTAction("Dismiss") { hideBalloon() }
 
     if (shouldShowUpgradeOption) {
       val upgradeAction: AnAction =
-          object : DumbAwareAction("Upgrade") {
+          object : DumbAwareBGTAction("Upgrade") {
             override fun actionPerformed(anActionEvent: AnActionEvent) {
               openInBrowser(anActionEvent.project, "https://sourcegraph.com/cody/subscription")
               hideBalloon()

--- a/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/common/UpgradeToCodyProNotification.kt
@@ -4,12 +4,10 @@ import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
 import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.RateLimitError
 import com.sourcegraph.common.BrowserOpener.openInBrowser
-import com.sourcegraph.common.ui.DumbAwareBGTAction
 import com.sourcegraph.common.ui.SimpleDumbAwareBGTAction
 import java.util.concurrent.atomic.AtomicReference
 
@@ -19,28 +17,19 @@ private constructor(title: String, content: String, shouldShowUpgradeOption: Boo
     NotificationFullContent {
   init {
     icon = Icons.CodyLogo
-    val learnMoreAction: AnAction =
-        object : DumbAwareBGTAction("Learn more") {
-          override fun actionPerformed(anActionEvent: AnActionEvent) {
-            val learnMoreLink =
-                when {
-                  shouldShowUpgradeOption -> "https://sourcegraph.com/cody/subscription"
-                  else ->
-                      "https://sourcegraph.com/docs/cody/core-concepts/cody-gateway#rate-limits-and-quotas"
-                }
-            openInBrowser(anActionEvent.project, learnMoreLink)
-            hideBalloon()
-          }
+    val learnMoreAction =
+        SimpleDumbAwareBGTAction("Learn more") { anActionEvent ->
+          val learnMoreLink = if (shouldShowUpgradeOption) UPGRADE_URL else RATE_LIMITS_URL
+          openInBrowser(anActionEvent.project, learnMoreLink)
+          hideBalloon()
         }
     val dismissAction: AnAction = SimpleDumbAwareBGTAction("Dismiss") { hideBalloon() }
 
     if (shouldShowUpgradeOption) {
-      val upgradeAction: AnAction =
-          object : DumbAwareBGTAction("Upgrade") {
-            override fun actionPerformed(anActionEvent: AnActionEvent) {
-              openInBrowser(anActionEvent.project, "https://sourcegraph.com/cody/subscription")
-              hideBalloon()
-            }
+      val upgradeAction =
+          SimpleDumbAwareBGTAction("Upgrade") { anActionEvent ->
+            openInBrowser(anActionEvent.project, UPGRADE_URL)
+            hideBalloon()
           }
       addAction(upgradeAction)
     }
@@ -50,6 +39,11 @@ private constructor(title: String, content: String, shouldShowUpgradeOption: Boo
   }
 
   companion object {
+
+    const val UPGRADE_URL = "https://sourcegraph.com/cody/subscription"
+    const val RATE_LIMITS_URL =
+        "https://sourcegraph.com/docs/cody/core-concepts/cody-gateway#rate-limits-and-quotas"
+
     fun notify(rateLimitError: RateLimitError, project: Project) {
 
       val shouldShowUpgradeOption = rateLimitError.upgradeIsAvailable

--- a/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareBGTAction.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareBGTAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.util.NlsActions
 import com.sourcegraph.cody.ui.BGTActionSetter
 import javax.swing.Icon
+import org.jetbrains.annotations.NotNull
 
 abstract class DumbAwareBGTAction : DumbAwareAction {
 
@@ -25,9 +26,9 @@ abstract class DumbAwareBGTAction : DumbAwareAction {
 
 class SimpleDumbAwareBGTAction(
     text: @NlsActions.ActionText String? = null,
-    private val action: () -> Unit
+    private val action: (@NotNull AnActionEvent) -> Unit
 ) : DumbAwareBGTAction(text) {
-  override fun actionPerformed(e: AnActionEvent) {
-    action()
+  override fun actionPerformed(@NotNull e: AnActionEvent) {
+    action(e)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareBGTAction.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareBGTAction.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.common.ui
 
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.util.NlsActions
 import com.sourcegraph.cody.ui.BGTActionSetter
@@ -20,4 +21,13 @@ abstract class DumbAwareBGTAction : DumbAwareAction {
       description: @NlsActions.ActionDescription String?,
       icon: Icon?
   ) : super(text, description, icon)
+}
+
+class SimpleDumbAwareBGTAction(
+    text: @NlsActions.ActionText String? = null,
+    private val action: () -> Unit
+) : DumbAwareBGTAction(text) {
+  override fun actionPerformed(e: AnActionEvent) {
+    action()
+  }
 }


### PR DESCRIPTION
This should fix #1327.

## Test plan
I have clicked around a little bit in IntelliJ IDEA 2024.1.1 RC, and I haven't seen any OLD_EDT warnings in the log.