### PR TITLE
Display onboarding tooltip on first autocomplete suggestion

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -417,7 +417,7 @@ class CodyAutocompleteManager {
                           KeymapUtil.getShortcutText("cody.cycleBackAutocompleteAction")),
                   inlay /* dispose tooltip alongside inlay */)
               .withHeader(CodyBundle.getString("gotit.autocomplete.header"))
-              .withPosition(Balloon.Position.atLeft)
+              .withPosition(Balloon.Position.above)
               .withIcon(Icons.CodyLogo)
               .andShowCloseShortcut()
       try {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -8,24 +8,23 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.InlayModel
 import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.TextRange
+import com.intellij.ui.GotItTooltip
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.CodyToolWindowContent
+import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.AutocompleteItem
-import com.sourcegraph.cody.agent.protocol.AutocompleteParams
-import com.sourcegraph.cody.agent.protocol.AutocompleteResult
-import com.sourcegraph.cody.agent.protocol.AutocompleteTriggerKind
-import com.sourcegraph.cody.agent.protocol.CompletionItemParams
-import com.sourcegraph.cody.agent.protocol.ErrorCode
+import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
 import com.sourcegraph.cody.agent.protocol.Position
 import com.sourcegraph.cody.agent.protocol.RateLimitError.Companion.toRateLimitError
-import com.sourcegraph.cody.agent.protocol.SelectedCompletionInfo
 import com.sourcegraph.cody.autocomplete.render.AutocompleteRendererType
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteBlockElementRenderer
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteElementRenderer
@@ -35,11 +34,10 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.statusbar.CodyStatus
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
-import com.sourcegraph.cody.vscode.CancellationToken
-import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
-import com.sourcegraph.cody.vscode.IntelliJTextDocument
+import com.sourcegraph.cody.vscode.*
 import com.sourcegraph.cody.vscode.Range
-import com.sourcegraph.cody.vscode.TextDocument
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.CodyBundle.fmt
 import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil.isCodyEnabled
 import com.sourcegraph.config.UserLevelConfig
@@ -384,23 +382,49 @@ class CodyAutocompleteManager {
     val lineBreaks = listOf("\r\n", "\n", "\r")
     val startsInline = lineBreaks.none { separator -> completionText.startsWith(separator) }
 
+    var inlay: Inlay<*>? = null
     if (startsInline) {
       val renderer =
           CodyAutocompleteSingleLineRenderer(
               completionText.lines().first(), items, editor, AutocompleteRendererType.INLINE)
-      inlayModel.addInlineElement(offset, /* relatesToPrecedingText = */ true, renderer)
+      inlay = inlayModel.addInlineElement(offset, /* relatesToPrecedingText = */ true, renderer)
     }
     val lines = completionText.lines()
     if (lines.size > 1) {
       val text =
           (if (startsInline) lines.drop(1) else lines).dropWhile { it.isBlank() }.joinToString("\n")
       val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
-      inlayModel.addBlockElement(
-          /* offset = */ offset,
-          /* relatesToPrecedingText = */ true,
-          /* showAbove = */ false,
-          /* priority = */ Int.MAX_VALUE,
-          /* renderer = */ renderer)
+      val inlay2 =
+          inlayModel.addBlockElement(
+              /* offset = */ offset,
+              /* relatesToPrecedingText = */ true,
+              /* showAbove = */ false,
+              /* priority = */ Int.MAX_VALUE,
+              /* renderer = */ renderer)
+      if (inlay == null) {
+        inlay = inlay2
+      }
+    }
+
+    if (inlay?.bounds?.location != null) {
+      val gotit =
+          GotItTooltip(
+                  "cody.autocomplete.gotIt",
+                  CodyBundle.getString("gotit.autocomplete.message")
+                      .fmt(
+                          KeymapUtil.getShortcutText("cody.acceptAutocompleteAction"),
+                          KeymapUtil.getShortcutText("cody.cycleForwardAutocompleteAction"),
+                          KeymapUtil.getShortcutText("cody.cycleBackAutocompleteAction")),
+                  inlay /* dispose tooltip alongside inlay */)
+              .withHeader(CodyBundle.getString("gotit.autocomplete.header"))
+              .withPosition(Balloon.Position.atLeft)
+              .withIcon(Icons.CodyLogo)
+              .andShowCloseShortcut()
+      try {
+        gotit.show(editor.contentComponent) { _, _ -> inlay.bounds!!.location }
+      } catch (e: Exception) {
+        logger.info("Failed to display gotit tooltip", e)
+      }
     }
   }
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -116,22 +116,27 @@ duration.x-months-ago={0} months ago
 duration.last-year=Last year
 duration.x-years-ago={0} years ago
 duration.x-ago={0} ago
+
 popup.select-chat=Select Chat
 popup.export-chat=Export Chat As JSON
 popup.remove-chat=Remove Chat
 popup.remove-all-chats=Remove All Chats
 export.failed=Cody: Chat export failed. Please retry...
 export.timed-out=Cody: Chat export timed out. Please retry...
+
 PromptPanel.ask-cody.message=Message (type @ to include specific files as context)
 PromptPanel.ask-cody.follow-up-message=Follow-up message (type @ to include specific files as context)
 LlmDropdown.disabled.text=Start a new chat to change the model
+
 # Actions Groups
 group.SourcegraphEditor.text=Sourcegraph
 group.CodyStatusBarActions.text=Cody
 group.CodyEditorActions.text=Cody
+
 # Authentication Actions
 action.Cody.Accounts.LogInToSourcegraphAction.text=Log In to Sourcegraph
 action.Cody.Accounts.AddCodyEnterpriseAccount.text=Log In with Token to Sourcegraph Enterprise
+
 # Sourcegraph Actions
 action.sourcegraph.openFile.text=Open Selection in Sourcegraph Web
 action.sourcegraph.openFile.description=Open selection in Sourcegraph Web
@@ -146,6 +151,7 @@ action.sourcegraph.openFindPopup.text=Find with Sourcegraph...
 action.sourcegraph.openFindPopup.description=Search all your repos on Sourcegraph
 action.sourcegraph.login.text=Log in to Sourcegraph
 action.sourcegraph.login.description=Log in to Sourcegraph
+
 # Chat Actions
 action.cody.openChat.text=Open Chat
 action.cody.newChat.text=New Chat
@@ -155,6 +161,7 @@ action.cody.exportChats.description=Export all chats as JSON
 action.cody.command.Explain.text=Execute Command 'Explain Code'
 action.cody.command.Smell.text=Execute Command 'Smell Code'
 action.cody.command.Test.text=Execute Command 'Generate Test'
+
 # Inline Edit Actions
 action.cody.enableInlineEditsActions.text=Enable Inline Edits
 action.cody.editCodeAction.text=Edit Code
@@ -167,8 +174,10 @@ action.cody.cycleForwardAutocompleteAction.text=Cycle Forward Autocomplete Sugge
 action.cody.cycleBackAutocompleteAction.text=Cycle Backwards Autocomplete Suggestion
 action.cody.disposeInlays.text=Hide Completions
 action.cody.triggerAutocomplete.text=Autocomplete
+
 # GotItTooltip
 gotit.autocomplete.header=Your first Cody Autocomplete
 gotit.autocomplete.message=This is how Cody displays autocomplete suggestions.<br>Press <b>{0}</b> to insert it into the editor.<br>Press <b>{1}</b> and <b>{2}</b> to cycle through alternatives.
+
 # Other Actions
 action.cody.restartAgent.text=Restart Cody Agent

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -116,27 +116,22 @@ duration.x-months-ago={0} months ago
 duration.last-year=Last year
 duration.x-years-ago={0} years ago
 duration.x-ago={0} ago
-
 popup.select-chat=Select Chat
 popup.export-chat=Export Chat As JSON
 popup.remove-chat=Remove Chat
 popup.remove-all-chats=Remove All Chats
 export.failed=Cody: Chat export failed. Please retry...
 export.timed-out=Cody: Chat export timed out. Please retry...
-
 PromptPanel.ask-cody.message=Message (type @ to include specific files as context)
 PromptPanel.ask-cody.follow-up-message=Follow-up message (type @ to include specific files as context)
 LlmDropdown.disabled.text=Start a new chat to change the model
-
 # Actions Groups
 group.SourcegraphEditor.text=Sourcegraph
 group.CodyStatusBarActions.text=Cody
 group.CodyEditorActions.text=Cody
-
 # Authentication Actions
 action.Cody.Accounts.LogInToSourcegraphAction.text=Log In to Sourcegraph
 action.Cody.Accounts.AddCodyEnterpriseAccount.text=Log In with Token to Sourcegraph Enterprise
-
 # Sourcegraph Actions
 action.sourcegraph.openFile.text=Open Selection in Sourcegraph Web
 action.sourcegraph.openFile.description=Open selection in Sourcegraph Web
@@ -151,7 +146,6 @@ action.sourcegraph.openFindPopup.text=Find with Sourcegraph...
 action.sourcegraph.openFindPopup.description=Search all your repos on Sourcegraph
 action.sourcegraph.login.text=Log in to Sourcegraph
 action.sourcegraph.login.description=Log in to Sourcegraph
-
 # Chat Actions
 action.cody.openChat.text=Open Chat
 action.cody.newChat.text=New Chat
@@ -161,7 +155,6 @@ action.cody.exportChats.description=Export all chats as JSON
 action.cody.command.Explain.text=Execute Command 'Explain Code'
 action.cody.command.Smell.text=Execute Command 'Smell Code'
 action.cody.command.Test.text=Execute Command 'Generate Test'
-
 # Inline Edit Actions
 action.cody.enableInlineEditsActions.text=Enable Inline Edits
 action.cody.editCodeAction.text=Edit Code
@@ -174,6 +167,8 @@ action.cody.cycleForwardAutocompleteAction.text=Cycle Forward Autocomplete Sugge
 action.cody.cycleBackAutocompleteAction.text=Cycle Backwards Autocomplete Suggestion
 action.cody.disposeInlays.text=Hide Completions
 action.cody.triggerAutocomplete.text=Autocomplete
-
+# GotItTooltip
+gotit.autocomplete.header=Your first Cody Autocomplete
+gotit.autocomplete.message=This is how Cody displays autocomplete suggestions.<br>Press <b>{0}</b> to insert it into the editor.<br>Press <b>{1}</b> and <b>{2}</b> to cycle through alternatives.
 # Other Actions
 action.cody.restartAgent.text=Restart Cody Agent


### PR DESCRIPTION
Fixes #1319.

Previously, users didn't get any onboarding instructions when using Cody for the first time in JetBrains. For example, many users didn't know they should press TAB to accept an autocomplete suggestion, or option-bracket to cycle through options. This PR fixes the problem by using the built-in `GotItTooltip` component, which is designed for this use-case.

## Test plan

Manually tested. 
![CleanShot 2024-04-18 at 16 01 48@2x](https://github.com/sourcegraph/jetbrains/assets/1408093/5d01db65-72e2-44a1-8288-8dbac5ea6ab8)


<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
