### PR TITLE
Cody Ignore: Add an action to override the Cody Ignore policy for testing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=0fac85f348b63dfb3ccec0c547b75cc7df08ffc8
+cody.commit=3a50f57ca0a249c05851cc19ec891f49885dff86

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -69,6 +69,15 @@ public class CodyAgentClient {
     }
   }
 
+  @Nullable Consumer<Void> onIgnoreDidChange;
+
+  @JsonNotification("ignore/didChange")
+  public void ignoreDidChange() {
+    if (onIgnoreDidChange != null) {
+      onIgnoreDidChange.accept(null);
+    }
+  }
+
   @JsonRequest("textDocument/edit")
   public CompletableFuture<Void> textDocumentEdit(TextDocumentEditParams params) {
     return acceptOnEventThread("textDocument/edit", onTextDocumentEdit, params);

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -65,11 +65,6 @@ interface CodyAgentServer {
   @JsonNotification("autocomplete/completionAccepted")
   fun completionAccepted(logID: CompletionItemParams)
 
-  @JsonNotification("remoteRepo/didChange") fun remoteRepoDidChange()
-
-  @JsonNotification("remoteRepo/didChangeState")
-  fun remoteRepoDidChangeState(state: RemoteRepoFetchState)
-
   @JsonRequest("webview/receiveMessage")
   fun webviewReceiveMessage(params: WebviewReceiveMessageParams): CompletableFuture<Any?>
 
@@ -119,4 +114,12 @@ interface CodyAgentServer {
 
   @JsonRequest("remoteRepo/list")
   fun remoteRepoList(params: RemoteRepoListParams): CompletableFuture<RemoteRepoListResponse>
+
+  @JsonRequest("ignore/forUri")
+  fun ignoreForUri(params: IgnoreForUriParams): CompletableFuture<IgnoreForUriResponse>
+
+  @JsonRequest("testing/ignore/overridePolicy")
+  fun testingIgnoreOverridePolicy(
+      params: List<TestingIgnoreOverridePolicy?>
+  ): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -120,6 +120,6 @@ interface CodyAgentServer {
 
   @JsonRequest("testing/ignore/overridePolicy")
   fun testingIgnoreOverridePolicy(
-      params: List<TestingIgnoreOverridePolicy?>
+      params: TestingIgnoreOverridePolicy?
   ): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -119,7 +119,5 @@ interface CodyAgentServer {
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
-  fun testingIgnoreOverridePolicy(
-      params: TestingIgnoreOverridePolicy?
-  ): CompletableFuture<Unit>
+  fun testingIgnoreOverridePolicy(params: TestingIgnoreOverridePolicy?): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -115,8 +115,8 @@ interface CodyAgentServer {
   @JsonRequest("remoteRepo/list")
   fun remoteRepoList(params: RemoteRepoListParams): CompletableFuture<RemoteRepoListResponse>
 
-  @JsonRequest("ignore/forUri")
-  fun ignoreForUri(params: IgnoreForUriParams): CompletableFuture<IgnoreForUriResponse>
+  @JsonRequest("ignore/test")
+  fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
   fun testingIgnoreOverridePolicy(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -71,6 +71,10 @@ class CodyAgentService(project: Project) : Disposable {
         RemoteRepoSearcher.getInstance(project).remoteRepoDidChangeState(state)
       }
 
+      agent.client.onIgnoreDidChange = Consumer {
+        println("handling ignore rules changing not yet implemented")
+      }
+
       if (!project.isDisposed) {
         AgentChatSessionService.getInstance(project).restoreAllSessions(agent)
         CodyFileEditorListener.registerAllOpenedFiles(project, agent)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,8 +1,8 @@
 package com.sourcegraph.cody.agent.protocol
 
-data class IgnoreForUriParams(val uri: String)
+data class IgnoreTestParams(val uri: String)
 
-data class IgnoreForUriResponse(
+data class IgnoreTestResponse(
     val policy: String // "use" or "ignore"
 )
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class IgnoreForUriParams(val uri: String)
+
+data class IgnoreForUriResponse(
+    val policy: String // "use" or "ignore"
+)
+
+data class TestingIgnoreOverridePolicy(val uriRe: String, val repoRe: String)

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -43,14 +43,14 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
   override fun doOKAction() {
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
-              if (ignoreOverrideModel.enabled) {
-                TestingIgnoreOverridePolicy(
-                    uriRe = ignoreOverrideModel.uriRe,
-                    repoRe = ignoreOverrideModel.repoRe,
-                )
-              } else {
-                null
-              })
+          if (ignoreOverrideModel.enabled) {
+            TestingIgnoreOverridePolicy(
+                uriRe = ignoreOverrideModel.uriRe,
+                repoRe = ignoreOverrideModel.repoRe,
+            )
+          } else {
+            null
+          })
     }
     super.doOKAction()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -1,0 +1,64 @@
+package com.sourcegraph.cody.internals
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.dsl.builder.*
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.TestingIgnoreOverridePolicy
+import javax.swing.JComponent
+
+data object ignoreOverrideModel {
+  var enabled: Boolean = false
+  var uriRe: String = ""
+  var repoRe: String = ""
+}
+
+class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
+  init {
+    super.init()
+    title = "Testing: Cody Ignore"
+  }
+
+  override fun createCenterPanel(): JComponent {
+    return panel {
+      lateinit var overrideCheckbox: Cell<JBCheckBox>
+      row {
+        overrideCheckbox =
+            checkBox("Override policy for testing").bindSelected(ignoreOverrideModel::enabled)
+      }
+      row {
+        label("URI Regex (ECMA-262):")
+        textField().enabledIf(overrideCheckbox.selected).bindText(ignoreOverrideModel::uriRe)
+      }
+      row {
+        label("Repo regex (ECMA-262):")
+        textField().enabledIf(overrideCheckbox.selected).bindText(ignoreOverrideModel::repoRe)
+      }
+    }
+  }
+
+  override fun doOKAction() {
+    CodyAgentService.withAgent(project) { agent ->
+      agent.server.testingIgnoreOverridePolicy(
+          listOf(
+              if (ignoreOverrideModel.enabled) {
+                TestingIgnoreOverridePolicy(
+                    uriRe = ignoreOverrideModel.uriRe,
+                    repoRe = ignoreOverrideModel.repoRe,
+                )
+              } else {
+                null
+              }))
+    }
+    super.doOKAction()
+  }
+}
+
+class IgnoreOverrideAction(val project: Project) : DumbAwareAction("Testing: Cody Ignore") {
+  override fun actionPerformed(e: AnActionEvent) {
+    IgnoreOverrideDialog(project).show()
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -43,7 +43,6 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
   override fun doOKAction() {
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
-          listOf(
               if (ignoreOverrideModel.enabled) {
                 TestingIgnoreOverridePolicy(
                     uriRe = ignoreOverrideModel.uriRe,
@@ -51,7 +50,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
                 )
               } else {
                 null
-              }))
+              })
     }
     super.doOKAction()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
@@ -12,7 +12,7 @@ class InternalsStatusBarActionGroup : DefaultActionGroup() {
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    e.presentation.isVisible = ConfigUtil.isCodyDebugEnabled()
+    e.presentation.isVisible = ConfigUtil.isFeatureFlagEnabled("cody.feature.internals-menu")
     removeAll()
     if (e.project != null) {
       addAll(

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
@@ -1,0 +1,23 @@
+package com.sourcegraph.cody.internals
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.sourcegraph.cody.ui.BGTActionSetter
+import com.sourcegraph.config.ConfigUtil
+
+class InternalsStatusBarActionGroup : DefaultActionGroup() {
+  init {
+    BGTActionSetter.runUpdateOnBackgroundThread(this)
+  }
+
+  override fun update(e: AnActionEvent) {
+    super.update(e)
+    e.presentation.isVisible = ConfigUtil.isCodyDebugEnabled()
+    removeAll()
+    if (e.project != null) {
+      addAll(
+          IgnoreOverrideAction(e.project!!),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidget.kt
@@ -1,0 +1,56 @@
+package com.sourcegraph.cody.internals
+
+import com.intellij.ide.DataManager
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.ListPopup
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
+import com.sourcegraph.cody.statusbar.CodyWidgetFactory
+
+class InternalsStatusBarWidget(project: Project) : EditorBasedStatusBarPopup(project, false) {
+  override fun ID(): String = CodyWidgetFactory.ID
+
+  override fun getWidgetState(file: VirtualFile?): WidgetState {
+    val state = WidgetState("Cody Internals", "Internals", true)
+    return state
+  }
+
+  override fun createPopup(context: DataContext?): ListPopup {
+    val actionGroup =
+        ActionManager.getInstance().getAction("InternalStatusBarActions") as? ActionGroup
+            ?: InternalsStatusBarActionGroup()
+    return JBPopupFactory.getInstance()
+        .createActionGroupPopup(
+            "Cody Internals",
+            actionGroup,
+            DataManager.getInstance().getDataContext(this.component),
+            JBPopupFactory.ActionSelectionAid.SPEEDSEARCH,
+            true)
+  }
+
+  override fun createInstance(project: Project): StatusBarWidget {
+    return InternalsStatusBarWidget(project)
+  }
+
+  companion object {
+
+    fun update(project: Project) {
+      val widget: InternalsStatusBarWidget? = findWidget(project)
+      widget?.update { widget.myStatusBar.updateWidget(InternalsStatusBarWidgetFactory.ID) }
+    }
+
+    private fun findWidget(project: Project): InternalsStatusBarWidget? {
+      val widget =
+          WindowManager.getInstance()
+              .getStatusBar(project)
+              ?.getWidget(InternalsStatusBarWidgetFactory.ID)
+      return if (widget is InternalsStatusBarWidget) widget else null
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidgetFactory.kt
@@ -2,13 +2,21 @@ package com.sourcegraph.cody.internals
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.StatusBar
 import com.intellij.openapi.wm.StatusBarWidget
-import com.intellij.openapi.wm.impl.status.widget.StatusBarEditorBasedWidgetFactory
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.sourcegraph.config.ConfigUtil
 
-class InternalsStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() {
+class InternalsStatusBarWidgetFactory : StatusBarWidgetFactory {
   override fun getId(): String = ID
 
   override fun getDisplayName(): String = "⚠\uFE0F Cody Internals"
+
+  override fun isAvailable(project: Project): Boolean {
+    return ConfigUtil.isFeatureFlagEnabled("cody.feature.internals-menu")
+  }
+
+  override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
 
   override fun createWidget(project: Project): StatusBarWidget = InternalsStatusBarWidget(project)
 

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarWidgetFactory.kt
@@ -1,0 +1,22 @@
+package com.sourcegraph.cody.internals
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.impl.status.widget.StatusBarEditorBasedWidgetFactory
+
+class InternalsStatusBarWidgetFactory : StatusBarEditorBasedWidgetFactory() {
+  override fun getId(): String = ID
+
+  override fun getDisplayName(): String = "⚠\uFE0F Cody Internals"
+
+  override fun createWidget(project: Project): StatusBarWidget = InternalsStatusBarWidget(project)
+
+  override fun disposeWidget(widget: StatusBarWidget) {
+    Disposer.dispose(widget)
+  }
+
+  companion object {
+    const val ID = "cody.internalsStatusBarWidget"
+  }
+}

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -132,6 +132,7 @@ LlmDropdown.disabled.text=Start a new chat to change the model
 group.SourcegraphEditor.text=Sourcegraph
 group.CodyStatusBarActions.text=Cody
 group.CodyEditorActions.text=Cody
+group.InternalsStatusBarActions.text=?? Internals
 
 # Authentication Actions
 action.Cody.Accounts.LogInToSourcegraphAction.text=Log In to Sourcegraph

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -86,7 +86,9 @@
         <errorHandler
                 implementation="com.sourcegraph.cody.error.CodyErrorSubmitter"/>
 
-        <!-- status bar -->
+        <!-- status bar widgets -->
+        <statusBarWidgetFactory order="first" id="cody.internalsStatusBarWidget"
+                                implementation="com.sourcegraph.cody.internals.InternalsStatusBarWidgetFactory"/>
         <statusBarWidgetFactory order="first" id="cody.statusBarWidget"
                                 implementation="com.sourcegraph.cody.statusbar.CodyWidgetFactory"/>
         <actionPromoter order="last"
@@ -264,6 +266,10 @@
 
         <group id="CodyStatusBarActions" popup="true" searchable="false"
                class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup">
+        </group>
+
+        <group id="InternalsStatusBarActions" popup="true" searchable="false"
+               class="com.sourcegraph.cody.internals.InternalsStatusBarActionGroup">
         </group>
 
         <group id="Cody.Accounts.AddAccount">


### PR DESCRIPTION
This adds some plumbing for Cody Ignore, and a way to interactively test that locally in IntelliJ without admin access to a Sourcegraph instance.

- Adds Agent protocol stubs for Cody Ignore protocol. These depend on Agent-side changes in sourcegraph/cody#3858
- Adds an "internals" menu to the status bar, hidden behind a feature flag, for doing ad-hoc manual ignore policy settings

Part of #1252

## Test plan

- Run agent with sourcegraph/cody#3858
- Run the plugin with `CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true` and open a clone of the sourcegraph/sourcegraph repo
- On the status bar, Internals, Testing: Cody Ignore
- Check *Override policy for testing*
- Enter URI regex `\.go$` . Any repo regex is fine; that setting is currently unused on the extension side. Click OK.
- Verify that console output includes `handling ignore rules changing not yet implemented`. This indicates the testing override generated a notification that the rules have changed, through to the stub in the extension.
- Start a chat
- In the Enhanced Context Selector, ensure *Chat Context* is checked. Uncheck any specific repos.
- Open a Go file, for example `cmd/batcheshelper/main.go` and highlight some code
- In chat, ask Cody "what does this do?" There should be *no local context* and Cody should make something up unrelated to the highlighted code.
- On the status bar, Internals, Testing: Cody Ignore. Uncheck *Override policy for testing*. OK. Again verify console output.
- In chat, hit up and resubmit the same chat message. There should be local context from the open Go file and Cody should comment related to that code.
- Run the plugin again *without* `CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true` and verify that the Internals menu does not appear on the status bar.
