### PR TITLE
QA test of agent using new JSON-RPC library

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,5 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=0fac85f348b63dfb3ccec0c547b75cc7df08ffc8
+# TODO(sqs): not for merging into main, just for a QA pass on the agent PR at https://github.com/sourcegraph/cody/pull/3807
+cody.commit=3ae258a4a89c993a4ffc11e1acad964ea5b9489c


### PR DESCRIPTION
The PR at https://github.com/sourcegraph/cody/pull/3807 switches the JSON-RPC library used by the agent. This should not change anything, but just to be safe, we want to run a QA test on it.

This PR is not intended to be merged. If the QA test passes, we will merge that PR and then point this JetBrains repo at the commit on `main`.

Slack thread: https://sourcegraph.slack.com/archives/C06GFD8GFCN/p1713601212183189


## Test plan

See above