### PR TITLE
Push enhanced context state to the extension when creating an EnhancedContextPanel

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -256,11 +256,18 @@ private constructor(
     // Update the extension-side state.
     val remoteRepos = state.enhancedContext?.remoteRepositories
     if (remoteRepos != null) {
-      RemoteRepoUtils.resolveReposWithErrorNotification(project, remoteRepos.filter { it -> it.isEnabled && it.codebaseName != null }.map { it -> CodebaseName(it.codebaseName!!) }.toList()) { resolvedRepos ->
-        sendWebviewMessage(
-          WebviewMessage(
-            command = "context/choose-remote-search-repo", explicitRepos=resolvedRepos))
-      }.join()
+      RemoteRepoUtils.resolveReposWithErrorNotification(
+              project,
+              remoteRepos
+                  .filter { it -> it.isEnabled && it.codebaseName != null }
+                  .map { it -> CodebaseName(it.codebaseName!!) }
+                  .toList()) { resolvedRepos ->
+                sendWebviewMessage(
+                    WebviewMessage(
+                        command = "context/choose-remote-search-repo",
+                        explicitRepos = resolvedRepos))
+              }
+          .join()
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -13,16 +13,11 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.ExtensionMessage
 import com.sourcegraph.cody.agent.WebviewMessage
 import com.sourcegraph.cody.agent.WebviewReceiveMessageParams
-import com.sourcegraph.cody.agent.protocol.ChatError
-import com.sourcegraph.cody.agent.protocol.ChatMessage
-import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
-import com.sourcegraph.cody.agent.protocol.ChatRestoreParams
-import com.sourcegraph.cody.agent.protocol.ChatSubmitMessageParams
-import com.sourcegraph.cody.agent.protocol.ContextItem
-import com.sourcegraph.cody.agent.protocol.Speaker
+import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.chat.ui.ChatPanel
 import com.sourcegraph.cody.commands.CommandId
 import com.sourcegraph.cody.config.RateLimitStateManager
+import com.sourcegraph.cody.context.RemoteRepoUtils
 import com.sourcegraph.cody.error.CodyErrorSubmitter
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.ChatState
@@ -31,6 +26,7 @@ import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
 import com.sourcegraph.telemetry.GraphQlLogger
+import com.sourcegraph.vcs.CodebaseName
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
@@ -256,6 +252,16 @@ private constructor(
     val newConnectionId =
         restoreChatSession(agent, chatMessages, chatModelProviderFromState, state.internalId!!)
     connectionId.getAndSet(newConnectionId)
+
+    // Update the extension-side state.
+    val remoteRepos = state.enhancedContext?.remoteRepositories
+    if (remoteRepos != null) {
+      RemoteRepoUtils.resolveReposWithErrorNotification(project, remoteRepos.filter { it -> it.isEnabled && it.codebaseName != null }.map { it -> CodebaseName(it.codebaseName!!) }.toList()) { resolvedRepos ->
+        sendWebviewMessage(
+          WebviewMessage(
+            command = "context/choose-remote-search-repo", explicitRepos=resolvedRepos))
+      }.join()
+    }
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
@@ -1,11 +1,15 @@
 package com.sourcegraph.cody.context
 
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.GetRepoIdsParam
 import com.sourcegraph.cody.agent.protocol.Repo
+import com.sourcegraph.cody.context.ui.MAX_REMOTE_REPOSITORY_COUNT
+import com.sourcegraph.cody.context.ui.RemoteRepoResolutionFailedNotification
 import com.sourcegraph.vcs.CodebaseName
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
 object RemoteRepoUtils {
   /**
@@ -31,5 +35,21 @@ object RemoteRepoUtils {
       }
     }
     return result
+  }
+
+  /**
+   * Resolves the repositories named in `repos` and runs `callback` with the first `MAX_REMOTE_REPOSITORY_COUNT` of
+   * them. If remote repo resolution fails, displays an error message instead.
+   */
+  fun resolveReposWithErrorNotification(project: Project, repos: List<CodebaseName>, callback: (List<Repo>) -> Unit): CompletableFuture<Unit> {
+    return getRepositories(project, repos)
+      .completeOnTimeout(null, 15, TimeUnit.SECONDS)
+      .thenApply { resolvedRepos ->
+        if (resolvedRepos == null || (resolvedRepos.isEmpty() && repos.isNotEmpty())) {
+          runInEdt { RemoteRepoResolutionFailedNotification().notify(project) }
+          return@thenApply
+        }
+        callback(resolvedRepos.take(MAX_REMOTE_REPOSITORY_COUNT))
+      }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoUtils.kt
@@ -38,18 +38,23 @@ object RemoteRepoUtils {
   }
 
   /**
-   * Resolves the repositories named in `repos` and runs `callback` with the first `MAX_REMOTE_REPOSITORY_COUNT` of
-   * them. If remote repo resolution fails, displays an error message instead.
+   * Resolves the repositories named in `repos` and runs `callback` with the first
+   * `MAX_REMOTE_REPOSITORY_COUNT` of them. If remote repo resolution fails, displays an error
+   * message instead.
    */
-  fun resolveReposWithErrorNotification(project: Project, repos: List<CodebaseName>, callback: (List<Repo>) -> Unit): CompletableFuture<Unit> {
+  fun resolveReposWithErrorNotification(
+      project: Project,
+      repos: List<CodebaseName>,
+      callback: (List<Repo>) -> Unit
+  ): CompletableFuture<Unit> {
     return getRepositories(project, repos)
-      .completeOnTimeout(null, 15, TimeUnit.SECONDS)
-      .thenApply { resolvedRepos ->
-        if (resolvedRepos == null || (resolvedRepos.isEmpty() && repos.isNotEmpty())) {
-          runInEdt { RemoteRepoResolutionFailedNotification().notify(project) }
-          return@thenApply
+        .completeOnTimeout(null, 15, TimeUnit.SECONDS)
+        .thenApply { resolvedRepos ->
+          if (resolvedRepos == null || (resolvedRepos.isEmpty() && repos.isNotEmpty())) {
+            runInEdt { RemoteRepoResolutionFailedNotification().notify(project) }
+            return@thenApply
+          }
+          callback(resolvedRepos.take(MAX_REMOTE_REPOSITORY_COUNT))
         }
-        callback(resolvedRepos.take(MAX_REMOTE_REPOSITORY_COUNT))
-      }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -280,7 +280,7 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
   // Given a textual list of repos, extract a best effort list of repositories from it and update
   // context settings.
   private fun applyRepoSpec(spec: String) {
-    val repos = spec.split(Regex("""\s+""")).toSet()
+    val repos = spec.split(Regex("""\s+""")).filter { it -> it != "" }.toSet()
     RemoteRepoUtils.resolveReposWithErrorNotification(
         project, repos.map { it -> CodebaseName(it) }.toList()) { trimmedRepos ->
           runInEdt {

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -248,6 +248,15 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     treeRoot.add(contextRoot)
     treeModel.reload()
     resize()
+
+    // Update the extension-side state for this chat.
+    RemoteRepoUtils.resolveReposWithErrorNotification(project, repoNames.map{it -> CodebaseName(it)}) { repos ->
+      chatSession.sendWebviewMessage(
+        WebviewMessage(
+          command = "context/choose-remote-search-repo", explicitRepos=repos
+        )
+      )
+    }
   }
 
   @RequiresEdt

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -13,7 +13,6 @@ import com.intellij.ui.ToolbarDecorator.createDecorator
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.vcs.commit.NonModalCommitPanel.Companion.showAbove
 import com.sourcegraph.cody.agent.WebviewMessage
-import com.sourcegraph.cody.agent.protocol.Repo
 import com.sourcegraph.cody.chat.ChatSession
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.context.RemoteRepo
@@ -24,7 +23,6 @@ import com.sourcegraph.cody.history.state.RemoteRepositoryState
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.vcs.CodebaseName
 import java.awt.Dimension
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.BorderFactory
@@ -250,13 +248,11 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     resize()
 
     // Update the extension-side state for this chat.
-    RemoteRepoUtils.resolveReposWithErrorNotification(project, repoNames.map{it -> CodebaseName(it)}) { repos ->
-      chatSession.sendWebviewMessage(
-        WebviewMessage(
-          command = "context/choose-remote-search-repo", explicitRepos=repos
-        )
-      )
-    }
+    RemoteRepoUtils.resolveReposWithErrorNotification(
+        project, repoNames.map { it -> CodebaseName(it) }) { repos ->
+          chatSession.sendWebviewMessage(
+              WebviewMessage(command = "context/choose-remote-search-repo", explicitRepos = repos))
+        }
   }
 
   @RequiresEdt
@@ -285,30 +281,31 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
   // context settings.
   private fun applyRepoSpec(spec: String) {
     val repos = spec.split(Regex("""\s+""")).toSet()
-    RemoteRepoUtils.resolveReposWithErrorNotification(project, repos.map { it -> CodebaseName(it) }.toList()) { trimmedRepos ->
-      runInEdt {
-        // Update the plugin's copy of the state.
-        updateContextState { state ->
-          state.remoteRepositories.clear()
-          state.remoteRepositories.addAll(
-            trimmedRepos.map { repo ->
-              RemoteRepositoryState().apply {
-                codebaseName = repo.name
-                isEnabled = true
-              }
-            })
+    RemoteRepoUtils.resolveReposWithErrorNotification(
+        project, repos.map { it -> CodebaseName(it) }.toList()) { trimmedRepos ->
+          runInEdt {
+            // Update the plugin's copy of the state.
+            updateContextState { state ->
+              state.remoteRepositories.clear()
+              state.remoteRepositories.addAll(
+                  trimmedRepos.map { repo ->
+                    RemoteRepositoryState().apply {
+                      codebaseName = repo.name
+                      isEnabled = true
+                    }
+                  })
+            }
+
+            // Update the UI.
+            updateTree(trimmedRepos.map { it -> it.name })
+            resize()
+
+            // Update the extension state.
+            chatSession.sendWebviewMessage(
+                WebviewMessage(
+                    command = "context/choose-remote-search-repo", explicitRepos = trimmedRepos))
+          }
         }
-
-        // Update the UI.
-        updateTree(trimmedRepos.map { it -> it.name })
-        resize()
-
-        // Update the extension state.
-        chatSession.sendWebviewMessage(
-          WebviewMessage(
-            command = "context/choose-remote-search-repo", explicitRepos=trimmedRepos))
-      }
-    }
   }
 
   private fun setRepoEnabledInContextState(repoName: String, enabled: Boolean) {


### PR DESCRIPTION
Fixes #1347

## Test plan

- Open a clone of the sourcegraph repo
- Start a chat, click Pencil, add `github.com/sourcegraph/cody` repo, cmd-enter to commit
- Ask "how do local embeddings work", there should be some context results from the `cody` repo
- Click pencil, add `github.com/sourcegraph/handbook` repo, cmd-enter to commit
- Click "new chat" button
- Ask "what's the role of an engineering manager?", there should be some context results from the `handbook` repo
- Click pencil, delete the handbook repo, cmd-enter to commit
- Ask "what's the role of an engineering manager?", there should be no context results from the `handbook` repo
- Chat history, select the first chat, the repo selector should show the cody and handbook repos
- Chat history, select the second chat, the repo selector should show the cody repo
