### PR TITLE
Better error message for failed workspace edit operations

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/EditException.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/EditException.kt
@@ -1,0 +1,9 @@
+package com.sourcegraph.cody.edit.sessions
+
+import com.intellij.openapi.editor.RangeMarker
+import com.sourcegraph.cody.agent.protocol.TextEdit
+
+class EditException(val edit: TextEdit, val marker: RangeMarker, cause: Throwable) :
+    RuntimeException(cause) {
+  override val message: String = "Edit failed: $edit at $marker}"
+}


### PR DESCRIPTION
The logs would look like this:
```
INFO - FixupSession - Applying edits to a file: file://~/devel/cody-intellij/src/main/kotlin/com/sourcegraph/cody/auth/PersistentActiveAccountHolder.kt
SEVERE - org.eclipse.lsp4j.jsonrpc.RemoteEndpoint - Internal error: com.sourcegraph.cody.edit.sessions.EditException: Edit failed: TextEdit(type=replace, range=Range(start=Position(line=40, character=63), end=Position(line=40, character=64)), position=null, value=) at RangeMarker(1295,1296) 1714}
java.util.concurrent.CompletionException: com.sourcegraph.cody.edit.sessions.EditException: Edit failed: TextEdit(type=replace, range=Range(start=Position(line=40, character=63), end=Position(line=40, character=64)), position=null, value=) at RangeMarker(1295,1296) 1714}
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
...
```

This should make it easier to debug #1234.

## Test plan

No new functionality, no new tests needed