### PR TITLE
Apply repository cleaning, limits to old chat history state

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -16,6 +16,7 @@ import com.sourcegraph.cody.agent.WebviewReceiveMessageParams
 import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.chat.ui.ChatPanel
 import com.sourcegraph.cody.commands.CommandId
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.RateLimitStateManager
 import com.sourcegraph.cody.context.RemoteRepoUtils
 import com.sourcegraph.cody.error.CodyErrorSubmitter
@@ -255,7 +256,7 @@ private constructor(
 
     // Update the extension-side state.
     val remoteRepos = state.enhancedContext?.remoteRepositories
-    if (remoteRepos != null) {
+    if (remoteRepos != null && CodyAuthenticationManager.getInstance(project).getActiveAccount()?.isDotcomAccount() == false) {
       RemoteRepoUtils.resolveReposWithErrorNotification(
               project,
               remoteRepos

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -256,7 +256,9 @@ private constructor(
 
     // Update the extension-side state.
     val remoteRepos = state.enhancedContext?.remoteRepositories
-    if (remoteRepos != null && CodyAuthenticationManager.getInstance(project).getActiveAccount()?.isDotcomAccount() == false) {
+    if (remoteRepos != null &&
+        CodyAuthenticationManager.getInstance(project).getActiveAccount()?.isDotcomAccount() ==
+            false) {
       RemoteRepoUtils.resolveReposWithErrorNotification(
               project,
               remoteRepos

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -241,16 +241,18 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     contextRoot.endpointName = endpoint
     contextRoot.add(remotesNode)
 
-    val enabledRepoNames = cleanedRepos.filter { it.isEnabled }.mapNotNull { it.codebaseName }
-    updateTree(enabledRepoNames)
-
     treeRoot.add(contextRoot)
     treeModel.reload()
     resize()
 
     // Update the extension-side state for this chat.
+    val enabledRepos = cleanedRepos.filter { it.isEnabled }.mapNotNull { it.codebaseName }
     RemoteRepoUtils.resolveReposWithErrorNotification(
-        project, enabledRepoNames.map { it -> CodebaseName(it) }) { repos ->
+        project, enabledRepos.map { it -> CodebaseName(it) }) { repos ->
+          runInEdt {
+            updateTree(repos.map { it.name })
+            resize()
+          }
           chatSession.sendWebviewMessage(
               WebviewMessage(command = "context/choose-remote-search-repo", explicitRepos = repos))
         }


### PR DESCRIPTION
Fixes #1366

## Test plan

Manually tested:

1. Sign into an Enterprise account
1. Pencil, add a repository
1. Ask Cody something in chat
1. Close IntelliJ
1. Open `/path/to/workspace/.idea/cody_history.xml` and search for the chat message. Change the `<remoteRepositories>` list to include nulls, duplicates, more than 10 repositories, etc. See below for an example.
1. Reopen IntelliJ, Cody, Chat History, open the chat.
1. Verify that only there are no duplicate repos, `null` does not appear, etc.

```xml
                <enhancedContext>
                  <enhancedContext>
                    <remoteRepositories>
                      <list>
                        <remoteRepository />
                        <remoteRepository />
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository />
                        <remoteRepository />
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="github.com/sourcegraph/cody" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="github.com/sourcegraph/emacs-cody" />
                        </remoteRepository>
                        <remoteRepository>
                          <codebaseName value="jdk" />
                        </remoteRepository>
                      </list>
                    </remoteRepositories>
                  </enhancedContext>
                </enhancedContext>
```