### PR TITLE
Log the total size (in chars) of the document that's being edited.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -287,7 +287,7 @@ abstract class FixupSession(
           if (op.edits == null) {
             logger.warn("Workspace edit operation has no edits")
           } else {
-            logger.info("Applying edits to a file: ${op.uri}")
+            logger.info("Applying edits to a file (size ${document.textLength} chars): ${op.uri}")
             performInlineEdits(op.edits)
           }
         }


### PR DESCRIPTION
The log now looks like this:
```
2024-04-24 11:09:39,364 [  76359]   INFO - #com.sourcegraph.cody.edit.sessions.FixupSession - Applying edits to a file (size 6348 chars): file://~/devel/cody-intellij/src/main/java/com/sourcegraph/find/PreviewPanel.java
```

## Test plan
Checked manually