### PR TITLE
Pass `JetbrainsDocumentEvent` to `textDocument/didChange` (fixes #1371)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/JetbrainsDocumentEvent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/JetbrainsDocumentEvent.kt
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class JetbrainsDocumentEvent(
+    val offset: Int,
+    val oldLength: Int,
+    val content: String,
+)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/JetbrainsDocumentEvent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/JetbrainsDocumentEvent.kt
@@ -1,7 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class JetbrainsDocumentEvent(
-    val offset: Int,
-    val oldLength: Int,
-    val content: String,
-)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -10,7 +10,7 @@ class ProtocolTextDocument
 private constructor(
     var uri: String,
     var content: String?,
-    var jetbrainsDocumentEvent: JetbrainsDocumentEvent?,
+    var textDocumentContentChangeEvents: List<TextDocumentContentChangeEvent>?,
     var selection: Range?,
 ) {
 
@@ -48,15 +48,16 @@ private constructor(
       val text = FileDocumentManager.getInstance().getDocument(file)?.text
       val selection = getSelection(editor)
 
-      val jetbrainsDocumentEvent =
+      val textDocumentContentChangeEvent =
           if (event != null) {
-            JetbrainsDocumentEvent(
-                content = event.newFragment.toString(),
-                oldLength = event.oldLength,
-                offset = event.offset)
+            TextDocumentContentChangeEvent(
+                text = event.newFragment.toString(),
+                rangeLength = event.oldLength,
+                rangeOffset = event.offset)
           } else null
 
-      return ProtocolTextDocument(uriFor(file), text, jetbrainsDocumentEvent, selection)
+      return ProtocolTextDocument(
+          uriFor(file), text, listOfNotNull(textDocumentContentChangeEvent), selection)
     }
 
     fun uriFor(file: VirtualFile): String {

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocumentContentChangeEvent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TextDocumentContentChangeEvent.kt
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class TextDocumentContentChangeEvent(
+    val rangeOffset: Int,
+    val rangeLength: Int,
+    val text: String,
+)

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -41,7 +41,7 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
         CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
         !CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
 
-      ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
+      ProtocolTextDocument.fromEditor(editor, event)?.let { textDocument ->
         CodyAgentService.withAgent(project) { agent ->
           agent.server.textDocumentDidChange(textDocument)
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -28,10 +29,10 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
     }
   }
 
-  override fun documentChangedNonBulk(event: DocumentEvent) {
+  override fun documentChangedNonBulk(event: DocumentEvent) = runInEdt {
     val editor = FileEditorManager.getInstance(project).selectedTextEditor
     if (editor?.document != event.document) {
-      return
+      return@runInEdt
     }
 
     logCodeCopyPastedFromChat(event)


### PR DESCRIPTION
This PR adds `DocumentEvent` data to [ProtocolTextDocument.kt](https://github.com/sourcegraph/jetbrains/pull/1388/files#diff-c0bb048e18268f186841365d5e966eaff9f89d04f2d3b3ac48544510eadda0fb). It allows us to derive the `contentChanges` that are crucial to properly track changes, diffs, markers (ranges).

## Cody PR
https://github.com/sourcegraph/cody/pull/3931

## Test plan
In particular: 
- Inline edits should work properly while modifying the file (fixes #1371)
