### PR TITLE
Simplify agent packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,18 +24,17 @@ jobs:
           platforms: all
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.1.0
-      - run: ./scripts/install-ldid.sh
       - run: yarn global add pnpm@8.6.7
       - run: |
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
-      - run: ./gradlew "-PldidSign=true" "-PpluginVersion=$RELEASE_VERSION" publishPlugin
+      - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
       - name: Publish nightly version
         if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
         run: |
           echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
-          ./gradlew "-PldidSign=true" "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
+          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
-val isLdidSign = properties("ldidSign") == "true"
 val isForceBuild = properties("forceBuild") == "true"
 val isForceAgentBuild =
     isForceBuild ||
@@ -211,9 +210,9 @@ tasks {
     val url = "https://github.com/sourcegraph/node-binaries/archive/$nodeCommit.zip"
     val zipFile = githubArchiveCache.resolve("$nodeCommit.zip")
     download(url, zipFile)
-    val destination = githubArchiveCache.resolve("cody").resolve("cody-$nodeCommit")
+    val destination = githubArchiveCache.resolve("node").resolve("node-binaries-$nodeCommit")
     unzip(zipFile, destination.parentFile)
-    return destination.resolve("nodeVersion")
+    return destination.resolve(nodeVersion)
   }
 
   fun downloadCody(): File {
@@ -260,11 +259,6 @@ tasks {
         include("index.js.map")
         include("*.wasm")
       }
-      into(buildCodyDir)
-    }
-
-    copy {
-      from(downloadNodeBinaries())
       into(buildCodyDir)
     }
 
@@ -326,6 +320,8 @@ tasks {
     ) {
       into("agent/")
     }
+
+    from(fileTree(downloadNodeBinaries())) { into("agent/") }
 
     doLast {
       // Assert that agent binaries are included in the plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,7 @@ gradleVersion=8.1.1
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
+nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
+nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
 cody.commit=d951e25d0c84c72365bd2fffb144a3fbf1170158


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1276

## Changes

Instead of crating single file package for agent with `pkg` we bundling `js` and  `wasm` files together which `node` executables which are used to start the agent.

It solves a few issues:
* We can use newer node, as `pkg` only supported  node up to v. 18
* We can start agent the same way for debugging, developing and for the release build
* We avoid problem with memory lead on apple silicon, which was causing agent crashes for the last couple of weeks

## Test plan

Manual verification on all platforms if agent is starting properly.