### PR TITLE
Cody Ignore: Send "ignore" capability, update hook for new test override syntax

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=637ee99dd2d300f8e98e8f51c2242de24204bd92
+cody.commit=a7fe3bb4926a2ead1f94b10da46e447f58301c8c

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -113,7 +113,8 @@ private constructor(
                               edit = "enabled",
                               editWorkspace = "enabled",
                               codeLenses = "enabled",
-                              showDocument = "enabled")))
+                              showDocument = "enabled",
+                              ignore = "enabled")))
               .thenApply { info ->
                 logger.warn("Connected to Cody agent " + info.name)
                 server.initialized()

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -150,5 +150,5 @@ interface CodyAgentServer {
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
-  fun testingIgnoreOverridePolicy(params: TestingIgnoreOverridePolicy?): CompletableFuture<Unit>
+  fun testingIgnoreOverridePolicy(params: Map<String,Any>?): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -1,35 +1,6 @@
 package com.sourcegraph.cody.agent
 
-import com.sourcegraph.cody.agent.protocol.AttributionSearchParams
-import com.sourcegraph.cody.agent.protocol.AttributionSearchResponse
-import com.sourcegraph.cody.agent.protocol.AutocompleteParams
-import com.sourcegraph.cody.agent.protocol.AutocompleteResult
-import com.sourcegraph.cody.agent.protocol.ChatHistoryResponse
-import com.sourcegraph.cody.agent.protocol.ChatModelsParams
-import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
-import com.sourcegraph.cody.agent.protocol.ChatRestoreParams
-import com.sourcegraph.cody.agent.protocol.ChatSubmitMessageParams
-import com.sourcegraph.cody.agent.protocol.ClientInfo
-import com.sourcegraph.cody.agent.protocol.CompletionItemParams
-import com.sourcegraph.cody.agent.protocol.CurrentUserCodySubscription
-import com.sourcegraph.cody.agent.protocol.EditTask
-import com.sourcegraph.cody.agent.protocol.Event
-import com.sourcegraph.cody.agent.protocol.GetFeatureFlag
-import com.sourcegraph.cody.agent.protocol.GetFoldingRangeParams
-import com.sourcegraph.cody.agent.protocol.GetFoldingRangeResult
-import com.sourcegraph.cody.agent.protocol.GetRepoIdsParam
-import com.sourcegraph.cody.agent.protocol.GetRepoIdsResponse
-import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
-import com.sourcegraph.cody.agent.protocol.IgnoreTestResponse
-import com.sourcegraph.cody.agent.protocol.InlineEditParams
-import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
-import com.sourcegraph.cody.agent.protocol.RemoteRepoHasParams
-import com.sourcegraph.cody.agent.protocol.RemoteRepoHasResponse
-import com.sourcegraph.cody.agent.protocol.RemoteRepoListParams
-import com.sourcegraph.cody.agent.protocol.RemoteRepoListResponse
-import com.sourcegraph.cody.agent.protocol.ServerInfo
-import com.sourcegraph.cody.agent.protocol.TaskIdParam
-import com.sourcegraph.cody.agent.protocol.TestingIgnoreOverridePolicy
+import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.chat.ConnectionId
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
@@ -150,5 +121,5 @@ interface CodyAgentServer {
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
-  fun testingIgnoreOverridePolicy(params: Map<String,Any>?): CompletableFuture<Unit>
+  fun testingIgnoreOverridePolicy(params: IgnorePolicySpec?): CompletableFuture<Unit>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientCapabilities.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientCapabilities.kt
@@ -8,5 +8,6 @@ data class ClientCapabilities(
     var edit: String? = null,
     var editWorkspace: String? = null,
     var codeLenses: String? = null,
-    val showDocument: String? = null
+    val showDocument: String? = null,
+    val ignore: String? = null
 )

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -6,4 +6,12 @@ data class IgnoreTestResponse(
     val policy: String // "use" or "ignore"
 )
 
-data class TestingIgnoreOverridePolicy(val uriRe: String, val repoRe: String)
+data class IgnorePolicyPattern(
+    val repoNamePattern: String,
+    val filePathPatterns: List<String>?
+)
+
+data class IgnorePolicySpec(
+    val exclude: List<IgnorePolicyPattern>?,
+    val include: List<IgnorePolicyPattern>?,
+)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -6,10 +6,7 @@ data class IgnoreTestResponse(
     val policy: String // "use" or "ignore"
 )
 
-data class IgnorePolicyPattern(
-    val repoNamePattern: String,
-    val filePathPatterns: List<String>?
-)
+data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)
 
 data class IgnorePolicySpec(
     val exclude: List<IgnorePolicyPattern>?,

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -11,15 +11,12 @@ import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
-import kotlinx.serialization.SerializationException
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.jsonObject
 import javax.swing.JComponent
 
 data object ignoreOverrideModel {
   var enabled: Boolean = false
-  var policy: String = """{
+  var policy: String =
+      """{
  "exclude": [
   { "repoNamePattern": "github\\.com/sourcegraph/cody" }
  ]
@@ -41,19 +38,19 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
       }
       row {
         textArea()
-          .label("Policy JSON:")
-          .columns(40)
-          .rows(15)
-          .bindText(ignoreOverrideModel::policy)
-          .validation { textArea ->
-            try {
-              Gson().fromJson(textArea.text, IgnorePolicySpec::class.java);
-              null
-            } catch (e: JsonSyntaxException) {
-              ValidationInfo("JSON error: ${e.message}", textArea)
+            .label("Policy JSON:")
+            .columns(40)
+            .rows(15)
+            .bindText(ignoreOverrideModel::policy)
+            .validation { textArea ->
+              try {
+                Gson().fromJson(textArea.text, IgnorePolicySpec::class.java)
+                null
+              } catch (e: JsonSyntaxException) {
+                ValidationInfo("JSON error: ${e.message}", textArea)
+              }
             }
-          }
-          .enabledIf(overrideCheckbox.selected)
+            .enabledIf(overrideCheckbox.selected)
       }
     }
   }
@@ -62,7 +59,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
           if (ignoreOverrideModel.enabled) {
-            Gson().fromJson(ignoreOverrideModel.policy, IgnorePolicySpec::class.java);
+            Gson().fromJson(ignoreOverrideModel.policy, IgnorePolicySpec::class.java)
           } else {
             null
           })

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.internals
 
+import com.google.gson.Gson
+import com.google.gson.JsonSyntaxException
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
@@ -8,12 +10,11 @@ import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.TestingIgnoreOverridePolicy
+import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
-import org.jetbrains.uast.util.isInstanceOf
 import javax.swing.JComponent
 
 data object ignoreOverrideModel {
@@ -46,10 +47,9 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
           .bindText(ignoreOverrideModel::policy)
           .validation { textArea ->
             try {
-              println("${ignoreOverrideModel.policy}/${textArea.text}")
-              val element = Json.parseToJsonElement(textArea.text)
-              if (element is JsonObject) { null } else { ValidationInfo("Policy must be a JSON object", textArea) }
-            } catch (e: SerializationException) {
+              Gson().fromJson(textArea.text, IgnorePolicySpec::class.java);
+              null
+            } catch (e: JsonSyntaxException) {
               ValidationInfo("JSON error: ${e.message}", textArea)
             }
           }
@@ -62,7 +62,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
           if (ignoreOverrideModel.enabled) {
-            Json.parseToJsonElement(ignoreOverrideModel.policy).jsonObject
+            Gson().fromJson(ignoreOverrideModel.policy, IgnorePolicySpec::class.java);
           } else {
             null
           })

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -4,16 +4,25 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.DumbAwareAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.dsl.builder.*
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.TestingIgnoreOverridePolicy
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import org.jetbrains.uast.util.isInstanceOf
 import javax.swing.JComponent
 
 data object ignoreOverrideModel {
   var enabled: Boolean = false
-  var uriRe: String = ""
-  var repoRe: String = ""
+  var policy: String = """{
+ "exclude": [
+  { "repoNamePattern": "github\\.com/sourcegraph/cody" }
+ ]
+}"""
 }
 
 class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
@@ -30,12 +39,21 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
             checkBox("Override policy for testing").bindSelected(ignoreOverrideModel::enabled)
       }
       row {
-        label("URI Regex (ECMA-262):")
-        textField().enabledIf(overrideCheckbox.selected).bindText(ignoreOverrideModel::uriRe)
-      }
-      row {
-        label("Repo regex (ECMA-262):")
-        textField().enabledIf(overrideCheckbox.selected).bindText(ignoreOverrideModel::repoRe)
+        textArea()
+          .label("Policy JSON:")
+          .columns(40)
+          .rows(15)
+          .bindText(ignoreOverrideModel::policy)
+          .validation { textArea ->
+            try {
+              println("${ignoreOverrideModel.policy}/${textArea.text}")
+              val element = Json.parseToJsonElement(textArea.text)
+              if (element is JsonObject) { null } else { ValidationInfo("Policy must be a JSON object", textArea) }
+            } catch (e: SerializationException) {
+              ValidationInfo("JSON error: ${e.message}", textArea)
+            }
+          }
+          .enabledIf(overrideCheckbox.selected)
       }
     }
   }
@@ -44,10 +62,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
           if (ignoreOverrideModel.enabled) {
-            TestingIgnoreOverridePolicy(
-                uriRe = ignoreOverrideModel.uriRe,
-                repoRe = ignoreOverrideModel.repoRe,
-            )
+            Json.parseToJsonElement(ignoreOverrideModel.policy).jsonObject
           } else {
             null
           })


### PR DESCRIPTION
Fixes #1393

Part of #1252 #1253

Depends on sourcegraph/cody#3946

## Test plan

Tested manually:

1. Run the extension with
`CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true` and open the sourcegraph/sourcegraph repo.
2. Status bar, Internals, Testing: Cody Ignore
3. Check "Override policy for testing". OK.
4. Verify that no banners appear
5. Change the policy from excluding `...sourcegraph/cody` to `...sourcegraph/sourcegraph`
6. Verify that banners appear on open editors
7. Run a command like Explain Code with the right click context menu and
verify that a notification appears
8. Run a command like Explain Code with a keyboard shortcut like
ctrl-shift-E and verify that a notification appears
9. Verify when focus switches from a file within sourcegraph/sourcegraph to a file outside it, a slashed Cody icon appears in the status bar when an ignored file is focused.
10. Disable the policy override, verify that the banners/blocked commands/etc. revert.