### PR TITLE
Cody Ignore: Do not block the main thread on ignore checks

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -1,9 +1,13 @@
 package com.sourcegraph.cody.chat.actions
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
+import com.intellij.util.concurrency.AppExecutorUtil
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import com.sourcegraph.cody.chat.AgentChatSession
@@ -11,6 +15,7 @@ import com.sourcegraph.cody.commands.CommandId
 import com.sourcegraph.cody.context.ui.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.ignore.IgnorePolicy
+import java.util.concurrent.Callable
 
 abstract class BaseCommandAction : BaseChatAction() {
 
@@ -22,16 +27,28 @@ abstract class BaseCommandAction : BaseChatAction() {
       val file = FileDocumentManager.getInstance().getFile(editor.document)
       val protocolFile = file?.let { ProtocolTextDocument.fromVirtualFile(editor, it) } ?: return
 
-      // If this file is ignored, display an error and stop.
-      if (IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get() !=
-          IgnorePolicy.USE) {
-        ActionInIgnoredFileNotification().notify(project)
-        return
-      }
-
-      CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
-        switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
-      }
+      ReadAction.nonBlocking(Callable {
+        IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get()
+      })
+        .expireWith(project)
+        .finishOnUiThread(ModalityState.NON_MODAL) {
+          when (it) {
+            IgnorePolicy.USE -> {
+              CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
+                // Race: The selected text editor could change before IgnoreOracle completes, and the command runs on
+                // the wrong document. Ignore rules will still be enforced by prompt construction so this is a
+                // correctness, not a safety issue.
+                // TODO: Fix this race by giving commands an explicit document to act on.
+                switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
+              }
+            }
+            else -> {
+              // This file is ignored. Display an error and stop.
+              ActionInIgnoredFileNotification().notify(project)
+            }
+          }
+        }
+        .submit(AppExecutorUtil.getAppExecutorService())
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -3,7 +3,6 @@ package com.sourcegraph.cody.chat.actions
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
-import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
@@ -27,28 +26,27 @@ abstract class BaseCommandAction : BaseChatAction() {
       val file = FileDocumentManager.getInstance().getFile(editor.document)
       val protocolFile = file?.let { ProtocolTextDocument.fromVirtualFile(editor, it) } ?: return
 
-      ReadAction.nonBlocking(Callable {
-        IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get()
-      })
-        .expireWith(project)
-        .finishOnUiThread(ModalityState.NON_MODAL) {
-          when (it) {
-            IgnorePolicy.USE -> {
-              CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
-                // Race: The selected text editor could change before IgnoreOracle completes, and the command runs on
-                // the wrong document. Ignore rules will still be enforced by prompt construction so this is a
-                // correctness, not a safety issue.
-                // TODO: Fix this race by giving commands an explicit document to act on.
-                switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
+      ReadAction.nonBlocking(
+              Callable { IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get() })
+          .expireWith(project)
+          .finishOnUiThread(ModalityState.NON_MODAL) {
+            when (it) {
+              IgnorePolicy.USE -> {
+                CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
+                  // Race: The selected text editor could change before IgnoreOracle completes, and
+                  // the command runs on the wrong document. Ignore rules will still be enforced by
+                  // prompt construction so this is a correctness issue but not a safety issue.
+                  // TODO: Fix this race by giving commands an explicit document to act on.
+                  switchToChatSession(AgentChatSession.createFromCommand(project, myCommandId))
+                }
+              }
+              else -> {
+                // This file is ignored. Display an error and stop.
+                ActionInIgnoredFileNotification().notify(project)
               }
             }
-            else -> {
-              // This file is ignored. Display an error and stop.
-              ActionInIgnoredFileNotification().notify(project)
-            }
           }
-        }
-        .submit(AppExecutorUtil.getAppExecutorService())
+          .submit(AppExecutorUtil.getAppExecutorService())
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreNotificationProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreNotificationProvider.kt
@@ -1,12 +1,16 @@
 package com.sourcegraph.cody.ignore
 
 import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.EditorNotificationPanel
 import com.intellij.ui.EditorNotificationProvider
+import com.intellij.ui.EditorNotifications
+import com.intellij.vcs.log.runInEdt
 import com.sourcegraph.Icons
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import java.util.function.Function
@@ -19,9 +23,15 @@ class IgnoreNotificationProvider : EditorNotificationProvider, DumbAware {
       project: Project,
       file: VirtualFile
   ): Function<in FileEditor, out JComponent?> {
-    val policy =
-        IgnoreOracle.getInstance(project).policyForUri(ProtocolTextDocument.uriFor(file)).get()
-    if (policy == IgnorePolicy.USE) {
+    val uri = ProtocolTextDocument.uriFor(file)
+    val oracle = IgnoreOracle.getInstance(project)
+    val policy = oracle.policyForUriOrElse(uri) {
+      runInEdt {
+        updateNotifications(project)
+      }
+    }
+    if (policy == IgnorePolicy.USE || policy == null) {
+      // This file is allowed, or the policy is indeterminate.
       return Function { null }
     }
     return Function {
@@ -32,7 +42,20 @@ class IgnoreNotificationProvider : EditorNotificationProvider, DumbAware {
         text = "Cody ignores this file because of your admin policy"
 
         createActionLabel(
-            "Learn more", Runnable { BrowserUtil.browse(CODY_IGNORE_DOCS_URL) }, false)
+          "Learn more", Runnable { BrowserUtil.browse(CODY_IGNORE_DOCS_URL) }, false
+        )
+      }
+    }
+  }
+
+  companion object {
+    /**
+     * Update editor notifications to refresh banners.
+     */
+    fun updateNotifications(project: Project) {
+      ApplicationManager.getApplication().assertReadAccessAllowed()
+      if (!project.isDisposed) {
+        EditorNotifications.getInstance(project).updateAllNotifications()
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreNotificationProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreNotificationProvider.kt
@@ -25,11 +25,7 @@ class IgnoreNotificationProvider : EditorNotificationProvider, DumbAware {
   ): Function<in FileEditor, out JComponent?> {
     val uri = ProtocolTextDocument.uriFor(file)
     val oracle = IgnoreOracle.getInstance(project)
-    val policy = oracle.policyForUriOrElse(uri) {
-      runInEdt {
-        updateNotifications(project)
-      }
-    }
+    val policy = oracle.policyForUriOrElse(uri) { runInEdt { updateNotifications(project) } }
     if (policy == IgnorePolicy.USE || policy == null) {
       // This file is allowed, or the policy is indeterminate.
       return Function { null }
@@ -42,16 +38,13 @@ class IgnoreNotificationProvider : EditorNotificationProvider, DumbAware {
         text = "Cody ignores this file because of your admin policy"
 
         createActionLabel(
-          "Learn more", Runnable { BrowserUtil.browse(CODY_IGNORE_DOCS_URL) }, false
-        )
+            "Learn more", Runnable { BrowserUtil.browse(CODY_IGNORE_DOCS_URL) }, false)
       }
     }
   }
 
   companion object {
-    /**
-     * Update editor notifications to refresh banners.
-     */
+    /** Update editor notifications to refresh banners. */
     fun updateNotifications(project: Project) {
       ApplicationManager.getApplication().assertReadAccessAllowed()
       if (!project.isDisposed) {

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -10,6 +10,8 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 enum class IgnorePolicy(val value: String) {
   IGNORE("ignore"),
@@ -55,8 +57,7 @@ class IgnoreOracle(private val project: Project) {
   fun onIgnoreDidChange() {
     synchronized(cache) { cache.clear() }
 
-    // Update editor notifications to refresh IgnoreNotificationProvider banners.
-    EditorNotifications.getInstance(project).updateAllNotifications()
+    IgnoreNotificationProvider.updateNotifications(project)
 
     // Re-set the focused file URI to update the status bar.
     val uri = willFocusUri
@@ -84,5 +85,21 @@ class IgnoreOracle(private val project: Project) {
       completable.complete(policy)
     }
     return completable
+  }
+
+  /**
+   * Gets whether `uri` should be ignored for autocomplete, etc. If the result is not available quickly, returns null
+   * and invokes `orElse` on a pooled thread when the result is available.
+   */
+  fun policyForUriOrElse(uri: String, orElse: (policy: IgnorePolicy) -> Unit): IgnorePolicy? {
+    val completable = policyForUri(uri)
+    try {
+      return completable.get(16, TimeUnit.MILLISECONDS)
+    } catch (timedOut: TimeoutException) {
+      ApplicationManager.getApplication().executeOnPooledThread {
+        orElse(completable.get())
+      }
+      return null
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
-import com.intellij.ui.EditorNotifications
 import com.intellij.util.containers.SLRUMap
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
@@ -88,17 +87,15 @@ class IgnoreOracle(private val project: Project) {
   }
 
   /**
-   * Gets whether `uri` should be ignored for autocomplete, etc. If the result is not available quickly, returns null
-   * and invokes `orElse` on a pooled thread when the result is available.
+   * Gets whether `uri` should be ignored for autocomplete, etc. If the result is not available
+   * quickly, returns null and invokes `orElse` on a pooled thread when the result is available.
    */
   fun policyForUriOrElse(uri: String, orElse: (policy: IgnorePolicy) -> Unit): IgnorePolicy? {
     val completable = policyForUri(uri)
     try {
       return completable.get(16, TimeUnit.MILLISECONDS)
     } catch (timedOut: TimeoutException) {
-      ApplicationManager.getApplication().executeOnPooledThread {
-        orElse(completable.get())
-      }
+      ApplicationManager.getApplication().executeOnPooledThread { orElse(completable.get()) }
       return null
     }
   }


### PR DESCRIPTION
...actually, block it, but only for up to 16ms at a time.

This appears to have looping potential if retrieving a policy takes >16ms, eventually unblocks, and triggers a banner update which could restart policy retrieval. But because the policies are cached as the slow path unblocks, and the read side synchronously reads the cache, this should guarantee forward progress provided the policy is not changing.

This appears to have blocking potential if there's dozens of files visible, each blocking for up to 16ms. However `EditorNotificationsImpl` runs each `collectNotificationData` as a non-blocking task in the non-urgent executor. Delays may accumulate, but IntelliJ will prevent them from blocking interaction.

## Test plan

Tested manually starting the product, opening files, etc.:
- Dialing the 16ms timeout down to zero; throwing a TimeoutException in that `try`.
- Inducing a 5s delay on the agent side by adding `await new Promise(resolve => setTimeout(resolve, 5000))` to `ignore/test`.

Tested commands manually.