### PR TITLE
Some UI fixes after the big Inline Edits merge

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
@@ -8,6 +8,7 @@ import com.sourcegraph.cody.config.CodyPersistentAccountsHost
 import com.sourcegraph.cody.config.signInWithSourcegrapDialog
 import com.sourcegraph.common.ui.DumbAwareBGTAction
 import com.sourcegraph.config.ConfigUtil
+import java.awt.Dimension
 
 class SignInWithEnterpriseInstanceAction(
     private val defaultServer: String = ConfigUtil.DOTCOM_URL
@@ -19,9 +20,10 @@ class SignInWithEnterpriseInstanceAction(
         signInWithSourcegrapDialog(
             project,
             e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
-            accountsHost::isAccountUnique)
-
-    dialog.setServer(defaultServer)
+            accountsHost::isAccountUnique).apply {
+          contentPane.minimumSize = Dimension(MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT)
+          setServer(defaultServer)
+        }
     if (dialog.showAndGet()) {
       accountsHost.addAccount(
           dialog.server, dialog.login, dialog.displayName, dialog.token, dialog.id)
@@ -33,5 +35,11 @@ class SignInWithEnterpriseInstanceAction(
         toolWindow?.activate {}
       }
     }
+  }
+
+  companion object {
+    // Make it wide enough to see a reasonable servername and token
+    const val MIN_DIALOG_WIDTH = 600
+    const val MIN_DIALOG_HEIGHT = 200
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/SignInWithEnterpriseInstanceAction.kt
@@ -18,12 +18,13 @@ class SignInWithEnterpriseInstanceAction(
     val accountsHost = CodyPersistentAccountsHost(project)
     val dialog =
         signInWithSourcegrapDialog(
-            project,
-            e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
-            accountsHost::isAccountUnique).apply {
-          contentPane.minimumSize = Dimension(MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT)
-          setServer(defaultServer)
-        }
+                project,
+                e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT),
+                accountsHost::isAccountUnique)
+            .apply {
+              contentPane.minimumSize = Dimension(MIN_DIALOG_WIDTH, MIN_DIALOG_HEIGHT)
+              setServer(defaultServer)
+            }
     if (dialog.showAndGet()) {
       accountsHost.addAccount(
           dialog.server, dialog.login, dialog.displayName, dialog.token, dialog.id)

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
@@ -6,6 +6,7 @@ import com.intellij.util.xmlb.annotations.Property
 import com.intellij.util.xmlb.annotations.Tag
 import com.sourcegraph.cody.auth.ServerAccount
 import com.sourcegraph.config.ConfigUtil
+import java.io.File
 
 @Tag("account")
 data class CodyAccount(
@@ -21,7 +22,7 @@ data class CodyAccount(
 
   fun isEnterpriseAccount(): Boolean = isDotcomAccount().not()
 
-  override fun toString(): String = "$server/$name"
+  override fun toString(): String = File(server.toString(), name).path
 }
 
 fun Collection<CodyAccount>.getFirstAccountOrNull() =

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -173,7 +173,7 @@ abstract class FixupSession(
   // which may require switching to the EDT. This is primarily to help smooth
   // integration testing, but also because there's no real harm blocking pool threads.
   private fun showLensGroup(group: LensWidgetGroup) {
-    // lensGroup?.let { if (!it.isDisposed.get()) Disposer.dispose(it) }
+    lensGroup?.let { if (!it.isDisposed.get()) Disposer.dispose(it) }
     lensGroup = group
     var range = selectionRange
     if (range == null) {


### PR DESCRIPTION
Some UI fixes for various issues:

- Hide the Working/Cancel lens group when Accept group appears
- Make the Enterprise login dialog wide enough to see your token and server
- fixed a small bug CodyAccount toString method

## Test plan

Tested manuallly/visually -- we don't have UI Robot tests yet.
