### PR TITLE
Fix CodyTaskState serialization/deserialization issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ gradleVersion=8.1.1
 kotlin.stdlib.default.dependency=false
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 cody.autocomplete.enableFormatting=true
-cody.commit=a64e26e6a78ec36dca54c1ae994c8e122c0189a8
+cody.commit=d951e25d0c84c72365bd2fffb144a3fbf1170158

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/CodyTaskState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/CodyTaskState.kt
@@ -1,13 +1,15 @@
 package com.sourcegraph.cody.agent.protocol
 
-enum class CodyTaskState(val id: Int) {
-  Idle(1),
-  Working(2),
-  Inserting(3),
-  Applying(4),
-  Formatting(5),
-  Applied(6),
-  Finished(7),
-  Error(8),
-  Pending(9)
+import com.google.gson.annotations.SerializedName
+
+enum class CodyTaskState {
+  @SerializedName("Idle") Idle,
+  @SerializedName("Working") Working,
+  @SerializedName("Inserting") Inserting,
+  @SerializedName("Applying") Applying,
+  @SerializedName("Formatting") Formatting,
+  @SerializedName("Applied") Applied,
+  @SerializedName("Finished") Finished,
+  @SerializedName("Error") Error,
+  @SerializedName("Pending") Pending
 }


### PR DESCRIPTION
Depends on https://github.com/sourcegraph/cody/pull/3968

## Changes

Conversion of enums to integers and then back to enums in the clients is error prone to off-by-one errors (as it was the case).

## Test plan

Manual integration tests of inline Edit commands. 