### PR TITLE
Change "Check Usage" to "Manage Account" and add param for helping login mismatch problems

### DIFF
--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -81,14 +81,14 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
       button("Manage Account") {
+        val manageUrl = "${ConfigUtil.DOTCOM_URL}" + "cody/manage"
         val account = CodyAuthenticationManager.getInstance(project).getActiveAccount()
-        val url =
-            "${ConfigUtil.DOTCOM_URL}" +
-                "cody/manage" +
-                (if (account !== null)
-                    "?cody_client_user=${URLEncoder.encode(account.name, "UTF-8")}"
-                else null)
-        BrowserUtil.browse(url)
+        if (account != null) {
+          BrowserUtil.browse(
+              manageUrl + "?cody_client_user=" + URLEncoder.encode(account.name, "UTF-8"))
+        } else {
+          BrowserUtil.browse(manageUrl)
+        }
       }
     }
     if (accountTier == AccountTier.DOTCOM_FREE) {

--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -9,7 +9,6 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.config.AccountTier
-import com.sourcegraph.cody.config.CodyAccount
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.UpgradeToCodyProNotification
@@ -82,10 +81,7 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
       button("Manage Account") {
-        val username =
-            CodyAuthenticationManager.getInstance(project)
-                .getActiveAccount()
-                ?.let(CodyAccount::name)
+        val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.name
         BrowserUtil.browse(
             ConfigUtil.DOTCOM_URL +
                 "cody/manage?cody_client_user=" +

--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -81,11 +81,14 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
       button("Manage Account") {
-        val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.name
-        BrowserUtil.browse(
-            ConfigUtil.DOTCOM_URL +
-                "cody/manage?cody_client_user=" +
-                URLEncoder.encode(username, "UTF-8"))
+        val account = CodyAuthenticationManager.getInstance(project).getActiveAccount()
+        val url =
+            "${ConfigUtil.DOTCOM_URL}" +
+                "cody/manage" +
+                (if (account !== null)
+                    "?cody_client_user=${URLEncoder.encode(account.name, "UTF-8")}"
+                else null)
+        BrowserUtil.browse(url)
       }
     }
     if (accountTier == AccountTier.DOTCOM_FREE) {

--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -82,7 +82,7 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
       button("Manage Account") {
-          val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.let(CodyAccount::username)
+          val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.let(CodyAccount::name)
           BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage?cody_client_user=" + URLEncoder.encode(username, "UTF-8"))
       }
     }

--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -16,9 +16,9 @@ import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.config.ThemeUtil
 import java.awt.BorderLayout
+import java.net.URLEncoder
 import javax.swing.JPanel
 import javax.swing.border.EmptyBorder
-import java.net.URLEncoder;
 
 class MyAccountTabPanel(val project: Project) : JPanel() {
 
@@ -82,8 +82,14 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
       button("Manage Account") {
-          val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.let(CodyAccount::name)
-          BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage?cody_client_user=" + URLEncoder.encode(username, "UTF-8"))
+        val username =
+            CodyAuthenticationManager.getInstance(project)
+                .getActiveAccount()
+                ?.let(CodyAccount::name)
+        BrowserUtil.browse(
+            ConfigUtil.DOTCOM_URL +
+                "cody/manage?cody_client_user=" +
+                URLEncoder.encode(username, "UTF-8"))
       }
     }
     if (accountTier == AccountTier.DOTCOM_FREE) {

--- a/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/MyAccountTabPanel.kt
@@ -9,6 +9,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.config.AccountTier
+import com.sourcegraph.cody.config.CodyAccount
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.UpgradeToCodyProNotification
@@ -17,6 +18,7 @@ import com.sourcegraph.config.ThemeUtil
 import java.awt.BorderLayout
 import javax.swing.JPanel
 import javax.swing.border.EmptyBorder
+import java.net.URLEncoder;
 
 class MyAccountTabPanel(val project: Project) : JPanel() {
 
@@ -79,7 +81,10 @@ class MyAccountTabPanel(val project: Project) : JPanel() {
             button("Upgrade") { BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/subscription") }
         upgradeButton.component.putClientProperty(DarculaButtonUI.DEFAULT_STYLE_KEY, true)
       }
-      button("Check Usage") { BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage") }
+      button("Manage Account") {
+          val username = CodyAuthenticationManager.getInstance(project).getActiveAccount()?.let(CodyAccount::username)
+          BrowserUtil.browse(ConfigUtil.DOTCOM_URL + "cody/manage?cody_client_user=" + URLEncoder.encode(username, "UTF-8"))
+      }
     }
     if (accountTier == AccountTier.DOTCOM_FREE) {
       row { text(CodyBundle.getString("my-account-tab.already-pro")) }


### PR DESCRIPTION
This PR:
* Renames the "Check Usage" button to "Manage Account"
* Adds a `cody_client_user` parameter to the URL to help users where their web session is logged into a different account than their client
  * Uses sourcegraph/sourcegraph#62039)
  * Equivalent to sourcegraph/cody#3868

## Test plan

- Logged in to dot com
- Click "Manage Account"
- Verify URL has param