### PR TITLE
Adding help to troubleshoot error 134

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ Few tips and tricks regarding versioning of the tooling:
   Otherwise you won't see effects of your changes.
 - Running `./gradlew -PplatformRuntimeVersion=X.Y :runIde` for the first time might fail due to missing IntelliJ installation. You
   can fix it by running `./gradlew -PplatformVersion=X.Y :runIde` once - even if compilation fails it fixes your caches.
+- IF you get error 134 while building different things with jetbrains its because java process doesn't have enough memory to build so you might need to get into your activity monitor to close other processes.
+
 
 ## Using Nightly channel releases
 


### PR DESCRIPTION
I get this very bizarre  error in my build of Jetbrains and its error 134. The causality of this error is that the computer does not have enough memory. Interestingly enough I have 48 Gigs of ram and I still get this error on the rare times when I have many different things running different ide's and other things together. Initially I thought this error was non deterministic because I thought that restarting the computer solved it for me one time. 

The reason it solved it was because it closed all the processs but yeah the memory exceeded is something to keep in mind since this error usually doesn't tell you anything and happens rarely I added a troubleshooting step too. 


## Test plan
It doesn't need it 

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
