### PR TITLE
Move management of session lifecycle (undo, finish, etc) back to agent

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=6c6598148bffa3ad9e9a0daace563be4f8baf690
+cody.commit=b74b93fa41eec5864bb7c17271916c0b7680efad

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -52,8 +52,10 @@ class CodyAgentService(project: Project) : Disposable {
         FixupService.getInstance(project).getActiveSession()?.update(task)
       }
 
-      agent.client.onEditTaskDidDelete = Consumer { _ ->
-        FixupService.getInstance(project).getActiveSession()?.taskDeleted()
+      agent.client.onEditTaskDidDelete = Consumer { params ->
+        FixupService.getInstance(project).getActiveSession()?.let {
+          if (params.id == it.taskId) it.taskDeleted()
+        }
       }
 
       agent.client.onWorkspaceEdit = Consumer { params ->

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -553,7 +553,7 @@ class EditCommandPrompt(
         return
       }
       // Kick off the editing command.
-      controller.setActiveSession(EditCodeSession(controller, editor, text, llmDropdown.item))
+      EditCodeSession(controller, editor, text, llmDropdown.item)
     }
     clearActivePrompt()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -28,14 +28,12 @@ class FixupService(val project: Project) : Disposable {
   /** Entry point for the inline edit command, called by the action handler. */
   fun startCodeEdit(editor: Editor) {
     if (!isEligibleForInlineEdit(editor)) return
-    cancelActiveSession()
     currentEditPrompt.set(EditCommandPrompt(this, editor, "Edit Code with Cody"))
   }
 
   /** Entry point for the document code command, called by the action handler. */
   fun startDocumentCode(editor: Editor) {
     if (!isEligibleForInlineEdit(editor)) return
-    activeSession?.finish()
     DocumentCodeSession(this, editor, editor.project ?: return)
   }
 
@@ -61,18 +59,7 @@ class FixupService(val project: Project) : Disposable {
 
   fun setActiveSession(session: FixupSession) {
     if (session == activeSession) return
-    cancelActiveSession()
     activeSession = session
-  }
-
-  // Fully cancels/retracts any current session.
-  fun cancelActiveSession() {
-    try {
-      activeSession?.finish()
-    } catch (x: Exception) {
-      logger.warn("Error while disposing session", x)
-    }
-    clearActiveSession()
   }
 
   // Just clear the service's reference to an active session.

--- a/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -212,12 +212,13 @@ object CodyEditorUtil {
       val uri = URI.create(uriString).withScheme("file")
       val vf =
           LocalFileSystem.getInstance().refreshAndFindFileByNioFile(uri.toPath()) ?: return false
-      OpenFileDescriptor(
-              project,
-              vf,
-              selection?.start?.line ?: 0,
-              /* logicalColumn= */ selection?.start?.character ?: 0)
-          .navigate(/* requestFocus= */ preserveFocus != true)
+      if (selection == null) {
+        OpenFileDescriptor(project, vf).navigate(/* requestFocus= */ preserveFocus != true)
+      } else {
+        OpenFileDescriptor(
+                project, vf, selection.start.line, /* logicalColumn= */ selection.start.character)
+            .navigate(/* requestFocus= */ preserveFocus != true)
+      }
       return true
     } catch (e: Exception) {
       logger.error("Cannot switch view to file $uriString", e)


### PR DESCRIPTION
## Changes

* Remove manual `undo` and base on the one from agent
* Allow finishing of the session being controled by the agent as well instead of managing it manually
* Remove code for custom scrolling/selection restoration after undo - lost of the selection was caused by the bug in the `showDocument` method and proper scrolling should be managed by agent as well: 
https://github.com/sourcegraph/cody/pull/4061/

## Test plan

Not until we have test framework.