### PR TITLE
Fix :runIde gradle command

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -262,6 +262,11 @@ tasks {
       into(buildCodyDir)
     }
 
+    copy {
+      from(downloadNodeBinaries())
+      into(buildCodyDir)
+    }
+
     return buildCodyDir
   }
 
@@ -320,8 +325,6 @@ tasks {
     ) {
       into("agent/")
     }
-
-    from(fileTree(downloadNodeBinaries())) { into("agent/") }
 
     doLast {
       // Assert that agent binaries are included in the plugin


### PR DESCRIPTION
## Changes

Make sure `:runIde` properly copies `node` artefacts so it also works in development mode.

## Test plan

N/A