### PR TITLE
Several bug fixes for Inline Edits

### DIFF
--- a/src/main/java/com/sourcegraph/cody/Icons.java
+++ b/src/main/java/com/sourcegraph/cody/Icons.java
@@ -49,6 +49,10 @@ public interface Icons {
     Icon Download = IconLoader.getIcon("/icons/chat/download.svg", Icons.class);
   }
 
+  interface Edit {
+    Icon Error = IconLoader.getIcon("/icons/edit/error.svg", Icons.class);
+  }
+
   interface LLM {
     Icon Anthropic = IconLoader.getIcon("/icons/chat/llm/anthropic.svg", Icons.class);
     Icon OpenAI = IconLoader.getIcon("/icons/chat/llm/openai.svg", Icons.class);

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -89,6 +89,13 @@ class FixupService(val project: Project) : Disposable {
         logger.warn("Error disposing session", x)
       }
     }
+    currentEditPrompt.get()?.let {
+      try {
+        Disposer.dispose(it)
+      } catch (x: Exception) {
+        logger.warn("Error disposing prompt", x)
+      }
+    }
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -90,10 +90,7 @@ abstract class FixupSession(
       // Spend a turn to get folding ranges before showing lenses.
       ensureSelectionRange(agent, textFile)
 
-      showErrorGroup("TODO DELETE THIS LINE OF CODE BEFORE MERGING")
-
-      // And uncomment this!
-      // showWorkingGroup()
+      showWorkingGroup()
 
       // All this because we can get the workspace/edit before the request returns!
       fixupService.setActiveSession(this)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -208,10 +208,12 @@ abstract class FixupSession(
     } catch (x: Exception) {
       logger.debug("Session cleanup error", x)
     }
-    try {
-      Disposer.dispose(this)
-    } catch (x: Exception) {
-      logger.warn("Error disposing fixup session $this", x)
+    ApplicationManager.getApplication().invokeLater {
+      try { // Disposing inlay requires EDT.
+        Disposer.dispose(this)
+      } catch (x: Exception) {
+        logger.warn("Error disposing fixup session $this", x)
+      }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.edit.widget
 
-import com.intellij.icons.AllIcons
 import com.intellij.openapi.diagnostic.Logger
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.edit.EditCommandPrompt
@@ -85,7 +84,7 @@ class LensGroupFactory(val session: FixupSession) {
   }
 
   private fun addErrorIcon(group: LensWidgetGroup) {
-    addIcon(group, AllIcons.General.Error)
+    addIcon(group, Icons.Edit.Error)
   }
 
   private fun addIcon(group: LensWidgetGroup, icon: Icon) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
@@ -1,9 +1,11 @@
 package com.sourcegraph.cody.edit.widget
 
+import com.intellij.icons.AllIcons
 import com.intellij.openapi.diagnostic.Logger
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
+import javax.swing.Icon
 
 /** Handles assembling standard groups of lenses. */
 class LensGroupFactory(val session: FixupSession) {
@@ -66,8 +68,7 @@ class LensGroupFactory(val session: FixupSession) {
   }
 
   private fun addLogo(group: LensWidgetGroup) {
-    group.addWidget(LensIcon(group, Icons.StatusBar.CodyAvailable))
-    addSpacer(group)
+    addIcon(group, Icons.StatusBar.CodyAvailable)
   }
 
   private fun addSpacer(group: LensWidgetGroup) {
@@ -84,7 +85,11 @@ class LensGroupFactory(val session: FixupSession) {
   }
 
   private fun addErrorIcon(group: LensWidgetGroup) {
-    addLabel(group, " ! ") // TODO: Change to LensIcon when we get SVG
+    addIcon(group, AllIcons.General.Error)
+  }
+
+  private fun addIcon(group: LensWidgetGroup, icon: Icon) {
+    group.addWidget(LensIcon(group, icon))
     addSpacer(group)
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
@@ -11,8 +11,8 @@ class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
 
   private var scaledImage: Image? = null
 
-  // Squish the icon down to make it better fit the text. Eyeballed based on logo image.
-  private val scaleFactor = 0.6
+  // Squish the icon down to make it better fit the text.
+  private val scaleFactor = 0.9
 
   private fun getScaleFactor(fontMetrics: FontMetrics) = (fontMetrics.height * scaleFactor).toInt()
 

--- a/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
@@ -133,6 +133,9 @@ class FrameMover(private val frame: JFrame, private val titleBar: JComponent) : 
   }
 
   private fun resizeDialog(e: MouseEvent) {
+    val currentTime = System.currentTimeMillis()
+    if (currentTime - lastUpdateTime <= 16) return
+
     val newX = e.xOnScreen
     val newY = e.yOnScreen
     val deltaX = newX - lastMouseX
@@ -173,9 +176,10 @@ class FrameMover(private val frame: JFrame, private val titleBar: JComponent) : 
       else -> {}
     }
 
-    frame.setSize(newWidth, newHeight)
+    SwingUtilities.invokeLater { frame.setSize(newWidth, newHeight) }
     lastMouseX = newX
     lastMouseY = newY
+    lastUpdateTime = currentTime
   }
 
   private fun moveDialog(e: MouseEvent) {

--- a/src/main/resources/icons/edit/error.svg
+++ b/src/main/resources/icons/edit/error.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="7" cy="7" r="5.625" fill="#DB5C5C" stroke="#DB5C5C" style="fill:#DB5C5C;fill:color(display-p3 0.8600 0.3612 0.3612);fill-opacity:1;stroke:#DB5C5C;stroke:color(display-p3 0.8600 0.3612 0.3612);stroke-opacity:1;"/>
+<path d="M7 3.9375L7 7" stroke="white" style="stroke:white;stroke-opacity:1;" stroke-width="1.8" stroke-linecap="round"/>
+<circle cx="7.00034" cy="9.7125" r="0.9625" fill="white" style="fill:white;fill-opacity:1;"/>
+</svg>


### PR DESCRIPTION
A handful of small but important fixes:

- fixed the flicker when resizing the Edit dialog -- looks much nicer now
- use the error lens icon from Design, and fixed the error lens icon sizing
- cleaned up several memory leaks from listeners left around, including a big exception on exiting the app
- fixed an EDT issue with disposing inlays, another runtime exception

## Test plan

There were no user-visible changes except for the error icon, which I inspected manually. All unit tests and checks passed.