### PR TITLE
Finished up the Edit/Retry feature

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/EditTask.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/EditTask.kt
@@ -1,3 +1,8 @@
 package com.sourcegraph.cody.agent.protocol
 
-data class EditTask(val id: String, val state: CodyTaskState, val selectionRange: Range)
+data class EditTask(
+    val id: String,
+    val state: CodyTaskState,
+    val selectionRange: Range,
+    val instruction: String? = null
+)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
@@ -69,7 +70,6 @@ import javax.swing.JRootPane
 import javax.swing.JScrollPane
 import javax.swing.KeyStroke
 import javax.swing.ListCellRenderer
-import javax.swing.SwingUtilities
 import javax.swing.WindowConstants
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
@@ -201,7 +201,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialog
         }
 
         private fun handleDocumentChange() {
-          ApplicationManager.getApplication().invokeLater {
+          runInEdt {
             updateOkButtonState()
             checkForInterruptions()
           }
@@ -566,7 +566,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialog
   }
 
   private fun onThemeChange() {
-    SwingUtilities.invokeLater {
+    runInEdt {
       titleLabel.foreground = boldLabelColor() // custom background we manage ourselves
       revalidate()
       repaint()

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -124,7 +124,7 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialog
 
   private val instructionsField =
       InstructionsInputTextArea(this).apply {
-        text = lastPrompt
+        text = controller.getActiveSession()?.instruction ?: lastPrompt
         if (text.isBlank() && promptHistory.isNotEmpty()) {
           text = promptHistory.getPrevious()
         }
@@ -252,8 +252,9 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialog
         }
       }
 
-  // Note: Must be created on EDT, although we can't annotate it as such.
   init {
+    ApplicationManager.getApplication().assertIsDispatchThread()
+
     // Register with FixupService as a failsafe if the project closes. Normally we're disposed
     // sooner, when the dialog is closed or focus is lost.
     Disposer.register(controller, this)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -75,8 +75,12 @@ import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
 
 /** Pop up a user interface for giving Cody instructions to fix up code at the cursor. */
-class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialogTitle: String) :
-    JFrame(), Disposable {
+class EditCommandPrompt(
+    val controller: FixupService,
+    val editor: Editor,
+    dialogTitle: String,
+    instruction: String? = null
+) : JFrame(), Disposable {
   private val logger = Logger.getInstance(EditCommandPrompt::class.java)
 
   private val offset = editor.caretModel.primaryCaret.offset
@@ -124,8 +128,12 @@ class EditCommandPrompt(val controller: FixupService, val editor: Editor, dialog
 
   private val instructionsField =
       InstructionsInputTextArea(this).apply {
-        text = controller.getActiveSession()?.instruction ?: lastPrompt
-        if (text.isBlank() && promptHistory.isNotEmpty()) {
+        if (instruction != null) {
+          text = instruction
+        } else {
+          text = lastPrompt
+        }
+        if (text.isNullOrBlank() && promptHistory.isNotEmpty()) {
           text = promptHistory.getPrevious()
         }
       }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -189,7 +189,7 @@ abstract class FixupSession(
     }
     val future = group.show(range)
     // Make sure the lens is visible.
-    runInEdt {
+    ApplicationManager.getApplication().invokeLater {
       val logicalPosition = LogicalPosition(range.start.line, range.start.character)
       editor.scrollingModel.scrollTo(logicalPosition, ScrollType.CENTER)
     }
@@ -247,11 +247,11 @@ abstract class FixupSession(
   }
 
   fun retry() {
-    runInEdt {
+    undo()
+    ApplicationManager.getApplication().invokeLater {
       // This starts a brand-new session; the Edit dialog remembers your last prompt.
       EditCommandPrompt(controller, editor, "Edit instructions and Retry")
     }
-    undo()
   }
 
   // Action handler for FixupSession.ACTION_UNDO.

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -49,7 +49,8 @@ import kotlin.io.path.toPath
 
 /**
  * Common functionality for commands that let the agent edit the code inline, such as adding a doc
- * string, or fixing up a region according to user instructions.
+ * string, or fixing up a region according to user instructions. Instances of this class map 1:1
+ * with FixupTask instances in the Agent.
  */
 abstract class FixupSession(
     val controller: FixupService,
@@ -67,6 +68,11 @@ abstract class FixupSession(
   private var lensGroup: LensWidgetGroup? = null
 
   var selectionRange: Range? = null
+
+  // The prompt that the Agent used for this task. For Edit, it's the same as
+  // the most recent prompt the user sent, which we already have. But for Document Code,
+  // it enables us to show the user what we sent and let them hand-edit it.
+  var instruction: String? = null
 
   private val performedActions: MutableList<FixupUndoableAction> = mutableListOf()
 
@@ -139,6 +145,7 @@ abstract class FixupSession(
   }
 
   fun update(task: EditTask) {
+    task.instruction?.let { instruction = it }
     when (task.state) {
       // This is an internal state (parked/ready tasks) and we should never see it.
       CodyTaskState.Idle -> {}
@@ -239,15 +246,11 @@ abstract class FixupSession(
   }
 
   fun retry() {
-    // TODO: The actual prompt we sent is displayed as ghost text in the text input field, in VS
-    // Code.
-    // E.g. "Write a brief documentation comment for the selected code <etc.>"
-    // We need to send the prompt along with the lenses, so that the client can display it.
     ApplicationManager.getApplication().invokeLater {
-      // This starts an entirely new session, independent of this one.
+      // This starts a brand-new session; the Edit dialog remembers your last prompt.
       EditCommandPrompt(controller, editor, "Edit instructions and Retry")
     }
-    controller.cancelActiveSession()
+    undo()
   }
 
   // Action handler for FixupSession.ACTION_UNDO.
@@ -365,8 +368,24 @@ abstract class FixupSession(
 
   private fun undoEdits() {
     if (project.isDisposed) return
-    WriteCommandAction.runWriteCommandAction(project) {
-      performedActions.reversed().forEach { it.undo() }
+
+    // Scroll back to starting position, since Undo puts us at top of document.
+    val editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
+    val document = editor.document
+    val currentOffset = editor.caretModel.offset
+    val lineStartOffset = document.getLineStartOffset(document.getLineNumber(currentOffset))
+
+    try {
+      WriteCommandAction.runWriteCommandAction(project) {
+        performedActions.reversed().forEach { it.undo() }
+      }
+    } finally {
+      ApplicationManager.getApplication().invokeLater {
+        val validOffset = minOf(lineStartOffset, document.textLength)
+        val validPosition = editor.offsetToLogicalPosition(validOffset)
+        editor.caretModel.moveToLogicalPosition(validPosition)
+        editor.scrollingModel.scrollTo(validPosition, ScrollType.CENTER)
+      }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -381,7 +381,8 @@ abstract class FixupSession(
         performedActions.reversed().forEach { it.undo() }
       }
     } finally {
-      runInEdt {
+      // Queue this up and don't execute immediately (don't use runInEdt).
+      ApplicationManager.getApplication().invokeLater {
         val validOffset = minOf(lineStartOffset, document.textLength)
         val validPosition = editor.offsetToLogicalPosition(validOffset)
         editor.caretModel.moveToLogicalPosition(validPosition)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -247,10 +247,13 @@ abstract class FixupSession(
   }
 
   fun retry() {
+    val instruction = instruction
     undo()
+    // Don't queue this up until undo() finishes above, so that the scrolling is
+    // finished before we open this dialog (or it will immediately close).
     ApplicationManager.getApplication().invokeLater {
       // This starts a brand-new session; the Edit dialog remembers your last prompt.
-      EditCommandPrompt(controller, editor, "Edit instructions and Retry")
+      EditCommandPrompt(controller, editor, "Edit instructions and Retry", instruction)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensSpinner.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensSpinner.kt
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.edit.widget
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 import java.awt.geom.AffineTransform
@@ -22,7 +22,7 @@ class LensSpinner(group: LensWidgetGroup, private val icon: Icon) : LensWidget(g
       }
 
   init {
-    ApplicationManager.getApplication().invokeLater { start() }
+    runInEdt { start() }
   }
 
   fun start() {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.edit.widget
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorCustomElementRenderer
@@ -21,6 +22,7 @@ import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
 import com.sourcegraph.config.ThemeUtil
+import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -31,7 +33,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Supplier
 import kotlin.math.roundToInt
-import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 
@@ -297,7 +298,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     if (ApplicationManager.getApplication().isDispatchThread) {
       executeAndComplete()
     } else {
-      ApplicationManager.getApplication().invokeLater { executeAndComplete() }
+      runInEdt { executeAndComplete() }
     }
     return result
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -22,7 +22,6 @@ import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
 import com.sourcegraph.config.ThemeUtil
-import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -33,6 +32,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Supplier
 import kotlin.math.roundToInt
+import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -41,8 +41,8 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
       CodyAutocompleteManager.instance.clearAutocompleteSuggestions(editor)
 
       if (CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor) &&
-              CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
-              !CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
+          CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
+          !CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
 
         ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
           CodyAgentService.withAgent(project) { agent ->
@@ -59,7 +59,7 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
         val changeOffset = event.offset + event.newLength
         if (editor.caretModel.offset == changeOffset) {
           CodyAutocompleteManager.instance.triggerAutocomplete(
-                  editor, changeOffset, InlineCompletionTriggerKind.AUTOMATIC)
+              editor, changeOffset, InlineCompletionTriggerKind.AUTOMATIC)
         }
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -29,34 +30,37 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
   }
 
   override fun documentChangedNonBulk(event: DocumentEvent) {
-    val editor = FileEditorManager.getInstance(project).selectedTextEditor
-    if (editor?.document != event.document) {
-      return
-    }
-
-    logCodeCopyPastedFromChat(event)
-    CodyAutocompleteManager.instance.clearAutocompleteSuggestions(editor)
-
-    if (CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor) &&
-        CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
-        !CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
-
-      ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
-        CodyAgentService.withAgent(project) { agent ->
-          agent.server.textDocumentDidChange(textDocument)
-
-          // This notification must be sent after the above, see tracker comment for more details.
-          AcceptCodyAutocompleteAction.tracker.getAndSet(null)?.let { completionID ->
-            agent.server.completionAccepted(CompletionItemParams(completionID))
-            agent.server.autocompleteClearLastCandidate()
-          }
-        }
+    // Can be called on non-EDT during IDE shutdown.
+    runInEdt {
+      val editor = FileEditorManager.getInstance(project).selectedTextEditor
+      if (editor?.document != event.document) {
+        return@runInEdt
       }
 
-      val changeOffset = event.offset + event.newLength
-      if (editor.caretModel.offset == changeOffset) {
-        CodyAutocompleteManager.instance.triggerAutocomplete(
-            editor, changeOffset, InlineCompletionTriggerKind.AUTOMATIC)
+      logCodeCopyPastedFromChat(event)
+      CodyAutocompleteManager.instance.clearAutocompleteSuggestions(editor)
+
+      if (CodyEditorUtil.isImplicitAutocompleteEnabledForEditor(editor) &&
+              CodyEditorUtil.isEditorValidForAutocomplete(editor) &&
+              !CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
+
+        ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
+          CodyAgentService.withAgent(project) { agent ->
+            agent.server.textDocumentDidChange(textDocument)
+
+            // This notification must be sent after the above, see tracker comment for more details.
+            AcceptCodyAutocompleteAction.tracker.getAndSet(null)?.let { completionID ->
+              agent.server.completionAccepted(CompletionItemParams(completionID))
+              agent.server.autocompleteClearLastCandidate()
+            }
+          }
+        }
+
+        val changeOffset = event.offset + event.newLength
+        if (editor.caretModel.offset == changeOffset) {
+          CodyAutocompleteManager.instance.triggerAutocomplete(
+                  editor, changeOffset, InlineCompletionTriggerKind.AUTOMATIC)
+        }
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.ui
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.edit.EditUtil
@@ -176,7 +177,7 @@ class FrameMover(private val frame: JFrame, private val titleBar: JComponent) : 
       else -> {}
     }
 
-    SwingUtilities.invokeLater { frame.setSize(newWidth, newHeight) }
+    runInEdt { frame.setSize(newWidth, newHeight) }
     lastMouseX = newX
     lastMouseY = newY
     lastUpdateTime = currentTime
@@ -187,7 +188,7 @@ class FrameMover(private val frame: JFrame, private val titleBar: JComponent) : 
     if (currentTime - lastUpdateTime > 16) { // about 60 fps
       val x: Int = e.xOnScreen
       val y: Int = e.yOnScreen
-      SwingUtilities.invokeLater {
+      runInEdt {
         frame.rootPane?.let { rootPane ->
           UIUtil.getLocationOnScreen(rootPane)?.let { loc ->
             frame.setLocation(loc.x + x - lastMouseX, loc.y + y - lastMouseY)


### PR DESCRIPTION
Edit/Retry had a couple of issues, both fixed:

1. It wasn't Undoing before retrying, so it was leaving the original text in the document. Pretty bad bug.
2. Document Code needed to show the "instruction" (prompt) generated by the Agent. This mostly a snazzy extra from VS Code.

This PR goes hand-in-hand with a [PR in sourcegraph/cody](https://github.com/sourcegraph/cody/pull/4010) that sends the instruction along with task updates, so that it's available if the user chooses to retry.

This PR also fixes a couple of bugs, including a really annoying one with Undo, where it was scrolling to the top of the document.

## Test plan

Test plan is in TESTING.md.