### PR TITLE
Fix listeners calls to agent

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -25,7 +25,7 @@ class CodyCaretListener(val project: Project) : CaretListener {
 
     ProtocolTextDocument.fromEditor(e.editor)?.let { textDocument ->
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
-        agent.server.textDocumentDidFocus(textDocument)
+        agent.server.textDocumentDidChange(textDocument)
       }
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -16,7 +16,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
     source.selectedTextEditor?.let { editor ->
       val protocolTextFile = fromVirtualFile(editor, file)
       withAgent(source.project) { agent: CodyAgent ->
-        agent.server.textDocumentDidClose(protocolTextFile)
+        agent.server.textDocumentDidOpen(protocolTextFile)
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -16,7 +16,7 @@ class CodySelectionListener(val project: Project) : SelectionListener {
 
     ProtocolTextDocument.fromEditor(e.editor)?.let { textDocument ->
       CodyAgentService.withAgent(project) { agent ->
-        agent.server.textDocumentDidFocus(textDocument)
+        agent.server.textDocumentDidChange(textDocument)
       }
     }
 


### PR DESCRIPTION
## Changes 

When reading agent code I realised that change in cursor/selection should in fact be passed by `didChange` and not `didFocus` event. This was changed recently by me while trying to improve situation with agent crashes (and when we though excessive amount of agent notifications might be a partial reason) but I realised this change was simply incorrect.


## Test plan

Manual check with debugger if proper endpoints are hit.