### PR TITLE
Removed the reference to SEPARATOR_ABOVE_COLOR

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ignore/CommandPanelIgnoreBanner.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/CommandPanelIgnoreBanner.kt
@@ -27,9 +27,7 @@ class CommandPanelIgnoreBanner() : NonOpaquePanel() {
 
     // These colors cribbed from EditorComposite, createTopBottomSideBorder
     val scheme = EditorColorsManager.getInstance().globalScheme
-    val borderColor =
-        scheme.getColor(EditorColors.SEPARATOR_ABOVE_COLOR)
-            ?: scheme.getColor(EditorColors.TEARLINE_COLOR)
+    val borderColor = scheme.getColor(EditorColors.TEARLINE_COLOR)
     border = SideBorder(borderColor, SideBorder.TOP or SideBorder.BOTTOM)
   }
 


### PR DESCRIPTION
## Test plan

Build the plugin and load it in IntelliJ 2022.3 or newer. Check the log for occurrences of `NoSuchFieldError`. 