### PR TITLE
Apply IntelliJ formatting to the edited code snippet that comes from the agent

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -368,7 +368,7 @@ abstract class FixupSession(
             val input = document.getText(tr)
             val formatted =
                     CodyFormatter.formatStringBasedOnDocument(
-                            input, project, document, tr, editor.caretModel.offset)
+                            input, project, document, tr, tr.startOffset)
             if (input.replace(Regex("\\s"), "") != formatted.replace(Regex("\\s"), "")) {
               logger.error(
                       "Skipped internal formatting because the formatted text is different from the original text")

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -359,6 +359,7 @@ abstract class FixupSession(
         // by calling triggerFixupAsync() which in turn calls ensureSelectionRange().
         // The value of this property does not change
         // when the user selects a different snippet in the UI.
+        // FIXME this causes a problem when the entire file becomes shorter than the original selection range.
         selectionRange!!.let {
           val tr = TextRange(it.start.toOffset(document), it.end.toOffset(document))
           val input = document.getText(tr)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -64,12 +64,12 @@ abstract class FixupSession(
   // The current lens group. Changes as the state machine proceeds.
   private var lensGroup: LensWidgetGroup? = null
 
-  var selectionRange: Range? = null
+  private var selectionRange: Range? = null
 
   // The prompt that the Agent used for this task. For Edit, it's the same as
   // the most recent prompt the user sent, which we already have. But for Document Code,
   // it enables us to show the user what we sent and let them hand-edit it.
-  var instruction: String? = null
+  private var instruction: String? = null
 
   private val performedActions: MutableList<FixupUndoableAction> = mutableListOf()
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -355,7 +355,10 @@ abstract class FixupSession(
           }
         }
 
-        // TODO: Can selection range actually be null at this point?
+        // It is safe to use selectionRange here, because it is set in the constructor
+        // by calling triggerFixupAsync() which in turn calls ensureSelectionRange().
+        // The value of this property does not change
+        // when the user selects a different snippet in the UI.
         selectionRange!!.let {
           val tr = TextRange(it.start.toOffset(document), it.end.toOffset(document))
           val input = document.getText(tr)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -356,7 +356,7 @@ abstract class FixupSession(
         }
 
         // Skip the formatting if these edits are part of an undo operation.
-        if(!isUndo){
+        if (!isUndo) {
           // It is safe to use selectionRange here, because it is set in the constructor
           // by calling triggerFixupAsync() which in turn calls ensureSelectionRange().
           // The value of this property does not change
@@ -367,11 +367,11 @@ abstract class FixupSession(
             val tr = TextRange(it.start.toOffset(document), it.end.toOffset(document))
             val input = document.getText(tr)
             val formatted =
-                    CodyFormatter.formatStringBasedOnDocument(
-                            input, project, document, tr, tr.startOffset)
+                CodyFormatter.formatStringBasedOnDocument(
+                    input, project, document, tr, tr.startOffset)
             if (input.replace(Regex("\\s"), "") != formatted.replace(Regex("\\s"), "")) {
               logger.error(
-                      "Skipped internal formatting because the formatted text is different from the original text")
+                  "Skipped internal formatting because the formatted text is different from the original text")
             }
             document.replaceString(tr.startOffset, tr.endOffset, formatted)
           }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -372,10 +372,6 @@ abstract class FixupSession(
             val formatted =
                 CodyFormatter.formatStringBasedOnDocument(
                     input, project, document, tr, tr.startOffset)
-            if (input.replace(Regex("\\s"), "") != formatted.replace(Regex("\\s"), "")) {
-              logger.error(
-                  "Skipped internal formatting because the formatted text is different from the original text")
-            }
             document.replaceString(tr.startOffset, tr.endOffset, formatted)
           }
         }

--- a/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -34,7 +34,8 @@ class CodyFormatter {
                 .createFileFromText("TEMP", file.fileType, appendedString)
 
         val codeStyleManager = CodeStyleManager.getInstance(project)
-        // FIXME this will fail if cursor < range.startOffset + completionText.length
+        // This will fail if cursor < range.startOffset + completionText.length
+        // TODO change the signature of this method or at least validate the arguments
         codeStyleManager.reformatText(psiFile, cursor, range.startOffset + completionText.length)
 
         // Fix for the IJ formatting bug which removes spaces even before the given formatting

--- a/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -34,6 +34,7 @@ class CodyFormatter {
                 .createFileFromText("TEMP", file.fileType, appendedString)
 
         val codeStyleManager = CodeStyleManager.getInstance(project)
+        // FIXME this will fail if cursor < range.startOffset + completionText.length
         codeStyleManager.reformatText(psiFile, cursor, range.startOffset + completionText.length)
 
         // Fix for the IJ formatting bug which removes spaces even before the given formatting


### PR DESCRIPTION
## Test plan

Tested manually, mostly on [this file](https://github.com/odisseus/java-ipfs-http-client/blob/master/src/main/java/io/ipfs/api/Pair.java). 

### Things that are confirmed to work (prompts might need to be reworded)
Undoing these operations also works perfectly.

1. Select all text, prompt "Remove all blank lines".
    * The blank lines will be removed only inside the methods. The blank lines between the methods are removed by the agent but restored by the formatter.
2. Select a whole method, prompt "Remove all blank lines".
3. Select a piece of the code that references a variable, prompt "Check that the <variable> is not null".
    * This should add some lines of code, growing the selection accordingly.

### Intentionally misformatting the file
This flow technically works as expected, but the result might confuse the user.
1. Open a Java file. Make sure that it has formatting problems, e.g. multiple statements (ending with `;`) in the same line.
5. Select a few lines above and below the misformatted line, and invoke "Cody → Edit Code".
6. In the prompt, write "Remove all indents".
7. The result should come out correctly formatted, with the proper indents and each statement in its own line.
    * But if you place a breakpoint inside `FixupSession.performInlineEdits`, you'll see that the edit arrives from the agent without indents (as requested), and is later formatted by IntelliJ.
8. Click "Undo" or "Edit & Retry".
9. The code will return to its original state, complete with the original formatting problem.

### Things that don't work
These things seem to be broken in master.
* In some cases, the selection is smaller than the modified part of the code.
* If you ask Cody to edit code without selecting a range in the file, the generated code will not be selected a,d the Undo action will be broken.
* Show Diff action seems to be broken in many cases.