### PR TITLE
Roll the extension to 6c659814

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=d951e25d0c84c72365bd2fffb144a3fbf1170158
+cody.commit=6c6598148bffa3ad9e9a0daace563be4f8baf690


### PR DESCRIPTION
This is the extension commit in VSCode 1.16.2, plus the change to send client-name, client-version query string parameters required by Sourcegraph 6.

## Test plan

Manually tested:

- Signed in
- Chatted
- Generated an autocomplete