### PR TITLE
Cody Ignore: Ignore Chat UX updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=6.0.12345
+pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.sourcegraph.jetbrains
 pluginName=Sourcegraph
 # SemVer format -> https://semver.org
-pluginVersion=6.0-localbuild
+pluginVersion=6.0.12345
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.1

--- a/src/main/java/com/sourcegraph/Icons.java
+++ b/src/main/java/com/sourcegraph/Icons.java
@@ -8,6 +8,7 @@ public interface Icons {
   Icon CodyLogo = IconLoader.getIcon("/icons/codyLogo.svg", Icons.class);
   Icon CodyLogoSlash = IconLoader.getIcon("/icons/cody-logo-heavy-slash.svg", Icons.class);
   Icon GearPlain = IconLoader.getIcon("/icons/gearPlain.svg", Icons.class);
+  Icon RepoIgnored = IconLoader.getIcon("/icons/repo-ignored.svg", Icons.class);
   Icon RepoHostBitbucket = IconLoader.getIcon("/icons/repo-host-bitbucket.svg", Icons.class);
   Icon RepoHostGeneric = IconLoader.getIcon("/icons/repo-host-generic.svg", Icons.class);
   Icon RepoHostGitHub = IconLoader.getIcon("/icons/repo-host-github.svg", Icons.class);

--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -314,11 +314,12 @@ data class DisplayedContextFile(val contextItem: ContextItem) {
     val contextItemFile = contextItem as? ContextItemFile
     val isIgnored = contextItemFile?.isIgnored == true
     val isTooLarge = contextItemFile?.title == "large-file" || contextItemFile?.isTooLarge == true
-    val warnIfNeeded = when {
-      isIgnored -> "<i> - ⚠ Ignored by an admin setting.</i>"
-      isTooLarge -> "<i> - ⚠ File too large</i>"
-      else -> ""
-    }
+    val warnIfNeeded =
+        when {
+          isIgnored -> "<i> - ⚠ Ignored by an admin setting.</i>"
+          isTooLarge -> "<i> - ⚠ File too large</i>"
+          else -> ""
+        }
     return "<html>${contextItem.displayPath()}$warnIfNeeded</html>"
   }
 }

--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -316,7 +316,7 @@ data class DisplayedContextFile(val contextItem: ContextItem) {
     val isTooLarge = contextItemFile?.title == "large-file" || contextItemFile?.isTooLarge == true
     val warnIfNeeded =
         when {
-          isIgnored -> "<i> - ⚠ Ignored by an admin setting.</i>"
+          isIgnored -> "<i> - ⚠ Ignored by an admin setting</i>"
           isTooLarge -> "<i> - ⚠ File too large</i>"
           else -> ""
         }

--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -312,8 +312,13 @@ class PromptPanel(project: Project, private val chatSession: ChatSession) : JLay
 data class DisplayedContextFile(val contextItem: ContextItem) {
   override fun toString(): String {
     val contextItemFile = contextItem as? ContextItemFile
+    val isIgnored = contextItemFile?.isIgnored == true
     val isTooLarge = contextItemFile?.title == "large-file" || contextItemFile?.isTooLarge == true
-    val warnIfNeeded = if (isTooLarge) "<i> - ⚠ File too large</i>" else ""
+    val warnIfNeeded = when {
+      isIgnored -> "<i> - ⚠ Ignored by an admin setting.</i>"
+      isTooLarge -> "<i> - ⚠ File too large</i>"
+      else -> ""
+    }
     return "<html>${contextItem.displayPath()}$warnIfNeeded</html>"
   }
 }

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -39,6 +39,7 @@ data class ExtensionMessage(
     val errors: String?,
     val query: String? = null,
     val configFeatures: ConfigFeatures? = null,
+    val enhancedContextStatus: EnhancedContextContextT? = null,
 ) {
 
   object Type {
@@ -46,6 +47,7 @@ data class ExtensionMessage(
     const val ERRORS = "errors"
     const val USER_CONTEXT_FILES = "userContextFiles"
     const val SET_CONFIG_FEATURES = "setConfigFeatures"
+    const val ENHANCED_CONTEXT_STATUS = "enhanced-context"
   }
 }
 
@@ -53,4 +55,29 @@ data class WebviewPostMessageParams(val id: String, val message: ExtensionMessag
 
 data class ConfigFeatures(
     val attribution: Boolean,
+)
+
+data class EnhancedContextContextT(
+  val groups: List<ContextGroup>
+)
+
+data class ContextGroup(
+  val dir: String? = null, // URI
+  val displayName: String,
+  val providers: List<ContextProvider>
+)
+
+// This is a subset of the ContextProvider type in lib/shared/src/codebase-context/context-status.ts
+// It covers remote search repositories.
+data class ContextProvider(
+  val kind: String, // "embeddings", "search"
+
+  // if kind is "search"
+  val type: String? = null, // "local", "remote"
+
+  // if kind is "search" and type is "remote"
+  val state: String? = null, // "ready", "no-match",
+  val id: String? = null,
+  val inclusion: String? = null, // "auto" or "manual"
+  val isIgnored: Boolean? = null,
 )

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -57,27 +57,25 @@ data class ConfigFeatures(
     val attribution: Boolean,
 )
 
-data class EnhancedContextContextT(
-  val groups: List<ContextGroup>
-)
+data class EnhancedContextContextT(val groups: List<ContextGroup>)
 
 data class ContextGroup(
-  val dir: String? = null, // URI
-  val displayName: String,
-  val providers: List<ContextProvider>
+    val dir: String? = null, // URI
+    val displayName: String,
+    val providers: List<ContextProvider>
 )
 
 // This is a subset of the ContextProvider type in lib/shared/src/codebase-context/context-status.ts
 // It covers remote search repositories.
 data class ContextProvider(
-  val kind: String, // "embeddings", "search"
+    val kind: String, // "embeddings", "search"
 
-  // if kind is "search"
-  val type: String? = null, // "local", "remote"
+    // if kind is "search"
+    val type: String? = null, // "local", "remote"
 
-  // if kind is "search" and type is "remote"
-  val state: String? = null, // "ready", "no-match",
-  val id: String? = null,
-  val inclusion: String? = null, // "auto" or "manual"
-  val isIgnored: Boolean? = null,
+    // if kind is "search" and type is "remote"
+    val state: String? = null, // "ready", "no-match",
+    val id: String? = null,
+    val inclusion: String? = null, // "auto" or "manual"
+    val isIgnored: Boolean? = null,
 )

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
@@ -64,7 +64,8 @@ data class ContextItemFile(
         null, // Oneof: embeddings, user, keyword, editor, filename, search, unified, selection,
     // terminal
     val content: String? = null,
-    val isTooLarge: Boolean? = null
+    val isTooLarge: Boolean? = null,
+    val isIgnored: Boolean? = null,
 ) : ContextItem() {
 
   fun isLocal() = repoName == null

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -209,6 +209,11 @@ private constructor(
           this.chatPanel.promptPanel.setContextFilesSelector(message.userContextFiles)
         }
       }
+      ExtensionMessage.Type.ENHANCED_CONTEXT_STATUS -> {
+        if (message.enhancedContextStatus != null) {
+          this.chatPanel.contextView.updateFromExtension(message.enhancedContextStatus)
+        }
+      }
       else -> {
         logger.debug(String.format("unknown message type: %s", message.type))
       }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -211,7 +211,7 @@ private constructor(
       }
       ExtensionMessage.Type.ENHANCED_CONTEXT_STATUS -> {
         if (message.enhancedContextStatus != null) {
-          this.chatPanel.contextView.updateFromExtension(message.enhancedContextStatus)
+          this.chatPanel.contextView.updateFromAgent(message.enhancedContextStatus)
         }
       }
       else -> {
@@ -259,7 +259,7 @@ private constructor(
         restoreChatSession(agent, chatMessages, chatModelProviderFromState, state.internalId!!)
     connectionId.getAndSet(newConnectionId)
 
-    // Update the extension-side state.
+    // Update the Agent-side state.
     val remoteRepos = state.enhancedContext?.remoteRepositories
     if (remoteRepos != null &&
         CodyAuthenticationManager.getInstance(project).getActiveAccount()?.isDotcomAccount() ==

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -41,7 +41,7 @@ class ChatPanel(
   private val messagesPanel = MessagesPanel(project, chatSession)
   private val chatPanel = ChatScrollPane(messagesPanel)
 
-  private val contextView: EnhancedContextPanel = EnhancedContextPanel.create(project, chatSession)
+  internal val contextView: EnhancedContextPanel = EnhancedContextPanel.create(project, chatSession)
 
   private val stopGeneratingButton =
       object : JButton("Stop generating", IconUtil.desaturate(AllIcons.Actions.Suspend)) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFileActionLink.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFileActionLink.kt
@@ -4,9 +4,13 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.AnActionLink
+import com.intellij.util.applyIf
 import com.sourcegraph.cody.agent.protocol.ContextItemFile
 import java.awt.Color
+import java.awt.Font
 import java.awt.Graphics
+import java.awt.font.TextAttribute
+import javax.swing.text.Style
 
 class ContextFileActionLink(
     project: Project,
@@ -18,7 +22,16 @@ class ContextFileActionLink(
 
   init {
     text = contextItemFile.getLinkActionText(project.basePath)
-    toolTipText = contextItemFile.uri.path
+    font = when {
+      contextItemFile.isIgnored == true ||
+      contextItemFile.isTooLarge == true -> Font(super.getFont().attributes + (TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
+      else -> super.getFont()
+    }
+    toolTipText = when {
+      contextItemFile.isIgnored == true -> "File ignored by an admin setting"
+      contextItemFile.isTooLarge == true -> "Excluded due to context window limit"
+      else -> contextItemFile.uri.path
+    }
   }
 
   override fun paintComponent(g: Graphics) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFileActionLink.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFileActionLink.kt
@@ -4,13 +4,11 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.AnActionLink
-import com.intellij.util.applyIf
 import com.sourcegraph.cody.agent.protocol.ContextItemFile
 import java.awt.Color
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.font.TextAttribute
-import javax.swing.text.Style
 
 class ContextFileActionLink(
     project: Project,
@@ -22,16 +20,20 @@ class ContextFileActionLink(
 
   init {
     text = contextItemFile.getLinkActionText(project.basePath)
-    font = when {
-      contextItemFile.isIgnored == true ||
-      contextItemFile.isTooLarge == true -> Font(super.getFont().attributes + (TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
-      else -> super.getFont()
-    }
-    toolTipText = when {
-      contextItemFile.isIgnored == true -> "File ignored by an admin setting"
-      contextItemFile.isTooLarge == true -> "Excluded due to context window limit"
-      else -> contextItemFile.uri.path
-    }
+    font =
+        when {
+          contextItemFile.isIgnored == true || contextItemFile.isTooLarge == true ->
+              Font(
+                  super.getFont().attributes +
+                      (TextAttribute.STRIKETHROUGH to TextAttribute.STRIKETHROUGH_ON))
+          else -> super.getFont()
+        }
+    toolTipText =
+        when {
+          contextItemFile.isIgnored == true -> "File ignored by an admin setting"
+          contextItemFile.isTooLarge == true -> "Excluded due to context window limit"
+          else -> contextItemFile.uri.path
+        }
   }
 
   override fun paintComponent(g: Graphics) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -55,12 +55,13 @@ class ContextFilesPanel(
   }
 
   private fun deriveAccordionTitle(contextItemFiles: List<ContextItemFile>): String {
-    val filteredFiles = contextItemFiles.distinctBy { it.uri }
+    val (excludedFiles, includedFiles) = contextItemFiles.partition { it.isTooLarge == true || it.isIgnored == true }
     val prefix = "✨ Context: "
-    val lineCount = contextItemFiles.sumOf { it.range?.length() ?: 0 }
-    val fileCount = filteredFiles.size
-    val lines = "$lineCount line${if (lineCount > 1) "s" else ""}"
-    val files = "$fileCount file${if (fileCount > 1) "s" else ""}"
+    val excludedFileCount = excludedFiles.distinctBy { it.uri }.size
+    val includedFileCount = includedFiles.distinctBy { it.uri }.size
+    val lineCount = includedFiles.sumOf { it.range?.length() ?: 0 }
+    val lines = "$lineCount ${"line".pluralize(lineCount)}"
+    val files = "$includedFileCount ${"file".pluralize(includedFileCount)}${if (excludedFileCount > 0) " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded" else ""}"
     val title =
         if (lineCount > 0) {
           "$lines from $files"
@@ -101,5 +102,14 @@ class ContextFilesPanel(
         }
       }
     }
+  }
+}
+
+// Can pluralize "file" and "line" by adding -s
+private fun String.pluralize(count: Int): String {
+  return if (count == 1) {
+    this
+  } else {
+    "${this}s"
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -108,10 +108,7 @@ class ContextFilesPanel(
 }
 
 // Can pluralize "file" and "line" by adding -s
-private fun String.pluralize(count: Int): String {
-  return if (count == 1) {
-    this
-  } else {
-    "${this}s"
-  }
-}
+  private fun String.pluralize(count: Int): String = when {
+    count == 1 -> this
+    else -> "${this}s"
+  } 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -57,20 +57,24 @@ class ContextFilesPanel(
   private fun deriveAccordionTitle(contextItemFiles: List<ContextItemFile>): String {
     val (excludedFiles, includedFiles) =
         contextItemFiles.partition { it.isTooLarge == true || it.isIgnored == true }
-    val prefix = "✨ Context: "
-    val excludedFileCount = excludedFiles.distinctBy { it.uri }.size
-    val includedFileCount = includedFiles.distinctBy { it.uri }.size
+
     val lineCount = includedFiles.sumOf { it.range?.length() ?: 0 }
     val lines = "$lineCount ${"line".pluralize(lineCount)}"
-    val files =
-        "$includedFileCount ${"file".pluralize(includedFileCount)}${if (excludedFileCount > 0) " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded" else ""}"
-    val title =
-        if (lineCount > 0) {
-          "$lines from $files"
-        } else {
-          files
-        }
 
+    val excludedFileCount = excludedFiles.distinctBy { it.uri }.size
+    val includedFileCount = includedFiles.distinctBy { it.uri }.size
+    val excludedFilesMessage = when {
+      excludedFileCount > 0 -> " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded"
+      else -> ""
+    }
+    val files = "$includedFileCount ${"file".pluralize(includedFileCount)}${excludedFilesMessage}"
+
+    val title = when {
+      lineCount > 0 -> "$lines from $files"
+      else -> files
+    }
+
+    val prefix = "✨ Context: "
     return "$prefix $title"
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -63,16 +63,19 @@ class ContextFilesPanel(
 
     val excludedFileCount = excludedFiles.distinctBy { it.uri }.size
     val includedFileCount = includedFiles.distinctBy { it.uri }.size
-    val excludedFilesMessage = when {
-      excludedFileCount > 0 -> " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded"
-      else -> ""
-    }
+    val excludedFilesMessage =
+        when {
+          excludedFileCount > 0 ->
+              " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded"
+          else -> ""
+        }
     val files = "$includedFileCount ${"file".pluralize(includedFileCount)}${excludedFilesMessage}"
 
-    val title = when {
-      lineCount > 0 -> "$lines from $files"
-      else -> files
-    }
+    val title =
+        when {
+          lineCount > 0 -> "$lines from $files"
+          else -> files
+        }
 
     val prefix = "✨ Context: "
     return "$prefix $title"
@@ -112,7 +115,8 @@ class ContextFilesPanel(
 }
 
 // Can pluralize "file" and "line" by adding -s
-  private fun String.pluralize(count: Int): String = when {
-    count == 1 -> this
-    else -> "${this}s"
-  } 
+private fun String.pluralize(count: Int): String =
+    when {
+      count == 1 -> this
+      else -> "${this}s"
+    }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ContextFilesPanel.kt
@@ -55,13 +55,15 @@ class ContextFilesPanel(
   }
 
   private fun deriveAccordionTitle(contextItemFiles: List<ContextItemFile>): String {
-    val (excludedFiles, includedFiles) = contextItemFiles.partition { it.isTooLarge == true || it.isIgnored == true }
+    val (excludedFiles, includedFiles) =
+        contextItemFiles.partition { it.isTooLarge == true || it.isIgnored == true }
     val prefix = "✨ Context: "
     val excludedFileCount = excludedFiles.distinctBy { it.uri }.size
     val includedFileCount = includedFiles.distinctBy { it.uri }.size
     val lineCount = includedFiles.sumOf { it.range?.length() ?: 0 }
     val lines = "$lineCount ${"line".pluralize(lineCount)}"
-    val files = "$includedFileCount ${"file".pluralize(includedFileCount)}${if (excludedFileCount > 0) " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded" else ""}"
+    val files =
+        "$includedFileCount ${"file".pluralize(includedFileCount)}${if (excludedFileCount > 0) " — $excludedFileCount ${"file".pluralize(excludedFileCount)} excluded" else ""}"
     val title =
         if (lineCount > 0) {
           "$lines from $files"

--- a/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoInsight.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoInsight.kt
@@ -44,7 +44,12 @@ enum class RepoInclusion {
   MANUAL,
 }
 
-data class RemoteRepo(val name: String, val isEnabled: Boolean? = null, val isIgnored: Boolean? = null, val inclusion: RepoInclusion? = null) {
+data class RemoteRepo(
+    val name: String,
+    val isEnabled: Boolean? = null,
+    val isIgnored: Boolean? = null,
+    val inclusion: RepoInclusion? = null
+) {
   val displayName: String
     get() = name.substring(name.indexOf('/') + 1) // Note, works for names without / => full name.
 
@@ -375,7 +380,8 @@ class RemoteRepoCompletionContributor : CompletionContributor(), DumbAware {
             prefixedResult.restartCompletionOnAnyPrefixChange()
             try {
               runBlockingCancellable {
-                // TODO: Extend repo search to consult Cody Ignore and denote repositories that are ignored.
+                // TODO: Extend repo search to consult Cody Ignore and denote repositories that are
+                // ignored.
                 for (repos in searcher.search(query)) {
                   blockingContext { // addElement uses ProgressManager.checkCancelled
                     for (repo in repos) {

--- a/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoInsight.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/RemoteRepoInsight.kt
@@ -39,13 +39,19 @@ import com.sourcegraph.common.CodyBundle.fmt
 import javax.swing.Icon
 import org.jetbrains.annotations.NonNls
 
-data class RemoteRepo(val name: String) {
+enum class RepoInclusion {
+  AUTO,
+  MANUAL,
+}
+
+data class RemoteRepo(val name: String, val isEnabled: Boolean? = null, val isIgnored: Boolean? = null, val inclusion: RepoInclusion? = null) {
   val displayName: String
     get() = name.substring(name.indexOf('/') + 1) // Note, works for names without / => full name.
 
   val icon: Icon?
     get() =
         when {
+          isIgnored == true -> Icons.RepoIgnored
           name.startsWith("github.com/") -> Icons.RepoHostGitHub
           name.startsWith("gitlab.com/") -> Icons.RepoHostGitlab
           name.startsWith("bitbucket.org/") -> Icons.RepoHostBitbucket
@@ -369,6 +375,7 @@ class RemoteRepoCompletionContributor : CompletionContributor(), DumbAware {
             prefixedResult.restartCompletionOnAnyPrefixChange()
             try {
               runBlockingCancellable {
+                // TODO: Extend repo search to consult Cody Ignore and denote repositories that are ignored.
                 for (repos in searcher.search(query)) {
                   blockingContext { // addElement uses ProgressManager.checkCancelled
                     for (repo in repos) {

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
@@ -11,7 +11,8 @@ import com.sourcegraph.common.CodyBundle.fmt
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JTree
 
-class ContextRepositoriesCheckboxRenderer(private val enhancedContextEnabled: AtomicBoolean) : CheckboxTree.CheckboxTreeCellRenderer() {
+class ContextRepositoriesCheckboxRenderer(private val enhancedContextEnabled: AtomicBoolean) :
+    CheckboxTree.CheckboxTreeCellRenderer() {
 
   override fun customizeRenderer(
       tree: JTree?,
@@ -62,24 +63,31 @@ class ContextRepositoriesCheckboxRenderer(private val enhancedContextEnabled: At
       is ContextTreeRemoteRepoNode -> {
         val isEnhancedContextEnabled = enhancedContextEnabled.get()
 
-        textRenderer.appendHTML(
-            node.repo.displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
+        textRenderer.appendHTML(node.repo.displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
         textRenderer.icon = node.repo.icon
-        toolTipText = when {
-          node.repo.isIgnored == true -> CodyBundle.getString("context-panel.tree.node-ignored.tooltip")
-          node.repo.inclusion == RepoInclusion.AUTO -> CodyBundle.getString("context-panel.tree.node-auto.tooltip")
-          else -> node.repo.name
-        }
-        myCheckbox.state = when {
-          isEnhancedContextEnabled && node.repo.isEnabled == true && node.repo.isIgnored != true -> ThreeStateCheckBox.State.SELECTED
-          node.repo.isEnabled == true -> ThreeStateCheckBox.State.DONT_CARE
-          else -> ThreeStateCheckBox.State.NOT_SELECTED
-        }
+        toolTipText =
+            when {
+              node.repo.isIgnored == true ->
+                  CodyBundle.getString("context-panel.tree.node-ignored.tooltip")
+              node.repo.inclusion == RepoInclusion.AUTO ->
+                  CodyBundle.getString("context-panel.tree.node-auto.tooltip")
+              else -> node.repo.name
+            }
+        myCheckbox.state =
+            when {
+              isEnhancedContextEnabled &&
+                  node.repo.isEnabled == true &&
+                  node.repo.isIgnored != true -> ThreeStateCheckBox.State.SELECTED
+              node.repo.isEnabled == true -> ThreeStateCheckBox.State.DONT_CARE
+              else -> ThreeStateCheckBox.State.NOT_SELECTED
+            }
         myCheckbox.isEnabled = isEnhancedContextEnabled && node.repo.inclusion != RepoInclusion.AUTO
-        myCheckbox.toolTipText = when {
-          node.repo.inclusion == RepoInclusion.AUTO -> CodyBundle.getString("context-panel.tree.node-auto.tooltip")
-          else -> CodyBundle.getString("context-panel.tree.node.checkbox.remove-tooltip")
-        }
+        myCheckbox.toolTipText =
+            when {
+              node.repo.inclusion == RepoInclusion.AUTO ->
+                  CodyBundle.getString("context-panel.tree.node-auto.tooltip")
+              else -> CodyBundle.getString("context-panel.tree.node.checkbox.remove-tooltip")
+            }
       }
 
       // Fallback

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
@@ -5,6 +5,7 @@ import com.intellij.ui.CheckboxTree
 import com.intellij.ui.CheckedTreeNode
 import com.intellij.ui.SimpleTextAttributes
 import com.intellij.util.ui.ThreeStateCheckBox
+import com.sourcegraph.cody.context.RepoInclusion
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
 import javax.swing.JTree
@@ -60,6 +61,16 @@ class ContextRepositoriesCheckboxRenderer : CheckboxTree.CheckboxTreeCellRendere
         textRenderer.appendHTML(
             "<b>${node.repo.displayName}</b>", SimpleTextAttributes.REGULAR_ATTRIBUTES)
         textRenderer.icon = node.repo.icon
+        toolTipText = when {
+          node.repo.isIgnored == true -> CodyBundle.getString("context-panel.tree.node-ignored.tooltip")
+          node.repo.inclusion == RepoInclusion.AUTO -> CodyBundle.getString("context-panel.tree.node-auto.tooltip")
+          else -> node.repo.name
+        }
+        myCheckbox.state = when {
+          node.repo.isEnabled == true -> ThreeStateCheckBox.State.SELECTED
+          else -> ThreeStateCheckBox.State.NOT_SELECTED
+        }
+        myCheckbox.isEnabled = node.repo.inclusion != RepoInclusion.AUTO
       }
 
       // Fallback

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextRepositoriesCheckboxRenderer.kt
@@ -8,9 +8,10 @@ import com.intellij.util.ui.ThreeStateCheckBox
 import com.sourcegraph.cody.context.RepoInclusion
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JTree
 
-class ContextRepositoriesCheckboxRenderer : CheckboxTree.CheckboxTreeCellRenderer() {
+class ContextRepositoriesCheckboxRenderer(private val enhancedContextEnabled: AtomicBoolean) : CheckboxTree.CheckboxTreeCellRenderer() {
 
   override fun customizeRenderer(
       tree: JTree?,
@@ -42,14 +43,15 @@ class ContextRepositoriesCheckboxRenderer : CheckboxTree.CheckboxTreeCellRendere
                 .fmt(style, node.numRepos.toString(), node.endpointName),
             SimpleTextAttributes.REGULAR_ATTRIBUTES)
         // The root element controls enhanced context which includes editor selection, etc. Do not
-        // display unchecked/bar
-        // even if the child repos are unchecked.
+        // display unchecked/bar even if the child repos are unchecked.
         myCheckbox.state =
             if (node.isChecked) {
               ThreeStateCheckBox.State.SELECTED
             } else {
               ThreeStateCheckBox.State.NOT_SELECTED
             }
+        toolTipText = ""
+        myCheckbox.toolTipText = ""
       }
       is ContextTreeRemotesNode -> {
         textRenderer.append(
@@ -58,8 +60,10 @@ class ContextRepositoriesCheckboxRenderer : CheckboxTree.CheckboxTreeCellRendere
         myCheckbox.isVisible = false
       }
       is ContextTreeRemoteRepoNode -> {
+        val isEnhancedContextEnabled = enhancedContextEnabled.get()
+
         textRenderer.appendHTML(
-            "<b>${node.repo.displayName}</b>", SimpleTextAttributes.REGULAR_ATTRIBUTES)
+            node.repo.displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
         textRenderer.icon = node.repo.icon
         toolTipText = when {
           node.repo.isIgnored == true -> CodyBundle.getString("context-panel.tree.node-ignored.tooltip")
@@ -67,10 +71,15 @@ class ContextRepositoriesCheckboxRenderer : CheckboxTree.CheckboxTreeCellRendere
           else -> node.repo.name
         }
         myCheckbox.state = when {
-          node.repo.isEnabled == true -> ThreeStateCheckBox.State.SELECTED
+          isEnhancedContextEnabled && node.repo.isEnabled == true && node.repo.isIgnored != true -> ThreeStateCheckBox.State.SELECTED
+          node.repo.isEnabled == true -> ThreeStateCheckBox.State.DONT_CARE
           else -> ThreeStateCheckBox.State.NOT_SELECTED
         }
-        myCheckbox.isEnabled = node.repo.inclusion != RepoInclusion.AUTO
+        myCheckbox.isEnabled = isEnhancedContextEnabled && node.repo.inclusion != RepoInclusion.AUTO
+        myCheckbox.toolTipText = when {
+          node.repo.inclusion == RepoInclusion.AUTO -> CodyBundle.getString("context-panel.tree.node-auto.tooltip")
+          else -> CodyBundle.getString("context-panel.tree.node.checkbox.remove-tooltip")
+        }
       }
 
       // Fallback

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -194,7 +194,7 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
     }
   }
 
-  abstract fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT)
+  abstract fun updateFromAgent(enhancedContextStatus: EnhancedContextContextT)
 }
 
 class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession) :
@@ -228,7 +228,7 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
           /* checkParentWithCheckedChild = */ false,
           /* uncheckParentWithUncheckedChild = */ false)
 
-  override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
+  override fun updateFromAgent(enhancedContextStatus: EnhancedContextContextT) {
     val repos = mutableListOf<RemoteRepo>()
 
     for (group in enhancedContextStatus.groups) {
@@ -278,7 +278,7 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     treeModel.reload()
     resize()
 
-    // Update the extension-side state for this chat.
+    // Update the Agent-side state for this chat.
     val enabledRepos = cleanedRepos.filter { it.isEnabled }.mapNotNull { it.codebaseName }
     RemoteRepoUtils.resolveReposWithErrorNotification(
         project, enabledRepos.map { CodebaseName(it) }) { repos ->
@@ -329,7 +329,7 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
                   })
             }
 
-            // Update the extension state. This triggers the tree view update.
+            // Update the Agent state. This triggers the tree view update.
             chatSession.sendWebviewMessage(
                 WebviewMessage(
                     command = "context/choose-remote-search-repo", explicitRepos = trimmedRepos))
@@ -404,7 +404,7 @@ class ConsumerEnhancedContextPanel(project: Project, chatSession: ChatSession) :
           /* checkParentWithCheckedChild = */ true,
           /* uncheckParentWithUncheckedChild = */ false)
 
-  override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
+  override fun updateFromAgent(enhancedContextStatus: EnhancedContextContextT) {
     // No-op. The consumer panel relies solely on JetBrains-side state.
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -12,11 +12,13 @@ import com.intellij.ui.CheckedTreeNode
 import com.intellij.ui.ToolbarDecorator.createDecorator
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.vcs.commit.NonModalCommitPanel.Companion.showAbove
+import com.sourcegraph.cody.agent.EnhancedContextContextT
 import com.sourcegraph.cody.agent.WebviewMessage
 import com.sourcegraph.cody.chat.ChatSession
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.context.RemoteRepo
 import com.sourcegraph.cody.context.RemoteRepoUtils
+import com.sourcegraph.cody.context.RepoInclusion
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.EnhancedContextState
 import com.sourcegraph.cody.history.state.RemoteRepositoryState
@@ -111,12 +113,7 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
 
   /** The tree component. */
   protected val tree = run {
-    val checkPolicy =
-        CheckboxTreeBase.CheckPolicy(
-            /* checkChildrenWithCheckedParent = */ true,
-            /* uncheckChildrenWithUncheckedParent = */ true,
-            /* checkParentWithCheckedChild = */ true,
-            /* uncheckParentWithUncheckedChild = */ false)
+    val checkPolicy = createCheckboxPolicy()
     object : CheckboxTree(ContextRepositoriesCheckboxRenderer(), treeRoot, checkPolicy) {
       // When collapsed, the horizontal scrollbar obscures the Chat Context summary & checkbox.
       // Prefer to clip. Users
@@ -124,6 +121,8 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
       override fun getScrollableTracksViewportWidth(): Boolean = true
     }
   }
+
+  protected abstract fun createCheckboxPolicy(): CheckboxTreeBase.CheckPolicy
 
   /** The toolbar decorator component. */
   protected val toolbar = run {
@@ -192,6 +191,8 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
       expandAllNodes(tree.rowCount)
     }
   }
+
+  abstract fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT)
 }
 
 class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession) :
@@ -216,6 +217,35 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     }
     toolbar.addExtraAction(HelpButton())
     return toolbar.createPanel()
+  }
+
+  override fun createCheckboxPolicy(): CheckboxTreeBase.CheckPolicy =
+    CheckboxTreeBase.CheckPolicy(
+      /* checkChildrenWithCheckedParent = */ false,
+      /* uncheckChildrenWithUncheckedParent = */ false,
+      /* checkParentWithCheckedChild = */ false,
+      /* uncheckParentWithUncheckedChild = */ false)
+
+  override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
+    val repos = mutableListOf<RemoteRepo>()
+
+    for (group in enhancedContextStatus.groups) {
+      val provider = group.providers.firstOrNull() ?: continue
+      val name = group.displayName
+      val enabled = provider.state == "ready"
+      val ignored = provider.isIgnored == true
+      val inclusion = when (provider.inclusion) {
+        "auto" -> RepoInclusion.AUTO
+        "explicit" -> RepoInclusion.MANUAL
+        else -> null
+      }
+      repos.add(RemoteRepo(name, isEnabled=enabled, isIgnored=ignored, inclusion=inclusion))
+    }
+
+    runInEdt {
+      updateTree(repos)
+      resize()
+    }
   }
 
   private val remotesNode = ContextTreeRemotesNode()
@@ -248,32 +278,27 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     // Update the extension-side state for this chat.
     val enabledRepos = cleanedRepos.filter { it.isEnabled }.mapNotNull { it.codebaseName }
     RemoteRepoUtils.resolveReposWithErrorNotification(
-        project, enabledRepos.map { it -> CodebaseName(it) }) { repos ->
-          runInEdt {
-            updateTree(repos.map { it.name })
-            resize()
-          }
+        project, enabledRepos.map { CodebaseName(it) }) { repos ->
           chatSession.sendWebviewMessage(
               WebviewMessage(command = "context/choose-remote-search-repo", explicitRepos = repos))
         }
   }
 
   @RequiresEdt
-  private fun updateTree(repoNames: List<String>) {
+  private fun updateTree(repos: List<RemoteRepo>) {
     // TODO: When Kotlin @RequiresEdt annotations are instrumented, remove this manual assertion.
     ApplicationManager.getApplication().assertIsDispatchThread()
 
     val remotesPath = treeModel.getTreePath(remotesNode.userObject)
     val wasExpanded = remotesPath != null && tree.isExpanded(remotesPath)
     remotesNode.removeAllChildren()
-    repoNames.forEach { repoName ->
-      val node =
-          ContextTreeRemoteRepoNode(RemoteRepo(repoName)) { checked ->
-            setRepoEnabledInContextState(repoName, checked)
+    repos.map { repo ->
+          ContextTreeRemoteRepoNode(repo) { checked ->
+            setRepoEnabledInContextState(repo.name, checked)
           }
-      remotesNode.add(node)
-    }
-    contextRoot.numRepos = repoNames.size
+    }.forEach { remotesNode.add(it) }
+    // TODO: Count the enabled repos, not all repos; count the ignored repos.
+    contextRoot.numRepos = repos.count { it.isIgnored != true }
     treeModel.reload(contextRoot)
     if (wasExpanded) {
       tree.expandPath(remotesPath)
@@ -299,11 +324,7 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
                   })
             }
 
-            // Update the UI.
-            updateTree(trimmedRepos.map { it -> it.name })
-            resize()
-
-            // Update the extension state.
+            // Update the extension state. This triggers the tree view update.
             chatSession.sendWebviewMessage(
                 WebviewMessage(
                     command = "context/choose-remote-search-repo", explicitRepos = trimmedRepos))
@@ -369,6 +390,17 @@ class ConsumerEnhancedContextPanel(project: Project, chatSession: ChatSession) :
     toolbar.addExtraAction(ReindexButton(project))
     toolbar.addExtraAction(HelpButton())
     return toolbar.createPanel()
+  }
+
+  override fun createCheckboxPolicy(): CheckboxTreeBase.CheckPolicy =
+    CheckboxTreeBase.CheckPolicy(
+      /* checkChildrenWithCheckedParent = */ true,
+      /* uncheckChildrenWithUncheckedParent = */ true,
+      /* checkParentWithCheckedChild = */ true,
+      /* uncheckParentWithUncheckedChild = */ false)
+
+  override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
+    // No-op. The consumer panel relies solely on JetBrains-side state.
   }
 
   init {

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -114,7 +114,7 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
   /** The tree component. */
   protected val tree = run {
     val checkPolicy = createCheckboxPolicy()
-    object : CheckboxTree(ContextRepositoriesCheckboxRenderer(), treeRoot, checkPolicy) {
+    object : CheckboxTree(ContextRepositoriesCheckboxRenderer(enhancedContextEnabled), treeRoot, checkPolicy) {
       // When collapsed, the horizontal scrollbar obscures the Chat Context summary & checkbox.
       // Prefer to clip. Users
       // can resize the sidebar if desired.

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -114,7 +114,9 @@ constructor(protected val project: Project, protected val chatSession: ChatSessi
   /** The tree component. */
   protected val tree = run {
     val checkPolicy = createCheckboxPolicy()
-    object : CheckboxTree(ContextRepositoriesCheckboxRenderer(enhancedContextEnabled), treeRoot, checkPolicy) {
+    object :
+        CheckboxTree(
+            ContextRepositoriesCheckboxRenderer(enhancedContextEnabled), treeRoot, checkPolicy) {
       // When collapsed, the horizontal scrollbar obscures the Chat Context summary & checkbox.
       // Prefer to clip. Users
       // can resize the sidebar if desired.
@@ -220,11 +222,11 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
   }
 
   override fun createCheckboxPolicy(): CheckboxTreeBase.CheckPolicy =
-    CheckboxTreeBase.CheckPolicy(
-      /* checkChildrenWithCheckedParent = */ false,
-      /* uncheckChildrenWithUncheckedParent = */ false,
-      /* checkParentWithCheckedChild = */ false,
-      /* uncheckParentWithUncheckedChild = */ false)
+      CheckboxTreeBase.CheckPolicy(
+          /* checkChildrenWithCheckedParent = */ false,
+          /* uncheckChildrenWithUncheckedParent = */ false,
+          /* checkParentWithCheckedChild = */ false,
+          /* uncheckParentWithUncheckedChild = */ false)
 
   override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
     val repos = mutableListOf<RemoteRepo>()
@@ -234,12 +236,13 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
       val name = group.displayName
       val enabled = provider.state == "ready"
       val ignored = provider.isIgnored == true
-      val inclusion = when (provider.inclusion) {
-        "auto" -> RepoInclusion.AUTO
-        "explicit" -> RepoInclusion.MANUAL
-        else -> null
-      }
-      repos.add(RemoteRepo(name, isEnabled=enabled, isIgnored=ignored, inclusion=inclusion))
+      val inclusion =
+          when (provider.inclusion) {
+            "auto" -> RepoInclusion.AUTO
+            "explicit" -> RepoInclusion.MANUAL
+            else -> null
+          }
+      repos.add(RemoteRepo(name, isEnabled = enabled, isIgnored = ignored, inclusion = inclusion))
     }
 
     runInEdt {
@@ -292,11 +295,13 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     val remotesPath = treeModel.getTreePath(remotesNode.userObject)
     val wasExpanded = remotesPath != null && tree.isExpanded(remotesPath)
     remotesNode.removeAllChildren()
-    repos.map { repo ->
+    repos
+        .map { repo ->
           ContextTreeRemoteRepoNode(repo) { checked ->
             setRepoEnabledInContextState(repo.name, checked)
           }
-    }.forEach { remotesNode.add(it) }
+        }
+        .forEach { remotesNode.add(it) }
     // TODO: Count the enabled repos, not all repos; count the ignored repos.
     contextRoot.numRepos = repos.count { it.isIgnored != true }
     treeModel.reload(contextRoot)
@@ -393,11 +398,11 @@ class ConsumerEnhancedContextPanel(project: Project, chatSession: ChatSession) :
   }
 
   override fun createCheckboxPolicy(): CheckboxTreeBase.CheckPolicy =
-    CheckboxTreeBase.CheckPolicy(
-      /* checkChildrenWithCheckedParent = */ true,
-      /* uncheckChildrenWithUncheckedParent = */ true,
-      /* checkParentWithCheckedChild = */ true,
-      /* uncheckParentWithUncheckedChild = */ false)
+      CheckboxTreeBase.CheckPolicy(
+          /* checkChildrenWithCheckedParent = */ true,
+          /* uncheckChildrenWithUncheckedParent = */ true,
+          /* checkParentWithCheckedChild = */ true,
+          /* uncheckParentWithUncheckedChild = */ false)
 
   override fun updateFromExtension(enhancedContextStatus: EnhancedContextContextT) {
     // No-op. The consumer panel relies solely on JetBrains-side state.

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -189,3 +189,5 @@ ignore.action-in-ignored-file.title=Cody is Limited
 ignore.status-bar-ignored-file.tooltip=This file has been ignored by an admin.\nAutocomplete, commands, and other Cody features are disabled.
 ignore.sidebar-panel-ignored-file.text=<html>This file has been marked as ignored by an admin, which means commands that rely on its contents cannot be executed.</html>
 ignore.sidebar-panel-ignored-file.learn-more-cta=Learn more
+context-panel.tree.node-ignored.tooltip=Repo ignored by an admin setting
+context-panel.tree.node-auto.tooltip=Included automatically based on your project

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -189,6 +189,6 @@ ignore.action-in-ignored-file.title=Cody is Limited
 ignore.status-bar-ignored-file.tooltip=This file has been ignored by an admin.\nAutocomplete, commands, and other Cody features are disabled.
 ignore.sidebar-panel-ignored-file.text=<html>This file has been marked as ignored by an admin, which means commands that rely on its contents cannot be executed.</html>
 ignore.sidebar-panel-ignored-file.learn-more-cta=Learn more
-context-panel.tree.node-ignored.tooltip=Repo ignored by an admin setting
+context-panel.tree.node-ignored.tooltip=Repository ignored by an admin setting
 context-panel.tree.node-auto.tooltip=Included automatically based on your project
 context-panel.tree.node.checkbox.remove-tooltip=Uncheck to remove from enhanced context

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -191,3 +191,4 @@ ignore.sidebar-panel-ignored-file.text=<html>This file has been marked as ignore
 ignore.sidebar-panel-ignored-file.learn-more-cta=Learn more
 context-panel.tree.node-ignored.tooltip=Repo ignored by an admin setting
 context-panel.tree.node-auto.tooltip=Included automatically based on your project
+context-panel.tree.node.checkbox.remove-tooltip=Uncheck to remove from enhanced context

--- a/src/main/resources/icons/repo-ignored.svg
+++ b/src/main/resources/icons/repo-ignored.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <circle r="8" cx="12" cy="12" fill="none" stroke="#CCCCCC" stroke-width="2" />
+    <line x1="12" x2="12" y1="4" y2="20" stroke="#CCCCCC" stroke-width="2" transform="rotate(45 12 12)"/>
+</svg>


### PR DESCRIPTION
- @-mention selector for files badges ignored files
- Context inspection summary displays elaborate count of ignored files
- Context inspection disclosure displays ignored files with strikeout
- Repo picker displays ignored repos with a slashed circle, tooltips, etc.

This also changes the enhanced context selector to reflect the state of the extension. This has many effects:

- The implicitly included repository is displayed (adds tooltips, etc. for this.)
- Removing repos is done by clicking the checkboxes, and they disappear. This needs UX feedback. It is close to VSCode, but it is weird to have the items disappear.
- There's a bug in Agent where the git extension shim doesn't initialize the repository `state.remotes`, causing us to pick up the implicit repo poorly.

Part of #1256

## Test plan

![Screenshot 2024-05-07 at 23 12 17](https://github.com/sourcegraph/jetbrains/assets/55120/66b8fd15-1f1b-4761-8ac9-051b73e5f86c)

- Sign in to sg02.sourcegraphcloud.com
- Open the Cody repo, add a bunch of repos and verify the repos have a circle-slash in line with the sg02 policy
- Mention files with @ and the picker should say the files are ignored
- Sending a chat with ignored mentioned files and the context disclosure should display the files with strikeout text