### PR TITLE
Removed API usages that were deprecated in IntelliJ 2022.1.

### DIFF
--- a/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
+++ b/src/main/java/com/sourcegraph/find/browser/BrowserAndLoadingPanel.java
@@ -11,7 +11,6 @@ import com.intellij.util.ui.StatusText;
 import com.sourcegraph.cody.config.ui.AccountConfigurable;
 import java.awt.*;
 import javax.swing.*;
-import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang.WordUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -76,7 +75,7 @@ public class BrowserAndLoadingPanel extends JLayeredPane {
 
     } else if (errorMessage != null) {
       String wrappedText = WordUtils.wrap("Error: " + errorMessage, 100);
-      String[] lines = wrappedText.split(SystemUtils.LINE_SEPARATOR);
+      String[] lines = wrappedText.split("\\n");
       emptyText.setText(lines[0]);
       for (int i = 1; i < lines.length; i++) {
         if (!lines[i].trim().isEmpty()) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/ExportChatsAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/ExportChatsAction.kt
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.fileChooser.FileChooserFactory
 import com.intellij.openapi.fileChooser.FileSaverDescriptor
 import com.intellij.openapi.fileChooser.FileSaverDialog
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
@@ -36,8 +37,7 @@ class ExportChatsAction : DumbAwareBGTAction() {
     val token = CancellationToken()
     token.onFinished { isRunning.getAndSet(false) }
 
-    // Update default file path to user home if myProject.getBasePath() is not valid
-    var outputDir: VirtualFile? = project.baseDir
+    var outputDir: VirtualFile? = project.guessProjectDir()
     if (outputDir == null || !outputDir.exists()) {
       outputDir = VfsUtil.getUserHomeDir()
     }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -25,8 +25,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.messages.MessageBusConnection
+import com.intellij.util.ui.ImageUtil
 import com.intellij.util.ui.JBUI
-import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.ModelUsage
 import com.sourcegraph.cody.chat.ui.LlmDropdown
@@ -590,8 +590,7 @@ class EditCommandPrompt(
       if (offscreenImage == null ||
           offscreenImage!!.width != width ||
           offscreenImage!!.height != height) {
-        @Suppress("DEPRECATION")
-        offscreenImage = UIUtil.createImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        offscreenImage = ImageUtil.createImage(width, height, BufferedImage.TYPE_INT_ARGB)
       }
       val offscreenGraphics = offscreenImage!!.createGraphics()
       super.paintComponent(offscreenGraphics)


### PR DESCRIPTION
This PR is related to #1458.

## Test plan

`./gradlew runPluginVerifier`