### PR TITLE
 Fix undefined files handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=b74b93fa41eec5864bb7c17271916c0b7680efad
+cody.commit=2c5db972f152628d68e034064467369bb05760fd

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -42,6 +42,9 @@ public class CodyAgentClient {
   // Callback for the "textDocument/show" request from the agent.
   @Nullable Function<TextDocumentShowParams, Boolean> onTextDocumentShow;
 
+  // Callback for the "textDocument/openUntitledDocument" request from the agent.
+  @Nullable Function<UntitledTextDocument, Boolean> onOpenUntitledDocument;
+
   // Callback for the "workspace/edit" request from the agent.
   @Nullable Consumer<WorkspaceEditParams> onWorkspaceEdit;
 
@@ -90,6 +93,16 @@ public class CodyAgentClient {
   @JsonRequest("textDocument/show")
   public CompletableFuture<Boolean> textDocumentShow(TextDocumentShowParams params) {
     return acceptOnEventThread("textDocument/show", onTextDocumentShow, params);
+  }
+
+  @JsonRequest("textDocument/openUntitledDocument")
+  public CompletableFuture<Boolean> openUntitledDocument(UntitledTextDocument params) {
+    if (onOpenUntitledDocument == null) {
+      return CompletableFuture.failedFuture(
+          new Exception("No callback registered for textDocument/openUntitledDocument"));
+    } else {
+      return CompletableFuture.completedFuture(onOpenUntitledDocument.apply(params));
+    }
   }
 
   @JsonRequest("workspace/edit")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -116,7 +116,7 @@ private constructor(
                               codeLenses = "enabled",
                               showDocument = "enabled",
                               ignore = "enabled",
-                              untitledDocuments = "onlyRealFiles")))
+                              untitledDocuments = "enabled")))
               .thenApply { info ->
                 logger.warn("Connected to Cody agent " + info.name)
                 server.initialized()

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -115,7 +115,8 @@ private constructor(
                               editWorkspace = "enabled",
                               codeLenses = "enabled",
                               showDocument = "enabled",
-                              ignore = "enabled")))
+                              ignore = "enabled",
+                              untitledDocuments = "onlyRealFiles")))
               .thenApply { info ->
                 logger.warn("Connected to Cody agent " + info.name)
                 server.initialized()

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientCapabilities.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ClientCapabilities.kt
@@ -9,5 +9,6 @@ data class ClientCapabilities(
     var editWorkspace: String? = null,
     var codeLenses: String? = null,
     val showDocument: String? = null,
-    val ignore: String? = null
+    val ignore: String? = null,
+    val untitledDocuments: String? = null
 )

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/UntitledTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/UntitledTextDocument.kt
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class UntitledTextDocument(
+    val uri: String,
+    val content: String?,
+    val language: String?,
+)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -11,13 +11,10 @@ import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ScrollType
 import com.intellij.openapi.fileEditor.FileDocumentManager
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.intellij.util.io.createFile
-import com.intellij.util.io.exists
 import com.intellij.util.withScheme
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentCodebase
@@ -266,7 +263,7 @@ abstract class FixupSession(
 
     for (op in workspaceEditParams.operations) {
 
-      op.uri?.let { createAndSwitchFileIfNeeded(it) }
+      op.uri?.let { updateEditorIfNeeded(it) }
 
       // TODO: We need to support the file-level operations.
       when (op.type) {
@@ -294,22 +291,15 @@ abstract class FixupSession(
     }
   }
 
-  private fun createAndSwitchFileIfNeeded(path: String) {
+  private fun updateEditorIfNeeded(path: String) {
     val uri = URI.create(path).withScheme("file")
-    if (!uri.toPath().exists()) uri.toPath().createFile()
+    val vf = LocalFileSystem.getInstance().findFileByNioFile(uri.toPath()) ?: return
+    val documentForFile = FileDocumentManager.getInstance().getDocument(vf)
 
-    val vf = LocalFileSystem.getInstance().refreshAndFindFileByNioFile(uri.toPath()) ?: return
-    if (FileDocumentManager.getInstance().getFile(document) == vf) {
-      return
-    }
-
-    ApplicationManager.getApplication().invokeAndWait { CodyEditorUtil.showDocument(project, path) }
-    editor = FileEditorManager.getInstance(project).selectedTextEditor ?: return
-    val textFile = ProtocolTextDocument.fromVirtualFile(editor, vf)
-
-    CodyAgentService.withAgent(project) { agent ->
-      ensureSelectionRange(agent, textFile)
-      runInEdt { showWorkingGroup() }
+    if (document != documentForFile) {
+      CodyEditorUtil.getAllOpenEditors()
+          .firstOrNull { it.document == documentForFile }
+          ?.let { newEditor -> editor = newEditor }
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -300,6 +300,12 @@ abstract class FixupSession(
       CodyEditorUtil.getAllOpenEditors()
           .firstOrNull { it.document == documentForFile }
           ?.let { newEditor -> editor = newEditor }
+
+      val textFile = ProtocolTextDocument.fromVirtualFile(editor, vf)
+      CodyAgentService.withAgent(project) { agent ->
+        ensureSelectionRange(agent, textFile)
+        runInEdt { showWorkingGroup() }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1472

## Changes

Added new client capability which is partial support for `undefined` files.
IntelliJ does not support in-memory files, but is able to create real files on the disk if given url is a valid path.

This is fixing `Generate Unit Test` command.

Cody PR: https://github.com/sourcegraph/cody/pull/4088

## Test plan

Manual tests using`Generate Unit Test` command.