### PR TITLE
Block further inline edits until previous one completes

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -56,7 +56,7 @@ class CodyAgentService(project: Project) : Disposable {
 
       agent.client.onEditTaskDidDelete = Consumer { params ->
         FixupService.getInstance(project).getActiveSession()?.let {
-          if (params.id == it.taskId) it.taskDeleted()
+          if (params.id == it.taskId) it.dismiss()
         }
       }
 

--- a/src/main/kotlin/com/sourcegraph/cody/commands/CommandId.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/commands/CommandId.kt
@@ -2,8 +2,8 @@ package com.sourcegraph.cody.commands
 
 import java.awt.event.KeyEvent
 
-enum class CommandId(val displayName: String, val mnemonic: Int) {
-  Explain("Explain Code", KeyEvent.VK_E),
-  Smell("Smell Code", KeyEvent.VK_S),
-  Test("Generate Test", KeyEvent.VK_T)
+enum class CommandId(val id: String, val displayName: String, val mnemonic: Int) {
+  Explain("cody.command.Explain", "Explain Code", KeyEvent.VK_E),
+  Smell("cody.command.Smell", "Smell Code", KeyEvent.VK_S),
+  Test("cody.command.Test", "Generate Test", KeyEvent.VK_T)
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -80,7 +80,7 @@ class EditCommandPrompt(
     val editor: Editor,
     dialogTitle: String,
     instruction: String? = null
-) : JFrame(), Disposable {
+) : JFrame(), Disposable, FixupService.ActiveFixupSessionStateListener {
   private val logger = Logger.getInstance(EditCommandPrompt::class.java)
 
   private val offset = editor.caretModel.primaryCaret.offset
@@ -321,6 +321,8 @@ class EditCommandPrompt(
     // Close dialog if window loses focus.
     addWindowFocusListener(windowFocusListener)
     addFocusListener(focusListener)
+
+    FixupService.getInstance(controller.project).addListener(this)
   }
 
   override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
@@ -359,7 +361,9 @@ class EditCommandPrompt(
 
   @RequiresEdt
   private fun updateOkButtonState() {
-    okButton.isEnabled = instructionsField.text.isNotBlank()
+    okButton.isEnabled =
+        instructionsField.text.isNotBlank() &&
+            !FixupService.getInstance(controller.project).isEditInProgress()
   }
 
   @RequiresEdt
@@ -686,5 +690,9 @@ class EditCommandPrompt(
 
       return sb.toString()
     }
+  }
+
+  override fun fixupSessionStateChanged(isInProgress: Boolean) {
+    runInEdt { okButton.isEnabled = !isInProgress }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -76,20 +76,17 @@ class FixupService(val project: Project) : Disposable {
 
   fun getActiveSession(): FixupSession? = activeSession
 
-  fun setActiveSession(session: FixupSession) {
-    activeSession?.let { if (it.isShowingAcceptLens()) it.accept() else it.cancel() }
-    waitUntilActiveSessionIsFinished()
-    activeSession = session
-  }
-
-  fun waitUntilActiveSessionIsFinished() {
-    while (activeSession != null) {
-      Thread.sleep(100)
+  fun startNewSession(newSession: FixupSession, code: () -> Unit) {
+    activeSession?.let { currentSession ->
+      if (currentSession.isShowingAcceptLens()) currentSession.accept() else currentSession.cancel()
+      currentSession.cancellationToken.onFinished {
+        activeSession = newSession
+        code()
+      }
     }
   }
 
   fun clearActiveSession() {
-    // N.B. This cannot call back into the activeSession, or it will recurse.
     activeSession = null
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
@@ -1,9 +1,10 @@
 package com.sourcegraph.cody.edit.actions
 
-import com.intellij.openapi.project.DumbAware
-import com.sourcegraph.cody.autocomplete.action.CodyAction
-
 class DocumentCodeAction :
-    EditCommandAction({ editor, fixupService -> fixupService.startDocumentCode(editor) }),
-    CodyAction,
-    DumbAware
+    NonInteractiveEditCommandAction({ editor, fixupService ->
+      fixupService.startDocumentCode(editor)
+    }) {
+  companion object {
+    const val ID: String = "cody.documentCodeAction"
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
@@ -1,9 +1,8 @@
 package com.sourcegraph.cody.edit.actions
 
-import com.intellij.openapi.project.DumbAware
-import com.sourcegraph.cody.autocomplete.action.CodyAction
-
 class EditCodeAction :
-    EditCommandAction({ editor, fixupService -> fixupService.startCodeEdit(editor) }),
-    CodyAction,
-    DumbAware
+    EditCommandAction({ editor, fixupService -> fixupService.startCodeEdit(editor) }) {
+  companion object {
+    const val ID: String = "cody.editCodeAction"
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
@@ -1,0 +1,15 @@
+package com.sourcegraph.cody.edit.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.editor.Editor
+import com.sourcegraph.cody.edit.FixupService
+
+open class NonInteractiveEditCommandAction(runAction: (Editor, FixupService) -> Unit) :
+    EditCommandAction(runAction) {
+  override fun update(e: AnActionEvent) {
+    super.update(e)
+
+    val project = e.project ?: return
+    e.presentation.isEnabled = !FixupService.getInstance(project).isEditInProgress()
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/TestCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/TestCodeAction.kt
@@ -1,9 +1,10 @@
 package com.sourcegraph.cody.edit.actions
 
-import com.intellij.openapi.project.DumbAware
-import com.sourcegraph.cody.autocomplete.action.CodyAction
-
 class TestCodeAction :
-    EditCommandAction({ editor, fixupService -> fixupService.startTestCode(editor) }),
-    CodyAction,
-    DumbAware
+    NonInteractiveEditCommandAction({ editor, fixupService ->
+      fixupService.startTestCode(editor)
+    }) {
+  companion object {
+    const val ID: String = "cody.testCodeAction"
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
@@ -18,6 +18,7 @@ class LensGroupFactory(val session: FixupSession) {
       addSeparator(this)
       addAction(this, "Cancel", FixupSession.ACTION_CANCEL)
       registerWidgets()
+      isInWorkingGroup = true
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -93,6 +93,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private var prevCursor: Cursor? = null
 
+  var isInWorkingGroup = false
   var isAcceptGroup = false
   var isErrorGroup = false
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1415

## Changes

1. Remove active waiting from the code (`waitUntilActiveSessionIsFinished`)
2. Introduce `cancellationToken` which allows us to signal (and wait for) session ending
3. Block "Document Code" and "Generate Unit Test" buttons when other edit is in progress.
    "In-progress" means until Accept lens appears.
    If new edit is started before accepting previous on, previous one automatically gets accepted.

![image](https://github.com/sourcegraph/jetbrains/assets/1519649/67998137-992f-439d-bd62-849f541dc1ef)


## Test plan

Manual testing with Jetbrains plugin.
