### PR TITLE
Adding proxy reading from the jetbrains settings for agent setup

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.util.net.HttpConfigurable
 import com.intellij.util.system.CpuArch
 import com.sourcegraph.cody.agent.protocol.*
 import com.sourcegraph.cody.vscode.CancellationToken
@@ -166,7 +167,18 @@ private constructor(
         processBuilder.environment()["CODY_LOG_EVENT_MODE"] = "connected-instance-only"
       }
 
+      val proxy = HttpConfigurable.getInstance()
+      val proxyUrl =  proxy.PROXY_HOST + ":" + proxy.PROXY_PORT
+      if(proxy.PROXY_TYPE_IS_SOCKS) {
+        processBuilder.environment()["HTTP_PROXY"] = "socks://$proxyUrl"
+      } else {
+        processBuilder.environment()["HTTP_PROXY"] = "http://$proxyUrl"
+        processBuilder.environment()["HTTPS_PROXY"] = "https://$proxyUrl"
+      }
+
       logger.info("starting Cody agent ${command.joinToString(" ")}")
+      logger.info("Cody agent proxyUrl ${proxyUrl} PROXY_TYPE_IS_SOCKS ${proxy.PROXY_TYPE_IS_SOCKS}")
+
       val process =
           processBuilder
               .redirectErrorStream(false)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -168,8 +168,8 @@ private constructor(
       }
 
       val proxy = HttpConfigurable.getInstance()
-      val proxyUrl =  proxy.PROXY_HOST + ":" + proxy.PROXY_PORT
-      if(proxy.PROXY_TYPE_IS_SOCKS) {
+      val proxyUrl = proxy.PROXY_HOST + ":" + proxy.PROXY_PORT
+      if (proxy.PROXY_TYPE_IS_SOCKS) {
         processBuilder.environment()["HTTP_PROXY"] = "socks://$proxyUrl"
       } else {
         processBuilder.environment()["HTTP_PROXY"] = "http://$proxyUrl"
@@ -177,7 +177,8 @@ private constructor(
       }
 
       logger.info("starting Cody agent ${command.joinToString(" ")}")
-      logger.info("Cody agent proxyUrl ${proxyUrl} PROXY_TYPE_IS_SOCKS ${proxy.PROXY_TYPE_IS_SOCKS}")
+      logger.info(
+          "Cody agent proxyUrl ${proxyUrl} PROXY_TYPE_IS_SOCKS ${proxy.PROXY_TYPE_IS_SOCKS}")
 
       val process =
           processBuilder


### PR DESCRIPTION
This PR introduces proxy support for the agent process, allowing it to operate effectively in environments where internet access is restricted through a proxy. The changes are minimal and targeted, ensuring a clean integration without disrupting existing functionalities.

The changes have been unit tested, and integration testing can be conducted once I test all the cases for https in the subsequent PRs. This PR is designed for quick review and approval to facilitate immediate testing during the weekend with windows with the nightly build for jetbrains.



## Test plan

Tested this multiple times in testing with @pkukielka 


Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
