### PR TITLE
Don't fail when trying to clear autocomplete previews for editors which don't support inlay models.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtil.kt
@@ -22,12 +22,14 @@ object InlayModelUtil {
 
   @JvmStatic
   fun getAllInlaysForEditor(editor: Editor): List<Inlay<*>> {
-    val inlayModel = try {
-      editor.inlayModel
-    } catch (e: UnsupportedOperationException) {
-      // Not all editors, for example ImaginaryEditor used in Intention Previews, support inlays.
-      return emptyList()
-    }
+    val inlayModel =
+        try {
+          editor.inlayModel
+        } catch (e: UnsupportedOperationException) {
+          // Not all editors, for example ImaginaryEditor used in Intention Previews, support
+          // inlays.
+          return emptyList()
+        }
     return getAllInlays(inlayModel, 0, editor.document.textLength)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtil.kt
@@ -22,6 +22,12 @@ object InlayModelUtil {
 
   @JvmStatic
   fun getAllInlaysForEditor(editor: Editor): List<Inlay<*>> {
-    return getAllInlays(editor.inlayModel, 0, editor.document.textLength)
+    val inlayModel = try {
+      editor.inlayModel
+    } catch (e: UnsupportedOperationException) {
+      // Not all editors, for example ImaginaryEditor used in Intention Previews, support inlays.
+      return emptyList()
+    }
+    return getAllInlays(inlayModel, 0, editor.document.textLength)
   }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/autocomplete/render/InlayModelUtilTest.kt
@@ -1,0 +1,13 @@
+package com.sourcegraph.cody.autocomplete.render
+
+import com.intellij.openapi.editor.impl.ImaginaryEditor
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class InlayModelUtilTest : BasePlatformTestCase() {
+  fun `test getAllInlaysForEditor`() {
+    myFixture.configureByText("test.txt", "test")
+    val imaginaryEditor = ImaginaryEditor(myFixture.project, myFixture.editor.document)
+    val inlays = InlayModelUtil.getAllInlaysForEditor(imaginaryEditor)
+    assertEquals(0, inlays.size)
+  }
+}


### PR DESCRIPTION
ImaginaryEditor does not support InlayModel and throws an UnsupportedOperationException; IntentionPreviewEditor throws an IntentionPreviewUnsupportedOperationException: UnsupportedOperationException, etc.

Fixes #1488, #1486, #1485, #1480, #1466, #1462, #1435, #1363

## Test plan

```
./gradlew test --tests InlayModelUtilTest
```

Ran the IDE and clicked between editors, requesting autocompletes.