### PR TITLE
Only search for the first 10 repositories when editing the repository list

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -313,7 +313,12 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
   // Given a textual list of repos, extract a best effort list of repositories from it and update
   // context settings.
   private fun applyRepoSpec(spec: String) {
-    val repos = spec.split(Regex("""\s+""")).filter { it -> it != "" }.toSet()
+    val repos =
+        spec
+            .split(Regex("""\s+"""))
+            .filter { it -> it != "" }
+            .toSet()
+            .take(MAX_REMOTE_REPOSITORY_COUNT)
     RemoteRepoUtils.resolveReposWithErrorNotification(
         project, repos.map { it -> CodebaseName(it) }.toList()) { trimmedRepos ->
           runInEdt {


### PR DESCRIPTION
Fixes #1484

## Test plan

Tested manually:

- Sign into an Enterprise account
- Open the enhanced context picker and list more than ten repos, ensure some of the yellow highlight repos are alphabetically earlier than some of the first ten
- Cmd-Enter to save the list of repositories
- Verify that the highlighted list is what you would expect

https://github.com/sourcegraph/jetbrains/assets/55120/11c732bd-5161-4e01-8c8f-919e83192b04

