### PR TITLE
Show line, column offsets in human 1-based instead of LogicalPosition 0-based

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -434,7 +434,7 @@ class EditCommandPrompt(
       val (line, col) = editor.offsetToLogicalPosition(offset).let { Pair(it.line, it.column) }
       val virtualFile = FileDocumentManager.getInstance().getFile(editor.document)
       val file = getFormattedFilePath(virtualFile)
-      filePathLabel.text = "$file at $line:$col"
+      filePathLabel.text = "$file at ${line + 1}:${col + 1}"
       filePathLabel.toolTipText = virtualFile?.path
       add(filePathLabel, BorderLayout.CENTER)
       titleBar = this


### PR DESCRIPTION
Fixes #1456 

## Test plan

Tested manually:

- Enable edits with `CODY_JETBRAINS_FEATURES=cody.feature.inline-edits=true`
- Place the cursor in a file, note line:col position in status bar
- Right click, Cody, Edit Code
- Check that the location in the dialog reflects the cursor position in the status bar

![Screenshot 2024-05-13 at 12 30 37](https://github.com/sourcegraph/jetbrains/assets/55120/bdc42cea-15a5-45f9-80e1-dd81009807a1)
