### PR TITLE
Show the option to re-enable Cody autocomplete once disabled.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -29,6 +29,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
       addAll(listOfNotNull(deriveWarningAction()))
       addSeparator()
       addAll(
+          CodyEnableAutocompleteAction(),
           CodyDisableAutocompleteAction(),
           CodyEnableLanguageForAutocompleteAction(),
           CodyDisableLanguageForAutocompleteAction(),


### PR DESCRIPTION
Fixes #533

## Test plan

![Screenshot 2024-05-13 at 13 47 34](https://github.com/sourcegraph/jetbrains/assets/55120/68b44821-4196-41f9-8944-653e209ab3a9)

Manually tested:

1. Get Cody generating autocompletes. Alt-\ to generate a candidate.
2. Status bar, Cody, Disable Cody Autocomplete. Verify the candidate disappears.
3. Verify that autocomplete is disabled.
4. Open status bar and verify Enable Cody Autocomplete appears. Enable it.
5. Verify that autocomplete works again.
