### PR TITLE
Do not pass tokens, extra headers to non-endpoint URLs.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphApiRequests.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphApiRequests.kt
@@ -2,7 +2,6 @@ package com.sourcegraph.cody.api
 
 import com.intellij.openapi.progress.ProgressIndicator
 import com.sourcegraph.cody.config.CodyAccountDetails
-import com.sourcegraph.cody.config.SourcegraphServerPath
 import java.awt.Image
 
 object SourcegraphApiRequests {
@@ -10,12 +9,12 @@ object SourcegraphApiRequests {
       private val executor: SourcegraphApiRequestExecutor,
       private val progressIndicator: ProgressIndicator
   ) {
-    fun getDetails(server: SourcegraphServerPath): CodyAccountDetails {
+    fun getDetails(): CodyAccountDetails {
       return executor
           .execute(
               progressIndicator,
               SourcegraphApiRequest.Post.GQLQuery(
-                  server.toGraphQLUrl(),
+                  executor.server.toGraphQLUrl(),
                   SourcegraphGQLQueries.getUserDetails,
                   null,
                   CurrentUserWrapper::class.java))

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccount.kt
@@ -13,7 +13,7 @@ data class CodyAccount(
     @NlsSafe @Attribute("name") override var name: String = "",
     @Attribute("displayName") var displayName: String? = name,
     @Property(style = Property.Style.ATTRIBUTE, surroundWithTag = false)
-    override val server: SourcegraphServerPath =
+    override var server: SourcegraphServerPath =
         SourcegraphServerPath.from(ConfigUtil.DOTCOM_URL, ""),
     @Attribute("id") override var id: String = generateId(),
 ) : ServerAccount() {

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountDetailsProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountDetailsProvider.kt
@@ -28,10 +28,10 @@ class CodyAccountDetailsProvider(
               accountsModel.newCredentials.getOrElse(account) {
                 accountManager.findCredentials(account)
               } ?: return@submitIOTask noToken()
-          val executor = service<SourcegraphApiRequestExecutor.Factory>().create(token)
+          val executor =
+              service<SourcegraphApiRequestExecutor.Factory>().create(account.server, token)
 
-          val accountDetails =
-              SourcegraphApiRequests.CurrentUser(executor, indicator).getDetails(account.server)
+          val accountDetails = SourcegraphApiRequests.CurrentUser(executor, indicator).getDetails()
           val image =
               accountDetails.avatarURL?.let { url ->
                 CachingCodyUserAvatarLoader.getInstance().requestAvatar(executor, url).join()

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -28,7 +28,6 @@ class CodyAccountListModel(private val project: Project) :
   }
 
   override fun editAccount(parentComponent: JComponent, account: CodyAccount) {
-
     val token = newCredentials[account] ?: getOldToken(account)
     val authData =
         CodyAuthenticationManager.getInstance(project)
@@ -46,8 +45,8 @@ class CodyAccountListModel(private val project: Project) :
     if (authData == null) return
 
     account.name = authData.login
-    account.server.url = authData.server.url
-    account.server.customRequestHeaders = authData.server.customRequestHeaders
+    account.server =
+        SourcegraphServerPath(authData.server.url, authData.server.customRequestHeaders)
     newCredentials[account] = authData.token
     notifyCredentialsChanged(account)
   }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthCredentialsUi.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthCredentialsUi.kt
@@ -22,19 +22,19 @@ class CodyAuthCredentialsUi(
 
   override fun getValidator(): Validator = { null }
 
-  override fun createExecutor(): SourcegraphApiRequestExecutor = factory.create("")
+  override fun createExecutor(server: SourcegraphServerPath): SourcegraphApiRequestExecutor =
+      factory.create(server, "")
 
   override fun acquireDetailsAndToken(
-      server: SourcegraphServerPath,
       executor: SourcegraphApiRequestExecutor,
       indicator: ProgressIndicator,
       authMethod: SsoAuthMethod
   ): Pair<CodyAccountDetails, String> {
     val token = acquireToken(indicator, authMethod)
-    executor.token = token
-
-    val details =
-        CodyTokenCredentialsUi.acquireDetails(server, executor, indicator, isAccountUnique, null)
+    // The token has changed, so create a new executor to talk to the same server with the new
+    // token.
+    val executor = factory.create(executor.server, token)
+    val details = CodyTokenCredentialsUi.acquireDetails(executor, indicator, isAccountUnique, null)
     return details to token
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyCredentialsUi.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyCredentialsUi.kt
@@ -16,10 +16,9 @@ abstract class CodyCredentialsUi {
 
   abstract fun getValidator(): Validator
 
-  abstract fun createExecutor(): SourcegraphApiRequestExecutor
+  abstract fun createExecutor(server: SourcegraphServerPath): SourcegraphApiRequestExecutor
 
   abstract fun acquireDetailsAndToken(
-      server: SourcegraphServerPath,
       executor: SourcegraphApiRequestExecutor,
       indicator: ProgressIndicator,
       authMethod: SsoAuthMethod

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyLoginPanel.kt
@@ -103,11 +103,11 @@ class CodyLoginPanel(
     tokenAcquisitionError = null
 
     val server = getServer()
-    val executor = currentUi.createExecutor()
+    val executor = currentUi.createExecutor(server)
 
     return service<ProgressManager>()
         .submitIOTask(progressIndicator) {
-          currentUi.acquireDetailsAndToken(server, executor, it, authMethod)
+          currentUi.acquireDetailsAndToken(executor, it, authMethod)
         }
         .completionOnEdt(progressIndicator.modalityState) { setBusy(false) }
         .errorOnEdt(progressIndicator.modalityState) { setError(it) }

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsMigration.kt
@@ -249,8 +249,8 @@ class SettingsMigration : Activity {
           .submitIOTask(progressIndicator) {
             runCatching {
               SourcegraphApiRequests.CurrentUser(
-                      requestExecutorFactory.create(accessToken), progressIndicator)
-                  .getDetails(server)
+                      requestExecutorFactory.create(server, accessToken), progressIndicator)
+                  .getDetails()
             }
           }
           .successOnEdt(progressIndicator.modalityState) { accountDetailsResult ->

--- a/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphServerPath.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphServerPath.kt
@@ -9,8 +9,8 @@ import java.util.regex.Pattern
 
 @Tag("server")
 data class SourcegraphServerPath(
-    @Attribute("url") var url: String = "",
-    @Attribute("customRequestHeaders") var customRequestHeaders: String = ""
+    @Attribute("url") val url: String = "",
+    @Attribute("customRequestHeaders") val customRequestHeaders: String = ""
 ) : ServerPath {
 
   private val GRAPHQL_API_SUFFIX = ".api/graphql"


### PR DESCRIPTION
Fixes sourcegraph/security-issues#388

Note, this treats the host as the principal's identity, not scheme+host+port.

Note, in the case of redirects (eg HTTP/302), we will *not* pass credentials to the redirected URL, *even if it is the same principal.*

## Test plan

1. Log into sg02.sourcegraph.com
2. Settings, change the profile URL to http://localhost:1234/foo/bar
3. Run `mitmproxy -p 8123 --mode reverse:https://sourcegraph.com:443`
4. Run JetBrains, log in to sg02
5. Open the Cody settings panel which also lists accounts
6. Consult mitmproxy logs. Requests should *not* include `Authorization: token sgp_...` etc.
7. Finally, test that Cody settings, plus, log in to Sourcegraph.com is not broken and the avatar is displayed; log in to s2 and verify avatars are displayed; clear the profile URL setting from s02 and verify the default avatars is displayed; etc.