### PR TITLE
Adding a button to restart the agent on changing the proxy settings

### DIFF
--- a/src/main/java/com/sourcegraph/cody/PromptPanel.kt
+++ b/src/main/java/com/sourcegraph/cody/PromptPanel.kt
@@ -33,6 +33,8 @@ import javax.swing.border.EmptyBorder
 import javax.swing.event.AncestorEvent
 import javax.swing.event.AncestorListener
 import javax.swing.text.DefaultEditorKit
+import javax.swing.JButton
+
 
 class PromptPanel(project: Project, private val chatSession: ChatSession) : JLayeredPane() {
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -176,8 +176,8 @@ private constructor(
         processBuilder.environment()["HTTPS_PROXY"] = "https://$proxyUrl"
       }
 
-      logger.info("starting Cody agent ${command.joinToString(" ")}")
-      logger.info(
+      logger.warn("starting Cody agent ${command.joinToString(" ")}")
+      logger.warn(
           "Cody agent proxyUrl ${proxyUrl} PROXY_TYPE_IS_SOCKS ${proxy.PROXY_TYPE_IS_SOCKS}")
 
       val process =

--- a/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/ui/CodyConfigurable.kt
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.config.ui
 
+import javax.swing.JButton
+import com.sourcegraph.cody.agent.CodyAgentService
 import com.intellij.openapi.components.service
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.project.Project
@@ -52,6 +54,13 @@ class CodyConfigurable(val project: Project) : BoundConfigurable(ConfigUtil.CODY
           checkBox("Accept non-trusted certificates")
               .enabledIf(enableCodyCheckbox.selected)
               .bindSelected(settingsModel::shouldAcceptNonTrustedCertificatesAutomatically)
+        }
+        row {
+          val reloadButton = JButton("Reload Agent")
+          reloadButton.addActionListener {
+             CodyAgentService.getInstance(project).restartAgent(project)
+          }
+          cell(reloadButton)
         }
       }
 


### PR DESCRIPTION
Adding a button to reload the agent on proxy changes to jetbrains 
## Test plan
Tested in the UI
