### PR TITLE
Edit: Return Boolean response for workspace/edit

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -46,7 +46,7 @@ public class CodyAgentClient {
   @Nullable Function<UntitledTextDocument, Boolean> onOpenUntitledDocument;
 
   // Callback for the "workspace/edit" request from the agent.
-  @Nullable Consumer<WorkspaceEditParams> onWorkspaceEdit;
+  @Nullable Function<WorkspaceEditParams, Boolean> onWorkspaceEdit;
 
   @JsonNotification("editTask/didUpdate")
   public CompletableFuture<Void> editTaskDidUpdate(EditTask params) {
@@ -106,7 +106,7 @@ public class CodyAgentClient {
   }
 
   @JsonRequest("workspace/edit")
-  public CompletableFuture<Void> workspaceEdit(WorkspaceEditParams params) {
+  public CompletableFuture<Boolean> workspaceEdit(WorkspaceEditParams params) {
     return acceptOnEventThread("workspace/edit", onWorkspaceEdit, params);
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -79,8 +79,14 @@ class CodyAgentService(private val project: Project) : Disposable {
         }
       }
 
-      agent.client.onWorkspaceEdit = Consumer { params ->
-        FixupService.getInstance(project).getActiveSession()?.performWorkspaceEdit(params)
+      agent.client.onWorkspaceEdit = Function { params ->
+        try {
+          FixupService.getInstance(project).getActiveSession()?.performWorkspaceEdit(params)
+          true
+        } catch (e: RuntimeException) {
+          logger.error(e)
+          false
+        }
       }
 
       agent.client.onTextDocumentEdit = Function { params ->


### PR DESCRIPTION
## Description

Follow up on https://github.com/sourcegraph/jetbrains/pull/1501

## Test plan

Test manually and check the trace log. The response for workspace/edit should be either `true` or `false`.

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
