### PR TITLE
Updating proxy settings to support http tunneling for https connections

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -174,7 +174,7 @@ private constructor(
       }
       if (proxy.USE_HTTP_PROXY) {
         processBuilder.environment()["HTTP_PROXY"] = "http://$proxyUrl"
-        processBuilder.environment()["HTTPS_PROXY"] = "https://$proxyUrl"
+        processBuilder.environment()["HTTPS_PROXY"] = "http://$proxyUrl"
       }
 
       logger.info("starting Cody agent ${command.joinToString(" ")}")


### PR DESCRIPTION
Without setting both http and https proxy to have the prefix of http we cannot make requests to instances which are https that are routed through the http proxy to do http tunneling
If we don't make this change we get 
```
2024-05-15 12:45:45,615 [ 151442]   WARN - #c.s.c.a.CodyAgentClient - Cody by Sourcegraph: █ GraphQLTelemetryExporter: telemetry: failed to evaluate server version: Error: accessing Sourcegraph GraphQL API: FetchError: request to https://demo.sourcegraph.com/.api/graphql?SiteProductVersion failed, reason: write EPROTO C03ACAF601000000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number:../deps/openssl/openssl/ssl/record/ssl3_record.c:355:
 (https://demo.sourcegraph.com/.api/graphql?SiteProductVersion)
```
And in chat we see

```
Cody encountered an error when processing your message: 
⚠ org.eclipse.lsp4j.jsonrpc.ResponseErrorException: Request chat/new failed with message: No chat model found in server-provided config
If the problem persists, please create a support ticket.
```

Or we see `
⚠ write EPROTO 280A0000:error:0A00010B:SSL routines:ssl3_get_record:wrong version number:c:\ws\deps\openssl\openssl\ssl\record\ssl3_record.c:355:`

## Test plan
Tested in development
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
