### PR TITLE
Do not undo previous changes until retry is confirmed

### DIFF
--- a/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
+++ b/src/main/java/com/sourcegraph/cody/vscode/CancellationToken.java
@@ -18,8 +18,8 @@ public class CancellationToken {
         });
   }
 
-  public void onFinished(Consumer<Boolean> callback) {
-    this.cancelled.thenAccept(
+  public CompletableFuture<Void> onFinished(Consumer<Boolean> callback) {
+    return this.cancelled.thenAccept(
         (isCancelled) -> {
           try {
             callback.accept(isCancelled);

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -556,8 +556,15 @@ class EditCommandPrompt(
         logger.warn("Project was null when trying to add an edit session")
         return
       }
-      // Kick off the editing command.
-      EditCodeSession(controller, editor, text, llmDropdown.item)
+
+      fun editCode() = runInEdt { EditCodeSession(controller, editor, text, llmDropdown.item) }
+      val activeSession = controller.getActiveSession()
+      if (activeSession != null) {
+        activeSession.afterSessionFinished { editCode() }
+        activeSession.undo()
+      } else {
+        editCode()
+      }
     }
     clearActivePrompt()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditRetryAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditRetryAction.kt
@@ -6,6 +6,6 @@ import com.sourcegraph.cody.edit.FixupService
 
 class EditRetryAction : InlineEditAction() {
   override fun performAction(e: AnActionEvent, project: Project) {
-    FixupService.getInstance(project).getActiveSession()?.retry()
+    FixupService.getInstance(project).getActiveSession()?.showRetryPrompt()
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1426

##Changes

Do not undo previous changes until new edit instructions are provided by user and edit is confirmed.

## Test plan

#### Scenario 1:

1. Run Edit Code command
2. Click `Edit & Retry`
3. Cancel the edition
4. Make sure changes were not rolled back

#### Scenario 2:

1. Run Edit Code command
2. Click `Edit & Retry`
3. Type new edit instruction and confirm
4. Make sure old changes were rolled-back and new ones were applied