### PR TITLE
Fix Cancel action in case of early error preventing task creation

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -238,8 +238,12 @@ abstract class FixupSession(
   }
 
   fun cancel() {
-    CodyAgentService.withAgent(project) { agent ->
-      agent.server.cancelEditTask(TaskIdParam(taskId!!))
+    if (taskId == null) {
+      dismiss()
+    } else {
+      CodyAgentService.withAgent(project) { agent ->
+        agent.server.cancelEditTask(TaskIdParam(taskId!!))
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1522

## Changes

It is now possible to cancel action which is broken before task was created on the agent side.

## Test plan

1. Generate "unexpected" error - currently it is possible e.g. when trying to generate unit test for a text file from outside the workspace
2. Try to Cancel action which failed and is hanging