### PR TITLE
Scroll to the bottom on submit in the chat (fixes #340)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/ChatPanel.kt
@@ -80,11 +80,15 @@ class ChatPanel(
 
   @RequiresEdt
   fun addOrUpdateMessage(message: ChatMessage, index: Int) {
-    if (messagesPanel.componentCount == 1) {
+    val numberOfMessagesBeforeAddOrUpdate = messagesPanel.componentCount
+    if (numberOfMessagesBeforeAddOrUpdate == 1) {
       llmDropdown.updateAfterFirstMessage()
       promptPanel.updateEmptyTextAfterFirstMessage()
     }
     messagesPanel.addOrUpdateMessage(message, index)
+    if (numberOfMessagesBeforeAddOrUpdate < messagesPanel.componentCount) {
+      chatPanel.touchingBottom = true
+    }
   }
 
   @RequiresEdt

--- a/src/main/kotlin/com/sourcegraph/cody/ui/ChatScrollPane.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/ChatScrollPane.kt
@@ -11,7 +11,7 @@ import kotlin.math.max
 class ChatScrollPane(private val messagesPanel: JPanel) :
     JBScrollPane(messagesPanel, VERTICAL_SCROLLBAR_AS_NEEDED, HORIZONTAL_SCROLLBAR_NEVER) {
 
-  private var touchingBottom = false
+  internal var touchingBottom = false
 
   init {
     border = BorderFactory.createEmptyBorder()


### PR DESCRIPTION
Fixes #340

## Test plan
1. having a few messages in the chat (so that it takes the whole height)
2. scroll up (so that the view does not touch the bottom) 
3. send a chat message

Expected:
view goes down and autoscrolls 
