### PR TITLE
Greatly reduced flicker when resizing edit dialog

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/FrameMover.kt
@@ -176,8 +176,11 @@ class FrameMover(private val frame: JFrame, private val titleBar: JComponent) : 
       }
       else -> {}
     }
-
-    runInEdt { frame.setSize(newWidth, newHeight) }
+    SwingUtilities.invokeLater {
+      frame.setSize(newWidth, newHeight)
+      frame.revalidate()
+      frame.repaint()
+    }
     lastMouseX = newX
     lastMouseY = newY
     lastUpdateTime = currentTime


### PR DESCRIPTION
Forced an async repaint when the dialog resizes, and it reduced the flicker to what I think are probably tolerable levels for GA.

## Test plan

Tested manually by shaking my mouse vigorously.