### PR TITLE
Add support for providing visible document ranges

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=cf2f91bc2a6035169b8d9f21e13f63b024ab927b
+cody.commit=8915ec1f96a02b51cb865563579139bf717c4dd2


### PR DESCRIPTION
## Changes

Add support for visible ranges.
See also: https://github.com/sourcegraph/cody/pull/4226

## Test plan

I'm not able to find scenario in which visible range wins over smart selection (see [selection.ts:43](https://github.com/sourcegraph/cody/blob/main/vscode/src/commands/context/selection.ts#L43)) but I verified in the debugger that it works as expected, and it might fix some corner case issues we observed with not perfect document context.
