### PR TITLE
reverted Edit dialog to default colors

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -631,11 +631,11 @@ class EditCommandPrompt(
     // Caching these caused problems with theme switches, even when we
     // updated the cached values on theme-switch notifications.
 
-    fun mutedLabelColor(): Color = EditUtil.getMutedThemeColor("Label.disabledForeground")!!
+    fun mutedLabelColor(): Color = EditUtil.getThemeColor("Label.disabledForeground")!!
 
-    fun boldLabelColor(): Color = EditUtil.getEnhancedThemeColor("Label.foreground")!!
+    fun boldLabelColor(): Color = EditUtil.getThemeColor("Label.foreground")!!
 
-    fun textFieldBackground(): Color = EditUtil.getEnhancedThemeColor("TextField.background")!!
+    fun textFieldBackground(): Color = EditUtil.getThemeColor("TextField.background")!!
 
     /** Returns a compact symbol representation of the action's keyboard shortcut, if any. */
     @JvmStatic


### PR DESCRIPTION
it had been trying to match Daniel's theme mocks exactly, but Daniel and I decided to go with the defaults

## Test plan

This is just a color change, so it was a visual inspection of the Edit dialog. I have screenshots of before/after and our designer has given this change the thumbs-up.

Before:
![image](https://github.com/sourcegraph/jetbrains/assets/613744/de1e7792-eca8-420f-8a57-d9fe7b947476)

After:
![image](https://github.com/sourcegraph/jetbrains/assets/613744/20deceae-1b5a-41c0-97d0-13032c779bc1)