### PR TITLE
Code Lens Care Package -- the final visual polish for GA

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -342,6 +342,7 @@ All tests involving prompt history should end with:
    - While Cody is "thinking", you should see the Working lens group.
      - Check that the spinner is spinning, and is sized and positioned correctly when the font is large.
      - Check that no other widgets are drawing out of bounds or oddly in some other way.
+5. Ensure that the Cody Logo, present in all lens groups, is scaling with the font size.
 
 ## Chat
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -242,6 +242,9 @@ All tests involving prompt history should end with:
 4. Click the expansion icon at the right of the text field.
     - The text field expands to allow more of your instructions to be visible.
     - You can collapse it to return to the regular view.
+5. Change the IDE font size to 22 and try the dialog. It should lay out correctly.
+    - then try at font size 6 to ensure it works there too.
+    
 
 #### File Path
 
@@ -319,6 +322,26 @@ All tests involving prompt history should end with:
     - Clicking or using the shortcut to Undo removes the inline edit as well as the code lens
     - Clicking or using the shortcut to Edit & Retry opens the Edit Code dialog, undoes the initial edit, and applies new edits according to your new instructions.
     - Clicking or using the shortcut to Show Diff opens a new tab with a diff view of the edits. 
+
+#### Lens layout and and appearance
+
+1. Initiate an inline edit and wait for the Accept lens group to appear.
+2. Switch IDE themes while the lenses are visible.
+   - Verify that the lenses switch to match the new theme.
+     - Note that the "buttons" remain dark on light themes.
+3. Keeping the code lenses visible, test it with different font sizes.
+   - In Settings/Preferences, change the Editor font size to 6
+     - Scroll until the code lenses are visible again, if necessary.
+     - Verify that they are drawing correctly for the new size.
+     - The widgets should not be taller than the inlay, padding should look right, etc.
+     - Try it all over again at font size 26 or higher. Everything in the lenses should still look good.
+4. While you have it set to a large font size, test the Working lens group.
+   - Undo the current inline edit
+   - Initiate a new inline edit, ideally one that will take a while
+     - For instance, you could make a large selection of 50+ lines and ask the LLM to add thorough inline comments.
+   - While Cody is "thinking", you should see the Working lens group.
+     - Check that the spinner is spinning, and is sized and positioned correctly when the font is large.
+     - Check that no other widgets are drawing out of bounds or oddly in some other way.
 
 ## Chat
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -45,18 +45,14 @@ class LensAction(
     val originalFont = g.font
     val originalColor = g.color
     try {
-      // Set the background color using the enhanced theme color
       g.background = EditUtil.getEnhancedThemeColor("Panel.background")
 
-      // Get font metrics for calculating dimensions
       val metrics = g.fontMetrics
       val width = calcWidthInPixels(metrics)
       val textHeight = metrics.height
 
-      // Draw the highlight
       highlight.drawHighlight(g, x, y, width, textHeight)
 
-      // Change font and color based on mouse position
       if (mouseInBounds) {
         g.font = g.font.deriveFont(underline)
         g.color = UIManager.getColor("Link.hoverForeground")
@@ -65,14 +61,11 @@ class LensAction(
         g.color = Color.WHITE
       }
 
-      // Draw the text string
       g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent)
 
-      // Update the bounds of the last painted area
       lastPaintedBounds =
           Rectangle2D.Float(x, y - metrics.ascent, width.toFloat(), textHeight.toFloat())
     } finally {
-      // Other lenses are using the same Graphics2D.
       g.font = originalFont
       g.color = originalColor
     }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -26,7 +26,6 @@ class LensAction(
     private val actionId: String
 ) : LensWidget(group) {
 
-
   private val highlight =
       LabelHighlight(
           when (actionId) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.ui.JBColor
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.EditUtil
 import com.sourcegraph.cody.edit.sessions.FixupSession
@@ -25,12 +26,6 @@ class LensAction(
     private val actionId: String
 ) : LensWidget(group) {
 
-  private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
-
-  // TODO: Put in resources
-  private val actionColor = Color(44, 45, 50)
-  private val acceptColor = Color(37, 92, 53)
-  private val undoColor = Color(114, 38, 38)
 
   private val highlight =
       LabelHighlight(
@@ -46,25 +41,35 @@ class LensAction(
 
   override fun calcHeightInPixels(fontMetrics: FontMetrics): Int = fontMetrics.height
 
+  @Suppress("UseJBColor")
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     val originalFont = g.font
     val originalColor = g.color
     try {
+      // Set the background color using the enhanced theme color
       g.background = EditUtil.getEnhancedThemeColor("Panel.background")
+
+      // Get font metrics for calculating dimensions
       val metrics = g.fontMetrics
       val width = calcWidthInPixels(metrics)
       val textHeight = metrics.height
+
+      // Draw the highlight
       highlight.drawHighlight(g, x, y, width, textHeight)
 
+      // Change font and color based on mouse position
       if (mouseInBounds) {
         g.font = g.font.deriveFont(underline)
         g.color = UIManager.getColor("Link.hoverForeground")
       } else {
         g.font = g.font.deriveFont(Font.PLAIN)
-        g.color = baseTextColor
+        g.color = Color.WHITE
       }
+
+      // Draw the text string
       g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent)
 
+      // Update the bounds of the last painted area
       lastPaintedBounds =
           Rectangle2D.Float(x, y - metrics.ascent, width.toFloat(), textHeight.toFloat())
     } finally {
@@ -117,5 +122,11 @@ class LensAction(
 
   companion object {
     const val SIDE_MARGIN = 5
+
+    private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
+
+    val actionColor = JBColor(Color.DARK_GRAY, Color(44, 45, 50))
+    private val acceptColor = Color(37, 92, 53)
+    private val undoColor = Color(114, 38, 38)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -1,14 +1,12 @@
 package com.sourcegraph.cody.edit.widget
 
-import com.sourcegraph.cody.edit.EditCommandPrompt
 import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 
-@Suppress("UseJBColor")
 class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(group, text) {
 
-  private val hotkeyHighlightColor = Color(49, 51, 56) // TODO: Put this in resources
+  private val hotkeyHighlightColor = LensAction.actionColor
 
   private val highlight = LabelHighlight(hotkeyHighlightColor)
 
@@ -16,13 +14,14 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
     return fontMetrics.stringWidth(text) + 8
   }
 
+  @Suppress("UseJBColor")
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     // TODO: This will all break with larger font sizes. Use percentages of font width/height.
     val width = g.fontMetrics.stringWidth(text) + 5
     val height = g.fontMetrics.height - 3
     highlight.drawHighlight(g, x + 2, y + 2, width, height)
 
-    g.color = EditCommandPrompt.boldLabelColor()
+    g.color = Color.white // JBColor.WHITE looks like crap in Darcula theme (very dark)
     g.drawString(text, x + 4, y + g.fontMetrics.ascent)
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
@@ -2,67 +2,39 @@ package com.sourcegraph.cody.edit.widget
 
 import java.awt.FontMetrics
 import java.awt.Graphics2D
-import java.awt.Image
-import java.awt.image.BufferedImage
 import javax.swing.Icon
-import javax.swing.ImageIcon
 
 class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
 
-  private var scaledImage: Image? = null
-
-  // Squish the icon down to make it better fit the text.
-  private val scaleFactor = 0.9
-
-  private fun getScaleFactor(fontMetrics: FontMetrics) = (fontMetrics.height * scaleFactor).toInt()
-
   override fun calcWidthInPixels(fontMetrics: FontMetrics): Int {
-    if (scaledImage == null) {
-      scaledImage = scaleImage(icon, getScaleFactor(fontMetrics))
-    }
-    return scaledImage?.getWidth(null) ?: icon.iconWidth
+    // Calculate the desired width based on the font height, adjusted by a factor
+    val desiredHeight = (fontMetrics.height + fontMetrics.ascent) / 2.0f
+    val scaleFactor = desiredHeight / icon.iconHeight.toFloat()
+    return (icon.iconWidth * scaleFactor).toInt()
   }
 
   override fun calcHeightInPixels(fontMetrics: FontMetrics): Int {
-    if (scaledImage == null) {
-      scaledImage = scaleImage(icon, getScaleFactor(fontMetrics))
-    }
-    return fontMetrics.height
+    // Calculate the desired height based on the font height, adjusted by a factor
+    return ((fontMetrics.height + fontMetrics.ascent) / 2.0f).toInt()
   }
 
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     val fontMetrics = g.fontMetrics
     val textCenterLine = y + (fontMetrics.ascent + fontMetrics.descent) / 2.0f
+    val desiredHeight = (fontMetrics.height + fontMetrics.ascent) / 2.0f
+    val scaleFactor = desiredHeight / icon.iconHeight.toFloat()
+    val iconY = textCenterLine - desiredHeight / 2.0f
 
-    if (scaledImage != null) {
-      val iconHeight = scaledImage!!.getHeight(null)
-      val iconY = textCenterLine - iconHeight / 2.0f
-      g.drawImage(scaledImage, x.toInt(), iconY.toInt(), null)
-    } else {
-      // If for some reason the image is null, still attempt to center the icon.
-      val iconY = textCenterLine - icon.iconHeight / 2.0f
-      icon.paintIcon(null, g, x.toInt(), iconY.toInt())
-    }
-  }
+    // Apply scaling transformation
+    val originalTransform = g.transform
+    g.translate(x.toInt(), iconY.toInt())
+    g.scale(scaleFactor.toDouble(), scaleFactor.toDouble())
 
-  private fun scaleImage(icon: Icon, targetHeight: Int): Image {
-    val originalImage =
-        if (icon is ImageIcon) {
-          icon.image
-        } else {
-          // We get a "Please use UIUtil.createImage() instead" warning here. But that
-          // method is also deprecated, which just makes a new warning.
-          @Suppress("WARNINGS")
-          val bufferedImage =
-              BufferedImage(icon.iconWidth, icon.iconHeight, BufferedImage.TYPE_INT_ARGB)
-          val g = bufferedImage.createGraphics()
-          icon.paintIcon(null, g, 0, 0)
-          g.dispose()
-          bufferedImage
-        }
-    val aspectRatio = icon.iconWidth.toDouble() / icon.iconHeight
-    val targetWidth = (targetHeight * aspectRatio).toInt()
-    return originalImage.getScaledInstance(targetWidth, targetHeight, Image.SCALE_SMOOTH)
+    // Paint the icon
+    icon.paintIcon(null, g, 0, 0)
+
+    // Restore original transformation
+    g.transform = originalTransform
   }
 
   override fun toString(): String {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
@@ -25,15 +25,16 @@ class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
     val scaleFactor = desiredHeight / icon.iconHeight.toFloat()
     val iconY = textCenterLine - desiredHeight / 2.0f
 
-    // Apply scaling transformation
     val originalTransform = g.transform
     g.translate(x.toInt(), iconY.toInt())
     g.scale(scaleFactor.toDouble(), scaleFactor.toDouble())
 
-    // Paint the icon
-    icon.paintIcon(null, g, 0, 0)
+    // Paint the icon a bit down, presumably to account for the font baseline.
+    // This 1-"pixel" adjustment works surprisingly well for font sizes ranging
+    // from 7 to 24+, and I'm not sure why, but I tested across a wide range of sizes.
+    // If you take it out, the logo will be slightly too high and will drive you crazy.
+    icon.paintIcon(null, g, 0, 1)
 
-    // Restore original transformation
     g.transform = originalTransform
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
@@ -7,14 +7,12 @@ import javax.swing.Icon
 class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
 
   override fun calcWidthInPixels(fontMetrics: FontMetrics): Int {
-    // Calculate the desired width based on the font height, adjusted by a factor
     val desiredHeight = (fontMetrics.height + fontMetrics.ascent) / 2.0f
     val scaleFactor = desiredHeight / icon.iconHeight.toFloat()
     return (icon.iconWidth * scaleFactor).toInt()
   }
 
   override fun calcHeightInPixels(fontMetrics: FontMetrics): Int {
-    // Calculate the desired height based on the font height, adjusted by a factor
     return ((fontMetrics.height + fontMetrics.ascent) / 2.0f).toInt()
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
@@ -2,7 +2,6 @@ package com.sourcegraph.cody.edit.widget
 
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.sourcegraph.cody.edit.EditCommandPrompt
-import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 
@@ -22,20 +21,15 @@ open class LensLabel(group: LensWidgetGroup, private val text: String) : LensWid
 
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     g.color =
-        when {
-          text.trim() == "!" -> Color.red // TODO: Remove when we get the SVG
-          text == LensGroupFactory.SEPARATOR -> EditCommandPrompt.boldLabelColor()
-          else -> baseTextColor
+        if (text == LensGroupFactory.SEPARATOR) {
+          EditCommandPrompt.boldLabelColor()
+        } else {
+          baseTextColor
         }
     g.drawString(text, x, y + g.fontMetrics.ascent)
   }
 
   override fun toString(): String {
     return "LensLabel(text=$text)"
-  }
-
-  companion object {
-    const val HOTKEY_HIGHLIGHT_MARGIN = 2
-    const val HOTKEY_TEXT_MARGIN = 5
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
@@ -80,7 +80,7 @@ abstract class LensWidget(val parentGroup: LensWidgetGroup) : Disposable {
                   ColorKey.createColorKey("TOOLTIP_BACKGROUND", tooltipBackground))
                   ?: globalScheme.defaultBackground
           isOpaque = true
-          font = parentGroup.widgetFont
+          font = parentGroup.widgetFont.get()
           border = BorderFactory.createEmptyBorder(2, 8, 0, 8)
         }
     val hint = LightweightHint(tooltipLabel)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.ui.HintHint
 import com.intellij.ui.LightweightHint
-import com.sourcegraph.config.ThemeUtil
 import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
@@ -24,8 +23,10 @@ abstract class LensWidget(val parentGroup: LensWidgetGroup) : Disposable {
 
   protected var mouseInBounds = false
 
+  // Note: JBColor.white is actually a dark gray in some themes,
+  // which doesn't work with our widget backgrounds, which are red/green/gray.
   @Suppress("UseJBColor")
-  protected val baseTextColor: Color = if (ThemeUtil.isDarkTheme()) Color.white else Color.BLACK
+  protected val baseTextColor: Color = Color.WHITE
 
   private var showingTooltip = false
   private var tooltip: LightweightHint? = null

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
@@ -25,8 +25,7 @@ abstract class LensWidget(val parentGroup: LensWidgetGroup) : Disposable {
 
   // Note: JBColor.white is actually a dark gray in some themes,
   // which doesn't work with our widget backgrounds, which are red/green/gray.
-  @Suppress("UseJBColor")
-  protected val baseTextColor: Color = Color.WHITE
+  @Suppress("UseJBColor") protected val baseTextColor: Color = Color.WHITE
 
   private var showingTooltip = false
   private var tooltip: LightweightHint? = null

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -24,7 +24,6 @@ import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
 import com.sourcegraph.config.ThemeUtil
-import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -36,6 +35,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
 import kotlin.math.roundToInt
+import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -101,7 +101,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     editor.addEditorMouseMotionListener(mouseMotionListener)
     addedListeners.set(true)
 
-    // Subscribe to the color scheme changes
+    // Listen for color theme changes.
     ApplicationManager.getApplication()
         .messageBus
         .connect(this)
@@ -114,9 +114,10 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
   }
 
   private fun updateFonts() {
-    ideFont.set(EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN))
-    widgetFont.set(Font(ideFont.get().name, ideFont.get().style, ideFont.get().size))
-    widgetFontMetrics = null // recalculate
+    val font = EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN)
+    ideFont.set(font)
+    widgetFont.set(Font(font.name, font.style, font.size))
+    widgetFontMetrics = null // force recalculation
   }
 
   fun withListenersMuted(block: () -> Unit) {


### PR DESCRIPTION
I worked with @danielmarquespt to come up with the following fixes for code lenses in this PR:

**Font change** -- we now use the IDE font instead of the Editor font. This looks nicer with the default fonts, and makes the hotkeys easier to read.

**Color tweaks** -- I reverted the colors to a simple set of white and sometimes the theme color. I also made the button background less harsh on light themes.

**Theme Change Response** -- The lenses listen now for IDE theme changes and change their colors accordingly.

**Font Scaling** -- I was doing a very poor job of the layout management of my mini-widget library when the font size got too far away from 13 (the default). I have fixed the inlay and widgets to draw and lay out properly at all font sizes.

**Logo Scaling** -- The Cody logo was using a method for scaling to match the font size that resulted in pixellation; I have fixed it and it scales smoothly now.

## Test plan

I updated TESTING.md for code lenses, with detailed instructions for testing font size switches, theme changes, and other visual elements.