### PR TITLE
Added fine-grained error handling and logging to CodyFileListener

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -592,8 +592,7 @@ class EditCommandPrompt(
     }
   }
 
-  // TODO: Was hoping this would help avoid flicker while resizing.
-  // Needs more work, but I think this is likely the right general approach.
+  // Help reduce resizing flicker.
   class DoubleBufferedRootPane : JRootPane() {
     private var offscreenImage: BufferedImage? = null
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -182,7 +182,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
   fun widgetXY(widget: LensWidget): Point {
     val ourXY = widgetGroupXY()
     val fontMetrics = widgetFontMetrics ?: editor.getFontMetrics(Font.PLAIN)
-    var sum = 0
+    var sum = LEFT_MARGIN.toInt()
     for (w in widgets) {
       if (w == widget) break
       sum += w.calcWidthInPixels(fontMetrics)

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -24,7 +24,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
         }
       }
     } catch (x: Exception) {
-      logger.error("Error in fileOpened method for file: ${file.path}", x)
+      logger.warn("Error in fileOpened method for file: ${file.path}", x)
     }
   }
 
@@ -37,7 +37,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
         }
       }
     } catch (x: Exception) {
-      logger.error("Error in fileClosed method for file: ${file.path}", x)
+      logger.warn("Error in fileClosed method for file: ${file.path}", x)
     }
   }
 
@@ -55,7 +55,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
               val textDocument = fromVirtualFile(editor, file)
               codyAgent.server.textDocumentDidOpen(textDocument)
             } catch (x: Exception) {
-              logger.error("Error in registerAllOpenedFiles method for file: ${file.path}", x)
+              logger.warn("Error in registerAllOpenedFiles method for file: ${file.path}", x)
             }
           }
         }
@@ -66,7 +66,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
             val textDocument = fromVirtualFile(editor, file!!)
             codyAgent.server.textDocumentDidFocus(textDocument)
           } catch (x: Exception) {
-            logger.error("Error calling textDocument/didFocus on ${file?.path}", x)
+            logger.warn("Error calling textDocument/didFocus on ${file?.path}", x)
           }
         }
       }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -12,39 +13,60 @@ import com.sourcegraph.cody.agent.CodyAgentService.Companion.withAgent
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.fromVirtualFile
 
 class CodyFileEditorListener : FileEditorManagerListener {
+  private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
+
   override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
-    source.selectedTextEditor?.let { editor ->
-      val protocolTextFile = fromVirtualFile(editor, file)
-      withAgent(source.project) { agent: CodyAgent ->
-        agent.server.textDocumentDidOpen(protocolTextFile)
+    try {
+      source.selectedTextEditor?.let { editor ->
+        val protocolTextFile = fromVirtualFile(editor, file)
+        withAgent(source.project) { agent: CodyAgent ->
+          agent.server.textDocumentDidOpen(protocolTextFile)
+        }
       }
+    } catch (x: Exception) {
+      logger.error("Error in fileOpened method for file: ${file.path}", x)
     }
   }
 
   override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
-    source.selectedTextEditor?.let { editor ->
-      val protocolTextFile = fromVirtualFile(editor, file)
-      withAgent(source.project) { agent: CodyAgent ->
-        agent.server.textDocumentDidClose(protocolTextFile)
+    try {
+      source.selectedTextEditor?.let { editor ->
+        val protocolTextFile = fromVirtualFile(editor, file)
+        withAgent(source.project) { agent: CodyAgent ->
+          agent.server.textDocumentDidClose(protocolTextFile)
+        }
       }
+    } catch (x: Exception) {
+      logger.error("Error in fileClosed method for file: ${file.path}", x)
     }
   }
 
   companion object {
+    private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
+
     fun registerAllOpenedFiles(project: Project, codyAgent: CodyAgent) {
+
       ApplicationManager.getApplication().invokeLater {
         val fileDocumentManager = FileDocumentManager.getInstance()
+
         EditorFactory.getInstance().allEditors.forEach { editor ->
-          val file = fileDocumentManager.getFile(editor.document)
-          if (file != null) {
-            val textDocument = fromVirtualFile(editor, file)
-            codyAgent.server.textDocumentDidOpen(textDocument)
+          fileDocumentManager.getFile(editor.document)?.let { file ->
+            try {
+              val textDocument = fromVirtualFile(editor, file)
+              codyAgent.server.textDocumentDidOpen(textDocument)
+            } catch (x: Exception) {
+              logger.error("Error in registerAllOpenedFiles method for file: ${file.path}", x)
+            }
           }
         }
+
         FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->
-          fileDocumentManager.getFile(editor.document)?.let { file ->
-            val textDocument = fromVirtualFile(editor, file)
+          val file = fileDocumentManager.getFile(editor.document)
+          try {
+            val textDocument = fromVirtualFile(editor, file!!)
             codyAgent.server.textDocumentDidFocus(textDocument)
+          } catch (x: Exception) {
+            logger.error("Error calling textDocument/didFocus on ${file?.path}", x)
           }
         }
       }


### PR DESCRIPTION
This logging will help us identify the root cause of [Issue 1571](https://github.com/sourcegraph/jetbrains/issues/1571). Also, we will no longer show a big crash dump to the user when any `CodyFileListener` method encounters an error.

## Test plan

We're going to ask the tester who reported it to try to reproduce it with this new logging in place. The error should go away, and if there is any bad behavior, we can check the logs to see more detailed stack traces.