### PR TITLE
Added finer-grained error handling and logging for issue 1571

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -12,39 +13,60 @@ import com.sourcegraph.cody.agent.CodyAgentService.Companion.withAgent
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.fromVirtualFile
 
 class CodyFileEditorListener : FileEditorManagerListener {
+  private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
+
   override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
-    source.selectedTextEditor?.let { editor ->
-      val protocolTextFile = fromVirtualFile(editor, file)
-      withAgent(source.project) { agent: CodyAgent ->
-        agent.server.textDocumentDidOpen(protocolTextFile)
+    try {
+      source.selectedTextEditor?.let { editor ->
+        val protocolTextFile = fromVirtualFile(editor, file)
+        withAgent(source.project) { agent: CodyAgent ->
+          agent.server.textDocumentDidOpen(protocolTextFile)
+        }
       }
+    } catch (x: Exception) {
+      logger.warn("Error in fileOpened method for file: ${file.path}", x)
     }
   }
 
   override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
-    source.selectedTextEditor?.let { editor ->
-      val protocolTextFile = fromVirtualFile(editor, file)
-      withAgent(source.project) { agent: CodyAgent ->
-        agent.server.textDocumentDidClose(protocolTextFile)
+    try {
+      source.selectedTextEditor?.let { editor ->
+        val protocolTextFile = fromVirtualFile(editor, file)
+        withAgent(source.project) { agent: CodyAgent ->
+          agent.server.textDocumentDidClose(protocolTextFile)
+        }
       }
+    } catch (x: Exception) {
+      logger.warn("Error in fileClosed method for file: ${file.path}", x)
     }
   }
 
   companion object {
+    private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
+
     fun registerAllOpenedFiles(project: Project, codyAgent: CodyAgent) {
+
       ApplicationManager.getApplication().invokeLater {
         val fileDocumentManager = FileDocumentManager.getInstance()
+
         EditorFactory.getInstance().allEditors.forEach { editor ->
-          val file = fileDocumentManager.getFile(editor.document)
-          if (file != null) {
-            val textDocument = fromVirtualFile(editor, file)
-            codyAgent.server.textDocumentDidOpen(textDocument)
+          fileDocumentManager.getFile(editor.document)?.let { file ->
+            try {
+              val textDocument = fromVirtualFile(editor, file)
+              codyAgent.server.textDocumentDidOpen(textDocument)
+            } catch (x: Exception) {
+              logger.warn("Error calling textDocument/didOpen for file: ${file.path}", x)
+            }
           }
         }
+
         FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->
-          fileDocumentManager.getFile(editor.document)?.let { file ->
-            val textDocument = fromVirtualFile(editor, file)
+          val file = fileDocumentManager.getFile(editor.document)
+          try {
+            val textDocument = fromVirtualFile(editor, file!!)
             codyAgent.server.textDocumentDidFocus(textDocument)
+          } catch (x: Exception) {
+            logger.warn("Error calling textDocument/didFocus on ${file?.path}", x)
           }
         }
       }


### PR DESCRIPTION
Can't see the root cause in the stack trace with Issue 1571, so I've added finer-grained exception handling and logging to `CodyFileEditorFactory`.

## Test plan

Will ask @jay-fibi to repro after we put this fix in.

- If it fixes the error, great! 
- If there is still bad behavior, we can now check the logs to get the root cause.