### PR TITLE
Fix invalid ranger creation for undo/diff actions

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/fixupActions/ReplaceUndoableAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/fixupActions/ReplaceUndoableAction.kt
@@ -7,21 +7,34 @@ import com.intellij.openapi.util.TextRange
 import com.sourcegraph.cody.agent.protocol.TextEdit
 
 // Handles deletion requests as well, which are just replacements with "".
-class ReplaceUndoableAction(
-    project: Project,
-    edit: TextEdit, // Instructions for the replacement.
-    document: Document
-) : FixupUndoableAction(project, edit, document) {
+class ReplaceUndoableAction : FixupUndoableAction {
 
-  private val replacementText = edit.value ?: "" // "" for deletions
-  private var beforeMarker = createBeforeMarker()
+  private val replacementText: String
   private var originalText: String? = null
+  private var beforeMarker: RangeMarker? = null
   private var afterMarker: RangeMarker? = null
+
+  private constructor(
+      project: Project,
+      edit: TextEdit,
+      replacementText: String,
+      document: Document
+  ) : super(project, edit, document) {
+    this.replacementText = replacementText
+  }
+
+  constructor(
+      project: Project,
+      edit: TextEdit,
+      document: Document
+  ) : this(project, edit, edit.value ?: "", document) {
+    this.beforeMarker = createBeforeMarker()
+  }
 
   private constructor(
       other: ReplaceUndoableAction,
       document: Document
-  ) : this(other.project, other.edit, document) {
+  ) : this(other.project, other.edit, other.replacementText, document) {
     this.beforeMarker =
         other.beforeMarker?.let { document.createRangeMarker(it.startOffset, it.endOffset) }
     this.afterMarker =


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1570

## Changes

`createBeforeMarker()` should never be called for actions created using `copyForDocument`.
At this point document is changed, and we cannot create markers based on the original ranges.
We can only copy markers based on the existing markers, which tracked the changes made to the document.
Previously markers were accidentally created twice, once using `createBeforeMarker()` in the initialisation block, and then they were re-created in the private secondary constructor. So invalid ranges were never used, but could crash during the creation.

## Test plan

Manual tests of Undo for various edit actions.