### PR TITLE
Improves UI of Code Lenses

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -677,7 +677,7 @@ class EditCommandPrompt(
       val sb = StringBuilder()
 
       if (keyStroke.modifiers and InputEvent.CTRL_DOWN_MASK != 0) {
-        sb.append("^")
+        sb.append("⌃")
       }
       if (keyStroke.modifiers and InputEvent.META_DOWN_MASK != 0) {
         sb.append("⌘")

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
@@ -63,7 +63,7 @@ class InstructionsInputTextArea(parentDisposable: Disposable) :
         setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
         color = EditUtil.getThemeColor("Component.infoForeground")
         val leftMargin = 15
-        drawString(GHOST_TEXT, leftMargin, (fontMetrics.height * 1.5).toInt()-2)
+        drawString(GHOST_TEXT, leftMargin, (fontMetrics.height * 1.5).toInt() - 2)
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
@@ -50,7 +50,7 @@ class InstructionsInputTextArea(parentDisposable: Disposable) :
 
     lineWrap = true
     wrapStyleWord = true
-    border = JBUI.Borders.empty(JBUI.insets(5))
+    border = JBUI.Borders.empty(JBUI.insets(10, 15, 10, 15))
   }
 
   override fun paintComponent(g: Graphics) {
@@ -63,7 +63,7 @@ class InstructionsInputTextArea(parentDisposable: Disposable) :
         setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
         color = EditUtil.getThemeColor("Component.infoForeground")
         val leftMargin = 15
-        drawString(GHOST_TEXT, leftMargin, (fontMetrics.height * 1.5).toInt())
+        drawString(GHOST_TEXT, leftMargin, (fontMetrics.height * 1.5).toInt()-2)
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
@@ -1,5 +1,7 @@
 package com.sourcegraph.cody.edit.widget
 
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.UIUtil
 import java.awt.Color
 import java.awt.Graphics2D
 
@@ -15,11 +17,23 @@ class LabelHighlight(private val color: Color) {
    * @param textHeight the height of the text.
    */
   fun drawHighlight(g: Graphics2D, x: Float, y: Float, textWidth: Int, textHeight: Int) {
+    // Draw shadow
+    g.color = UIUtil.shade(color, 0.5, 0.75)
+    g.fillRoundRect(
+      (x + 0).toInt(),
+      (y + 1).toInt(),
+      textWidth,
+      textHeight,
+      RADIUS,
+      RADIUS
+    )
+
+    // Draw highlight
     g.color = color
     g.fillRoundRect(x.toInt(), y.toInt(), textWidth, textHeight, RADIUS, RADIUS)
   }
 
   companion object {
-    const val RADIUS = 6
+    const val RADIUS = 4
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
@@ -18,10 +18,10 @@ class LabelHighlight(private val color: Color) {
    */
   fun drawHighlight(g: Graphics2D, x: Float, y: Float, textWidth: Int, textHeight: Int) {
     // Draw shadow
-    g.color = UIUtil.shade(color, 0.5, 0.75)
+    g.color = UIUtil.shade(color, 0.5, 0.35)
     g.fillRoundRect(
       (x + 0).toInt(),
-      (y + 1).toInt(),
+      (y + 0.5).toInt(),
       textWidth,
       textHeight,
       RADIUS,

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LabelHighlight.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.edit.widget
 
-import com.intellij.ui.JBColor
 import com.intellij.util.ui.UIUtil
 import java.awt.Color
 import java.awt.Graphics2D
@@ -19,14 +18,7 @@ class LabelHighlight(private val color: Color) {
   fun drawHighlight(g: Graphics2D, x: Float, y: Float, textWidth: Int, textHeight: Int) {
     // Draw shadow
     g.color = UIUtil.shade(color, 0.5, 0.35)
-    g.fillRoundRect(
-      (x + 0).toInt(),
-      (y + 0.5).toInt(),
-      textWidth,
-      textHeight,
-      RADIUS,
-      RADIUS
-    )
+    g.fillRoundRect((x + 0).toInt(), (y + 0.5).toInt(), textWidth, textHeight, RADIUS, RADIUS)
 
     // Draw highlight
     g.color = color

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -56,14 +56,14 @@ class LensAction(
       highlight.drawHighlight(g, x, y, width, textHeight)
 
       if (mouseInBounds) {
-        g.font = g.font.deriveFont(Font.PLAIN)
-        g.color = JBColor.foreground()
+        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.9f)
+        g.color = JBColor.foreground().brighter()
       } else {
-        g.font = g.font.deriveFont(Font.PLAIN)
-        g.color = Color.WHITE
+        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.9f)
+        g.color = JBColor.foreground()
       }
 
-      g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent)
+      g.drawString(text, x + SIDE_MARGIN + 1, y + g.fontMetrics.ascent + 1)
 
       lastPaintedBounds =
           Rectangle2D.Float(x, y - metrics.ascent, width.toFloat(), textHeight.toFloat())
@@ -116,7 +116,7 @@ class LensAction(
   }
 
   companion object {
-    const val SIDE_MARGIN = 5
+    const val SIDE_MARGIN = 9
 
     private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -7,6 +7,8 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.ui.JBColor
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.EditUtil
 import com.sourcegraph.cody.edit.sessions.FixupSession
@@ -54,8 +56,8 @@ class LensAction(
       highlight.drawHighlight(g, x, y, width, textHeight)
 
       if (mouseInBounds) {
-        g.font = g.font.deriveFont(underline)
-        g.color = UIManager.getColor("Link.hoverForeground")
+        g.font = g.font.deriveFont(Font.PLAIN)
+        g.color = JBColor.foreground()
       } else {
         g.font = g.font.deriveFont(Font.PLAIN)
         g.color = Color.WHITE
@@ -76,10 +78,11 @@ class LensAction(
     return true
   }
 
-  override fun onMouseEnter(e: EditorMouseEvent) {
-    mouseInBounds = true
-    showTooltip(EditCommandPrompt.getShortcutText(actionId) ?: return, e.mouseEvent)
-  }
+  // No need for tooltip because we display the action's shortcut in the lens bar.
+ // override fun onMouseEnter(e: EditorMouseEvent) {
+ //   mouseInBounds = true
+ //   showTooltip(EditCommandPrompt.getShortcutText(actionId) ?: return, e.mouseEvent)
+ // }
 
   private fun triggerAction(actionId: String, editor: Editor, mouseEvent: MouseEvent) {
     val action = ActionManager.getInstance().getAction(actionId)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -74,12 +74,6 @@ class LensAction(
     return true
   }
 
-  // No need for tooltip because we display the action's shortcut in the lens bar.
-  // override fun onMouseEnter(e: EditorMouseEvent) {
-  //   mouseInBounds = true
-  //   showTooltip(EditCommandPrompt.getShortcutText(actionId) ?: return, e.mouseEvent)
-  // }
-
   private fun triggerAction(actionId: String, editor: Editor, mouseEvent: MouseEvent) {
     val action = ActionManager.getInstance().getAction(actionId)
     if (action != null) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -57,10 +57,10 @@ class LensAction(
 
       if (mouseInBounds) {
         g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
-        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 0.95)
+        g.color = UIUtil.shade(JBColor(0xFFFFFF, 0xFFFFFF), 1.0, 0.95)
       } else {
         g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
-        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 0.9)
+        g.color = UIUtil.shade(JBColor(0xFFFFFF, 0xFFFFFF), 1.0, 0.9)
       }
 
       g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent + 1)
@@ -120,8 +120,8 @@ class LensAction(
 
     private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
 
-    val actionColor = JBColor(0xDFE1E5, 0x393B40)
-    private val acceptColor = JBColor(0x208A3C, 0x388119)
-    private val undoColor = JBColor(0xBC303E, 0x7B282C)
+    val actionColor = JBColor(0x4C4D54, 0x393B40)
+    private val acceptColor = JBColor(0x369650, 0x388119)
+    private val undoColor = JBColor(0xCC3645, 0x7B282C)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -37,7 +37,7 @@ class LensAction(
           })
 
   override fun calcWidthInPixels(fontMetrics: FontMetrics): Int {
-    return fontMetrics.stringWidth(text) + 2 * SIDE_MARGIN
+    return fontMetrics.stringWidth(text) + (2 * SIDE_MARGIN)
   }
 
   override fun calcHeightInPixels(fontMetrics: FontMetrics): Int = fontMetrics.height
@@ -50,20 +50,20 @@ class LensAction(
       g.background = EditUtil.getEnhancedThemeColor("Panel.background")
 
       val metrics = g.fontMetrics
-      val width = calcWidthInPixels(metrics)
+      val width = calcWidthInPixels(metrics) - 4
       val textHeight = metrics.height
 
-      highlight.drawHighlight(g, x, y, width, textHeight)
+      highlight.drawHighlight(g, x, y+1, width, textHeight-2)
 
       if (mouseInBounds) {
-        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.9f)
-        g.color = JBColor.foreground().brighter()
+        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
+        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 0.95)
       } else {
-        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.9f)
-        g.color = JBColor.foreground()
+        g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
+        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 1.0)
       }
 
-      g.drawString(text, x + SIDE_MARGIN + 1, y + g.fontMetrics.ascent + 1)
+      g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent + 1)
 
       lastPaintedBounds =
           Rectangle2D.Float(x, y - metrics.ascent, width.toFloat(), textHeight.toFloat())
@@ -120,8 +120,8 @@ class LensAction(
 
     private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
 
-    val actionColor = JBColor(Color.DARK_GRAY, Color(44, 45, 50))
-    private val acceptColor = Color(37, 92, 53)
-    private val undoColor = Color(114, 38, 38)
+    val actionColor = JBColor(0xDFE1E5, 0x393B40)
+    private val acceptColor = JBColor(0x208A3C, 0x388119)
+    private val undoColor = JBColor(0xBC303E, 0x7B282C)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -7,19 +7,15 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.ui.JBColor
-import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
-import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.EditUtil
 import com.sourcegraph.cody.edit.sessions.FixupSession
-import java.awt.Color
 import java.awt.Font
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 import java.awt.event.MouseEvent
 import java.awt.font.TextAttribute
 import java.awt.geom.Rectangle2D
-import javax.swing.UIManager
 
 @Suppress("UseJBColor")
 class LensAction(
@@ -53,7 +49,7 @@ class LensAction(
       val width = calcWidthInPixels(metrics) - 4
       val textHeight = metrics.height
 
-      highlight.drawHighlight(g, x, y+1, width, textHeight-2)
+      highlight.drawHighlight(g, x, y + 1, width, textHeight - 2)
 
       if (mouseInBounds) {
         g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
@@ -79,10 +75,10 @@ class LensAction(
   }
 
   // No need for tooltip because we display the action's shortcut in the lens bar.
- // override fun onMouseEnter(e: EditorMouseEvent) {
- //   mouseInBounds = true
- //   showTooltip(EditCommandPrompt.getShortcutText(actionId) ?: return, e.mouseEvent)
- // }
+  // override fun onMouseEnter(e: EditorMouseEvent) {
+  //   mouseInBounds = true
+  //   showTooltip(EditCommandPrompt.getShortcutText(actionId) ?: return, e.mouseEvent)
+  // }
 
   private fun triggerAction(actionId: String, editor: Editor, mouseEvent: MouseEvent) {
     val action = ActionManager.getInstance().getAction(actionId)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -60,7 +60,7 @@ class LensAction(
         g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 0.95)
       } else {
         g.font = g.font.deriveFont(Font.BOLD).deriveFont(g.font.size * 0.85f)
-        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 1.0)
+        g.color = UIUtil.shade(JBColor(0x000000, 0xFFFFFF), 1.0, 0.9)
       }
 
       g.drawString(text, x + SIDE_MARGIN, y + g.fontMetrics.ascent + 1)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
@@ -95,6 +95,6 @@ class LensGroupFactory(val session: FixupSession) {
 
   companion object {
     const val ICON_SPACER = " "
-    const val SEPARATOR = " | "
+    const val SEPARATOR = " ∣ "
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -1,8 +1,6 @@
 package com.sourcegraph.cody.edit.widget
 
 import com.intellij.ui.JBColor
-import com.intellij.util.ui.UIUtil
-import java.awt.Color
 import java.awt.Font
 import java.awt.FontMetrics
 import java.awt.Graphics2D

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -9,7 +9,7 @@ import java.awt.Graphics2D
 
 class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(group, text) {
 
-  private val hotkeyHighlightColor = JBColor.PanelBackground
+  private val hotkeyHighlightColor = JBColor(0xDFE1E5, 0x252629)
 
   private val highlight = LabelHighlight(hotkeyHighlightColor)
 
@@ -30,10 +30,10 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
     val height = fontMetrics.height + 3
 
     // Draw highlight
-    highlight.drawHighlight(g, x + 2, y, width, height)
+    highlight.drawHighlight(g, x + 2, y + 1, width, height - 2)
 
     // Draw the text
-    g.color = UIUtil.shade(JBColor.foreground(), 1.0, 0.5)
+    g.color = JBColor(0x2B2D30, 0x6F737A)
     g.drawString(text, x + 7, y + fontMetrics.ascent + 1)
 
     // Restore original font

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -9,7 +9,7 @@ import java.awt.Graphics2D
 
 class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(group, text) {
 
-  private val hotkeyHighlightColor = JBColor(0xDFE1E5, 0x252629)
+  private val hotkeyHighlightColor = JBColor(0xDDDDDD, 0x252629)
 
   private val highlight = LabelHighlight(hotkeyHighlightColor)
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.edit.widget
 
 import com.intellij.ui.JBColor
+import com.intellij.util.ui.UIUtil
 import java.awt.Color
 import java.awt.Font
 import java.awt.FontMetrics
@@ -32,7 +33,7 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
     highlight.drawHighlight(g, x + 2, y, width, height)
 
     // Draw the text
-    g.color = JBColor.foreground()
+    g.color = UIUtil.shade(JBColor.foreground(), 1.0, 0.5)
     g.drawString(text, x + 7, y + fontMetrics.ascent + 1)
 
     // Restore original font

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -16,13 +16,25 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
 
   @Suppress("UseJBColor")
   override fun paint(g: Graphics2D, x: Float, y: Float) {
-    // TODO: This will all break with larger font sizes. Use percentages of font width/height.
-    val width = g.fontMetrics.stringWidth(text) + 5
-    val height = g.fontMetrics.height - 3
-    highlight.drawHighlight(g, x + 2, y + 2, width, height)
+    // Resize font and get new metrics
+    val originalFont = g.font
+    val resizedFont = originalFont.deriveFont(originalFont.size * 0.8f)
+    g.font = resizedFont
+    val fontMetrics = g.fontMetrics
 
+    // Calculate width and height with resized font
+    val width = fontMetrics.stringWidth(text) + 10
+    val height = fontMetrics.height + 3
+
+    // Draw highlight
+    highlight.drawHighlight(g, x + 2, y, width, height)
+
+    // Draw the text
     g.color = Color.white // JBColor.WHITE looks like crap in Darcula theme (very dark)
-    g.drawString(text, x + 4, y + g.fontMetrics.ascent)
+    g.drawString(text, x + 8, y + fontMetrics.ascent + 1)
+
+    // Restore original font
+    g.font = originalFont
   }
 
   override fun toString(): String {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -1,12 +1,13 @@
 package com.sourcegraph.cody.edit.widget
 
+import com.intellij.ui.JBColor
 import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 
 class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(group, text) {
 
-  private val hotkeyHighlightColor = LensAction.actionColor
+  private val hotkeyHighlightColor = JBColor.PanelBackground
 
   private val highlight = LabelHighlight(hotkeyHighlightColor)
 
@@ -30,7 +31,7 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
     highlight.drawHighlight(g, x + 2, y, width, height)
 
     // Draw the text
-    g.color = Color.white // JBColor.WHITE looks like crap in Darcula theme (very dark)
+    g.color = JBColor.foreground()
     g.drawString(text, x + 8, y + fontMetrics.ascent + 1)
 
     // Restore original font

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.edit.widget
 
 import com.intellij.ui.JBColor
 import java.awt.Color
+import java.awt.Font
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 
@@ -19,7 +20,7 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     // Resize font and get new metrics
     val originalFont = g.font
-    val resizedFont = originalFont.deriveFont(originalFont.size * 0.8f)
+    val resizedFont = originalFont.deriveFont(Font.BOLD, originalFont.size * 0.8f)
     g.font = resizedFont
     val fontMetrics = g.fontMetrics
 
@@ -32,7 +33,7 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
 
     // Draw the text
     g.color = JBColor.foreground()
-    g.drawString(text, x + 8, y + fontMetrics.ascent + 1)
+    g.drawString(text, x + 7, y + fontMetrics.ascent + 1)
 
     // Restore original font
     g.font = originalFont

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensHotkey.kt
@@ -33,7 +33,7 @@ class LensHotkey(group: LensWidgetGroup, private val text: String) : LensLabel(g
     highlight.drawHighlight(g, x + 2, y + 1, width, height - 2)
 
     // Draw the text
-    g.color = JBColor(0x2B2D30, 0x6F737A)
+    g.color = JBColor(0x6F737A, 0x6F737A)
     g.drawString(text, x + 7, y + fontMetrics.ascent + 1)
 
     // Restore original font

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensIcon.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.edit.widget
 
 import java.awt.FontMetrics
 import java.awt.Graphics2D
+import java.awt.RenderingHints
 import javax.swing.Icon
 
 class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
@@ -22,6 +23,11 @@ class LensIcon(group: LensWidgetGroup, val icon: Icon) : LensWidget(group) {
     val desiredHeight = (fontMetrics.height + fontMetrics.ascent) / 2.0f
     val scaleFactor = desiredHeight / icon.iconHeight.toFloat()
     val iconY = textCenterLine - desiredHeight / 2.0f
+
+    // Set rendering hints for high quality resize
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+    g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+    g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)
 
     val originalTransform = g.transform
     g.translate(x.toInt(), iconY.toInt())

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
@@ -1,7 +1,10 @@
 package com.sourcegraph.cody.edit.widget
 
 import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.ui.JBColor
+import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.edit.EditCommandPrompt
+import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 
@@ -22,7 +25,7 @@ open class LensLabel(group: LensWidgetGroup, private val text: String) : LensWid
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     g.color =
         if (text == LensGroupFactory.SEPARATOR) {
-          EditCommandPrompt.boldLabelColor()
+          UIUtil.shade(JBColor.foreground(), 1.0, 0.4)
         } else {
           baseTextColor
         }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensLabel.kt
@@ -3,8 +3,6 @@ package com.sourcegraph.cody.edit.widget
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.UIUtil
-import com.sourcegraph.cody.edit.EditCommandPrompt
-import java.awt.Color
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidget.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.ui.popup.Balloon
 import com.intellij.ui.HintHint
+import com.intellij.ui.JBColor
 import com.intellij.ui.LightweightHint
 import java.awt.Color
 import java.awt.FontMetrics
@@ -23,9 +24,7 @@ abstract class LensWidget(val parentGroup: LensWidgetGroup) : Disposable {
 
   protected var mouseInBounds = false
 
-  // Note: JBColor.white is actually a dark gray in some themes,
-  // which doesn't work with our widget backgrounds, which are red/green/gray.
-  @Suppress("UseJBColor") protected val baseTextColor: Color = Color.WHITE
+  @Suppress("UseJBColor") protected val baseTextColor: Color = JBColor(0x393B40, 0xDFE1E5)
 
   private var showingTooltip = false
   private var tooltip: LightweightHint? = null

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.Disposer
+import com.intellij.ui.JBColor
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
@@ -203,10 +204,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     val inlayHeight = calcHeightInPixels(inlay)
 
     // Draw the inlay background across the width of the Editor.
-    g.color =
-        EditCommandPrompt.textFieldBackground().run {
-          if (ThemeUtil.isDarkTheme()) darker() else this
-        }
+    g.color = JBColor(0xECEDF2,0x26282D)
     g.fillRect(
         targetRegion.x.roundToInt(),
         targetRegion.y.roundToInt(),
@@ -355,6 +353,6 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     // The height of the inlay is always scaled to the font height,
     // with room for the buttons and some top/bottom padding. This setting
     // was found empirically and seems to work well for all font sizes.
-    private const val INLAY_HEIGHT_SCALE_FACTOR = 1.3
+    private const val INLAY_HEIGHT_SCALE_FACTOR = 1.2
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -112,7 +112,6 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private fun updateFonts() {
     val font = EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN)
-    // ideFont.set(font)
     widgetFont.set(Font(font.name, font.style, font.size))
     widgetFontMetrics = null // force recalculation
   }
@@ -344,7 +343,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   companion object {
 
-    // todo: make it follow the identation of the block. for now it is fixed to the left
+    // TODO: make it follow the identation of the block. for now it is fixed to the left
     private const val LEFT_MARGIN = 20f
 
     // The height of the inlay is always scaled to the font height,

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -23,9 +23,7 @@ import com.intellij.ui.JBColor
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
-import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
-import com.sourcegraph.config.ThemeUtil
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -79,7 +77,6 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   val widgetFont = AtomicReference(UIUtil.getLabelFont())
 
-
   // Compute inlay height based on the widget font, not the editor font.
   private val inlayHeight = AtomicReference(computeInlayHeight())
 
@@ -115,7 +112,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private fun updateFonts() {
     val font = EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN)
-    //ideFont.set(font)
+    // ideFont.set(font)
     widgetFont.set(Font(font.name, font.style, font.size))
     widgetFontMetrics = null // force recalculation
   }
@@ -204,7 +201,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     val inlayHeight = calcHeightInPixels(inlay)
 
     // Draw the inlay background across the width of the Editor.
-    g.color = JBColor(0xECEDF2,0x26282D)
+    g.color = JBColor(0xECEDF2, 0x26282D)
     g.fillRect(
         targetRegion.x.roundToInt(),
         targetRegion.y.roundToInt(),
@@ -347,7 +344,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   companion object {
 
-    //todo: make it follow the identation of the block. for now it is fixed to the left
+    // todo: make it follow the identation of the block. for now it is fixed to the left
     private const val LEFT_MARGIN = 20f
 
     // The height of the inlay is always scaled to the font height,

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -348,7 +348,9 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
   }
 
   companion object {
-    private const val LEFT_MARGIN = 100f
+
+    //todo: make it follow the identation of the block. for now it is fixed to the left
+    private const val LEFT_MARGIN = 20f
 
     // The height of the inlay is always scaled to the font height,
     // with room for the buttons and some top/bottom padding. This setting

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
@@ -75,10 +76,8 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private var listenersMuted = false
 
-  private val ideFont =
-      AtomicReference(EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN))
+  val widgetFont = AtomicReference(UIUtil.getLabelFont())
 
-  val widgetFont = with(ideFont.get()) { AtomicReference(Font(name, style, size)) }
 
   // Compute inlay height based on the widget font, not the editor font.
   private val inlayHeight = AtomicReference(computeInlayHeight())
@@ -115,7 +114,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private fun updateFonts() {
     val font = EditorColorsManager.getInstance().globalScheme.getFont(EditorFontType.PLAIN)
-    ideFont.set(font)
+    //ideFont.set(font)
     widgetFont.set(Font(font.name, font.style, font.size))
     widgetFontMetrics = null // force recalculation
   }


### PR DESCRIPTION
Changes:
- Colors of buttons on Lens
- Font used on Lens
- Chars used for shortcuts
- Smaller size comparable to other decorations on the editor
- Uses specific color values with` JBColor([LIGTH_COLOR], [DARK_COLOR])` for better tuning of light/dark themes
- Makes padding on Edit Code text area consistent with placeholder
- Changes placement of the lens to be on the left
- Fixes rendering fuzzy rendering of Cody logo

Upcoming:
Might do further color tweaks, but I think this is good improvement already to merge 

----
**Before**: 
<img width="692" alt="Screenshot 2024-05-22 at 17 48 09" src="https://github.com/sourcegraph/jetbrains/assets/7814431/ede62b56-38cf-40c4-9004-76f7506484ca">

**After**:
<img width="674" alt="Screenshot 2024-05-22 at 17 47 05" src="https://github.com/sourcegraph/jetbrains/assets/7814431/8fe16a6e-cccc-4861-a962-1e4aabf8bcff">

Themes:
**Dark**:
<img width="674" alt="Screenshot 2024-05-22 at 17 47 05" src="https://github.com/sourcegraph/jetbrains/assets/7814431/8fe16a6e-cccc-4861-a962-1e4aabf8bcff">

**Light**:
<img width="657" alt="Screenshot 2024-05-22 at 17 46 07" src="https://github.com/sourcegraph/jetbrains/assets/7814431/1538b86b-44bf-455f-8d71-8f8de394f938">

**Dracula**:
<img width="835" alt="Screenshot 2024-05-22 at 17 50 03" src="https://github.com/sourcegraph/jetbrains/assets/7814431/70054164-712f-4eef-887d-72dd03bdce5c">





## Test plan

Tested locally with the available themes on JetBrains.
Dark themes are defently better, but Light themes are functional as well
Ran multiple code edits to check the various states

**I was not able to test an error scenario of the lens**