### PR TITLE
Indent code lenses to the line below them

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -110,7 +110,7 @@ automatically.
 
 1. Paste the following Java code:
     ```java
-    // print 
+    // print
     System.out.println("Hello World!");
     ```
 2. Place cursor at the end of the `// print ` line.
@@ -244,7 +244,7 @@ All tests involving prompt history should end with:
     - You can collapse it to return to the regular view.
 5. Change the IDE font size to 22 and try the dialog. It should lay out correctly.
     - then try at font size 6 to ensure it works there too.
-    
+
 
 #### File Path
 
@@ -289,7 +289,7 @@ All tests involving prompt history should end with:
 #### Applying an edit
 
 1. Open the dialog, enter a valid instruction, such as "add comment", and press Edit Code.
-2. Verify that Cody has applied the edits inline according to your instructions. 
+2. Verify that Cody has applied the edits inline according to your instructions.
 
 ### Document Code
 
@@ -298,7 +298,7 @@ All tests involving prompt history should end with:
     - Cody should apply documentation above the selected code.
 4. Move your cursor inside of a different function in the file without highlighting any code.
 5. Execute the Document command.
-    - Cody should apply documentation above the function that contains your cursor. 
+    - Cody should apply documentation above the function that contains your cursor.
 
 ### Generate Unit Test
 
@@ -310,7 +310,7 @@ All tests involving prompt history should end with:
 6. Execute the Document Code command.
    - Cody should add the suggested unit tests to the bottom of the existing test file.
 8. Instead of highlighting code, leave your cursor in a line on the file and execute the Document Code command.
-    - Cody should treat the function containing your cursor as "highlighted code" and perform the same behaviors as above.   
+    - Cody should treat the function containing your cursor as "highlighted code" and perform the same behaviors as above.
 
 ### Code Lenses
 
@@ -321,7 +321,21 @@ All tests involving prompt history should end with:
     - Clicking or using the shortcut to Accept applies the inline edit and removes the code lens
     - Clicking or using the shortcut to Undo removes the inline edit as well as the code lens
     - Clicking or using the shortcut to Edit & Retry opens the Edit Code dialog, undoes the initial edit, and applies new edits according to your new instructions.
-    - Clicking or using the shortcut to Show Diff opens a new tab with a diff view of the edits. 
+    - Clicking or using the shortcut to Show Diff opens a new tab with a diff view of the edits.
+
+#### Lens group indentation
+
+1. Execute any inline edit command.
+2. Observe where the first "Cody is working" code lens group is positioned.
+   - if there is a nonblank line below the lens group, then the first widget
+     (the Cody logo, a spinner, etc.) should be indented to the same indentation
+     level as the first non-blank line in the code beneath the lens group.
+   - if there is no next non-blank line, the lens group should indent 20 pixels
+   - It is not a bug is the first widget is positioned only "close" to the first
+     character of the next line, within a character's width on either side of
+     the leftmost widget. But if it is indented much more or less, it is a bug.
+3. Wait until the Accept (or Error) lens group appears.
+   - Follow the steps above to verify that the first widget is indented the same way.
 
 #### Lens layout and and appearance
 
@@ -442,16 +456,16 @@ Note: It's important to test performance on large repos here.
 4. Empty chat input and type multiline message "A\n\nB"
 5. Press `Up` arrow. Confirm that the caret is positioned in the empty line between A and B.
 
-### Cody Ignore 
+### Cody Ignore
 
-When testing Cody Ignore, please reload the editor after each policy change. Outside of the required testing steps, please also make sure general product usability is not affected when Cody Ignore policies are turned on. 
+When testing Cody Ignore, please reload the editor after each policy change. Outside of the required testing steps, please also make sure general product usability is not affected when Cody Ignore policies are turned on.
 
 Please use the SG02 endpoint to test and change Cody Ignore configuration.
 
-| Policy | Workspace Repository| Test Steps | 
-| --- | --- | --- | 
-| ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/cody"}],                        "include": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/.+"}]}``` |  github.com/sourcegraph/sourcegraph | Chat: <ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Add github.com/sourcegraph/cody to the repo context selector and verify that there is a striked out symbol in the Repositories dropdown</li><li>Ask Cody "How do you contribute to Cody?" and confirm that no files from the Cody repository was used for context </li></ol>Autocomplete: <ol><li>Verify that autocomplete works as normal in any file in the github.com/sourcegraph/sourcegraph repository</ol>Commands: <ol><li>Verify that commands (Edit, Document, Test, Smell) are possible on any file in github.com/sourcegraph/sourcegraph.</li></ol> | 
-| ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/cody"}],                          "include": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/.+"}]}``` |  github.com/sourcegraph/cody | Chat:<ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Open the Enhanced Context menu and verify that it shows the github.com/sourcegraph/cody repo is ignored, on hover explaining this is due to an admin policy.</li><li>@-mention any files in the github.com/sourcegraph/cody repo and verify that the user sees a disclaimer that the file is ignored upon selection.</li><li>Submit a chat with an @-file and verify that the file is crossed out and excluded in the context dropdown</li><li>Verify that the user can add the github.com/sourcegraph/sourcegraph and github.com/sourcegraph/jetbrains repos through the context popup menu for Enhanced context.</li></ol>Autocomplete:<ol><li>Verify that no autocomplete suggestions are possible on any files in the github.com/sourcegraph/cody repo.</li><li>Verify that the status bar reflects that autocomplete is disabled due to an Ignore policy.</li><li>Manually trigger autocompletes in any files in the github.com/sourcegraph/cody repo and verify that a notification is always triggered.</li></ol>Commands:<ol><li>While in any files in the github.com/sourcegraph/cody repo, verify that the sidebar shows commands are disabled, with a "Learn more" link directing to the Cody Ignore docs.</li><li>Attempt to use the right-click menu to run commands in any files in the github.com/sourcegraph/cody repo and verify that they don't run and a notification is triggered.</li><li>Attempt to use a keyboard shortcut to run commands in any files in the github.com/sourcegraph/cody repo and verify that they don't run and a notification is triggered.</li><ol> |                                                                                                                     
+| Policy | Workspace Repository| Test Steps |
+| --- | --- | --- |
+| ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/cody"}],                        "include": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/.+"}]}``` |  github.com/sourcegraph/sourcegraph | Chat: <ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Add github.com/sourcegraph/cody to the repo context selector and verify that there is a striked out symbol in the Repositories dropdown</li><li>Ask Cody "How do you contribute to Cody?" and confirm that no files from the Cody repository was used for context </li></ol>Autocomplete: <ol><li>Verify that autocomplete works as normal in any file in the github.com/sourcegraph/sourcegraph repository</ol>Commands: <ol><li>Verify that commands (Edit, Document, Test, Smell) are possible on any file in github.com/sourcegraph/sourcegraph.</li></ol> |
+| ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/cody"}],                          "include": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/.+"}]}``` |  github.com/sourcegraph/cody | Chat:<ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Open the Enhanced Context menu and verify that it shows the github.com/sourcegraph/cody repo is ignored, on hover explaining this is due to an admin policy.</li><li>@-mention any files in the github.com/sourcegraph/cody repo and verify that the user sees a disclaimer that the file is ignored upon selection.</li><li>Submit a chat with an @-file and verify that the file is crossed out and excluded in the context dropdown</li><li>Verify that the user can add the github.com/sourcegraph/sourcegraph and github.com/sourcegraph/jetbrains repos through the context popup menu for Enhanced context.</li></ol>Autocomplete:<ol><li>Verify that no autocomplete suggestions are possible on any files in the github.com/sourcegraph/cody repo.</li><li>Verify that the status bar reflects that autocomplete is disabled due to an Ignore policy.</li><li>Manually trigger autocompletes in any files in the github.com/sourcegraph/cody repo and verify that a notification is always triggered.</li></ol>Commands:<ol><li>While in any files in the github.com/sourcegraph/cody repo, verify that the sidebar shows commands are disabled, with a "Learn more" link directing to the Cody Ignore docs.</li><li>Attempt to use the right-click menu to run commands in any files in the github.com/sourcegraph/cody repo and verify that they don't run and a notification is triggered.</li><li>Attempt to use a keyboard shortcut to run commands in any files in the github.com/sourcegraph/cody repo and verify that they don't run and a notification is triggered.</li><ol> |
 | ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/sourcegraph"}]}``` |  github.com/sourcegraph/sourcegraph    | Chat: <ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Open the Enhanced Context menu and verify that it shows the github.com/sourcegraph/sourcegraph repo is ignored, on hover explaining this is due to an admin policy.</li><li>@-mention any files in the github.com/sourcegraph/sourcegraph repo and verify that the user sees a disclaimer that the file is ignored upon selection.</li><li>Submit a chat with an @-file and verify that the file is crossed out and excluded in the context dropdown</li><li>Verify that the user can add the github.com/sourcegraph/cody repo through the context popup menu for Enhanced context.</li></ol>Autocomplete: <ol><li>Verify that no autocomplete suggestions are possible on any files in the github.com/sourcegraph/sourcegraph.</li><li>Verify that the status bar reflects that autocomplete is disabled due to an Ignore policy.</li><li>Attempt automatic autocompletes and verify that they are not possible.</li><li>Provide multiple automatic autocomplete attempts and verify that only one notification per session is provided when autocomplete is blocked.</li><li>Manually trigger autocompletes in any files in the github.com/sourcegraph/sourcegraph repo and verify that a notification is always triggered.</li></ol>Commands: <ol><li>While in any files in the github.com/sourcegraph/sourcegraph repo, verify that the sidebar shows commands are disabled, with a "Learn more" link directing to the Cody Ignore docs.</li><li>Attempt to use the right-click menu to run commands in any files in the github.com/sourcegraph/sourcegraph repo and verify that they don't run and a notification is triggered.</li><li>Attempt to use a keyboard shortcut to run commands in any files in the github.com/sourcegraph/sourcegraph repo and verify that they don't run and a notification is triggered.</li></ol> |
 | ```"cody.contextFilters": {"exclude": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/sourcegraph"}]}``` |  github.com/sourcegraph/cody | Chat: <ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Add github.com/sourcegraph/sourcegraph to the repo context selector and verify that there is a striked out symbol in the Repositories dropdown</li><li>Ask Cody "How do you contribute to Sourcegraph?" and confirm that no files from the Cody repository was used for context </li></ol>Autocomplete: <ol><li>Verify that autocomplete works as normal in any file in the github.com/sourcegraph/sourcegraph repository</ol>Commands: <ol><li>Verify that commands (Edit, Document, Test, Smell) are possible on any file in github.com/sourcegraph/sourcegraph.</li></ol> |
 | ```"cody.contextFilters": {"include": [{"repoNamePattern": "^github\\.com\\/sourcegraph\\/sourcegraph"}]}``` |  github.com/sourcegraph/sourcegraph | Chat: <ol><li>Verify chat works as normal by asking Cody any question and receiving a response back.</li><li>Add github.com/sourcegraph/cody to the repo context selector and verify that there is a striked out symbol in the Repositories dropdown</li><li>Ask Cody "How do you contribute to Cody?" and confirm that no files from the Cody repository was used for context </li></ol>Autocomplete: <ol><li>Verify that autocomplete works as normal in any file in the github.com/sourcegraph/sourcegraph repository</ol>Commands: <ol><li>Verify that commands (Edit, Document, Test, Smell) are possible on any file in github.com/sourcegraph/sourcegraph.</li></ol> |

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -16,8 +16,7 @@ import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.listeners.CodyFileEditorListener
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.utils.CodyEditorUtil
-import java.util.Timer
-import java.util.TimerTask
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -290,7 +289,7 @@ class CodyAgentService(private val project: Project) : Disposable {
     suspend fun <T> coWithAgent(project: Project, callback: suspend (CodyAgent) -> T) =
         coWithAgent(project, false, callback)
 
-    suspend fun <T> coWithAgent(
+    private suspend fun <T> coWithAgent(
         project: Project,
         restartIfNeeded: Boolean,
         callback: suspend (CodyAgent) -> T

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -592,8 +592,6 @@ class EditCommandPrompt(
     }
   }
 
-  // TODO: Was hoping this would help avoid flicker while resizing.
-  // Needs more work, but I think this is likely the right general approach.
   class DoubleBufferedRootPane : JRootPane() {
     private var offscreenImage: BufferedImage? = null
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -190,35 +190,46 @@ abstract class FixupSession(
   // which may require switching to the EDT. This is primarily to help smooth
   // integration testing, but also because there's no real harm blocking pool threads.
   private fun showLensGroup(group: LensWidgetGroup) {
-    lensGroup?.let { if (!it.isDisposed.get()) Disposer.dispose(it) }
-    lensGroup = group
-
-    var range =
-        selectionRange?.let {
-          val position = Position(Range.fromRangeMarker(it).start.line, character = 0)
-          Range(start = position, end = position)
-        }
-
-    if (range == null) {
-      // Be defensive, as the protocol has been fragile with respect to selection ranges.
-      logger.warn("No selection range for session: $this")
-      // Last-ditch effort to show it somewhere other than top of file.
-      val position = Position(editor.caretModel.currentCaret.logicalPosition.line, 0)
-      range = Range(start = position, end = position)
-    }
-    val future = group.show(range)
-    // Make sure the lens is visible.
-    ApplicationManager.getApplication().invokeLater {
-      if (!editor.isDisposed) {
-        val logicalPosition = LogicalPosition(range.start.line, range.start.character)
-        editor.scrollingModel.scrollTo(logicalPosition, ScrollType.CENTER)
+    runInEdt {
+      try {
+        lensGroup?.let { if (!it.isDisposed.get()) Disposer.dispose(it) }
+      } catch (x: Exception) {
+        logger.warn("Error disposing previous lens group", x)
       }
-    }
-    if (!ApplicationManager.getApplication().isDispatchThread) { // integration test
-      future.get()
-    }
+      lensGroup = group
 
-    controller.notifySessionStateChanged()
+      var range =
+          selectionRange?.let {
+            val position = Position(Range.fromRangeMarker(it).start.line, character = 0)
+            Range(start = position, end = position)
+          }
+
+      if (range == null) {
+        // Be defensive, as the protocol has been fragile with respect to selection ranges.
+        logger.warn("No selection range for session: $this")
+        // Last-ditch effort to show it somewhere other than top of file.
+        val position = Position(editor.caretModel.currentCaret.logicalPosition.line, 0)
+        range = Range(start = position, end = position)
+      }
+      val future = group.show(range)
+      // Make sure the lens is visible.
+      ApplicationManager.getApplication().invokeLater {
+        if (!editor.isDisposed) {
+          val logicalPosition = LogicalPosition(range.start.line, range.start.character)
+          editor.scrollingModel.scrollTo(logicalPosition, ScrollType.CENTER)
+        }
+      }
+      if (!ApplicationManager.getApplication().isDispatchThread) { // integration test
+        future.get()
+      }
+
+      controller.notifySessionStateChanged()
+    }
+  }
+
+  // An optimization to avoid recomputing widget indentation in a tight loop.
+  fun resetLensGroup() {
+    lensGroup?.reset()
   }
 
   private fun showWorkingGroup() {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensAction.kt
@@ -14,10 +14,8 @@ import java.awt.Font
 import java.awt.FontMetrics
 import java.awt.Graphics2D
 import java.awt.event.MouseEvent
-import java.awt.font.TextAttribute
 import java.awt.geom.Rectangle2D
 
-@Suppress("UseJBColor")
 class LensAction(
     val group: LensWidgetGroup,
     private val text: String,
@@ -38,7 +36,6 @@ class LensAction(
 
   override fun calcHeightInPixels(fontMetrics: FontMetrics): Int = fontMetrics.height
 
-  @Suppress("UseJBColor")
   override fun paint(g: Graphics2D, x: Float, y: Float) {
     val originalFont = g.font
     val originalColor = g.color
@@ -107,8 +104,6 @@ class LensAction(
 
   companion object {
     const val SIDE_MARGIN = 9
-
-    private val underline = mapOf(TextAttribute.UNDERLINE to TextAttribute.UNDERLINE_ON)
 
     val actionColor = JBColor(0x4C4D54, 0x393B40)
     private val acceptColor = JBColor(0x369650, 0x388119)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -26,6 +26,7 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.sessions.FixupSession
+import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -37,7 +38,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
 import kotlin.math.roundToInt
-import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 
@@ -262,7 +262,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     try {
       val document = editor.document
       val inlayOffset = inlay?.offset
-      if (inlayOffset != null) {
+      if (inlayOffset == null) {
         lastComputedIndent = DEFAULT_MARGIN
         return DEFAULT_MARGIN
       }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -266,8 +266,8 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
         lastComputedIndent = DEFAULT_MARGIN
         return DEFAULT_MARGIN
       }
-      val lineCount = document.lineCount
 
+      val lineCount = document.lineCount
       val inlayLineNumber = document.getLineNumber(inlayOffset)
 
       // Find next non-blank line.

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -254,29 +254,35 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   // Computes the X coordinate in the Editor where the first widget is drawn.
   private fun leftMargin(): Int {
-    val document = editor.document
-    val inlayOffset = inlay?.offset ?: return DEFAULT_MARGIN
-    val lineCount = document.lineCount
+    try {
+      val document = editor.document
+      val inlayOffset = inlay?.offset ?: return DEFAULT_MARGIN
+      val lineCount = document.lineCount
 
-    val inlayLineNumber = document.getLineNumber(inlayOffset)
-    // Find next non-blank line.
-    for (lineNumber in inlayLineNumber until lineCount) {
-      val lineStartOffset = document.getLineStartOffset(lineNumber)
-      val lineEndOffset = document.getLineEndOffset(lineNumber)
-      val lineText = document.getText(TextRange(lineStartOffset, lineEndOffset))
-      // Compute the pixel width of the indentation.
-      if (lineText.isNotBlank()) {
-        val tabSize = EditorUtil.getTabSize(editor)
-        val spaceWidth = EditorUtil.getSpaceWidth(Font.PLAIN, editor)
-        val indentationLevel =
-            lineText
-                .takeWhile { it.isWhitespace() }
-                .sumOf { if (it == '\t') tabSize * spaceWidth else spaceWidth }
+      val inlayLineNumber = document.getLineNumber(inlayOffset)
 
-        return indentationLevel
+      // Find next non-blank line.
+      for (lineNumber in inlayLineNumber until lineCount) {
+        val lineStartOffset = document.getLineStartOffset(lineNumber)
+        val lineEndOffset = document.getLineEndOffset(lineNumber)
+        val lineText = document.getText(TextRange(lineStartOffset, lineEndOffset))
+
+        // Compute the pixel width of the indentation.
+        if (lineText.isNotBlank()) {
+          val tabSize = EditorUtil.getTabSize(editor)
+          val spaceWidth = EditorUtil.getSpaceWidth(Font.PLAIN, editor)
+          val indentationLevel =
+              lineText
+                  .takeWhile { it.isWhitespace() }
+                  .sumOf { if (it == '\t') tabSize * spaceWidth else spaceWidth }
+
+          return indentationLevel
+        }
       }
+    } catch (x: Exception) {
+      logger.warn("Error computing code lens left margin", x)
     }
-    return DEFAULT_MARGIN // No non-blank line found.
+    return DEFAULT_MARGIN
   }
 
   // Dispatch mouse click events to the appropriate widget.

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -90,7 +90,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   private var prevCursor: Cursor? = null
 
-  private var lastComputedIndent = -1
+  private var lastComputedIndent = RECOMPUTE
 
   var isInWorkingGroup = false
   var isAcceptGroup = false
@@ -256,7 +256,7 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   // Computes the X coordinate in the Editor where the first widget is drawn.
   private fun leftMargin(): Int {
-    if (lastComputedIndent != -1) {
+    if (lastComputedIndent != RECOMPUTE) {
       return lastComputedIndent
     }
     try {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -26,7 +26,6 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.sessions.FixupSession
-import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -38,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
 import kotlin.math.roundToInt
+import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/FixupSessionDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/FixupSessionDocumentListener.kt
@@ -16,6 +16,8 @@ class FixupSessionDocumentListener(private val session: FixupSession) : BulkAwar
     if (isAcceptLensGroupShown.get()) {
       logger.info("Auto-accepting current Fixup session: ${session.taskId}")
       session.accept()
+    } else {
+      session.resetLensGroup()
     }
   }
 


### PR DESCRIPTION
@danielmarquespt expressed that he would prefer to have the lenses indent to the same level as the next non-blank line below them, rather than always at a fixed offset.

This was very easy to add, and low-risk, so I added it. It handles errors and falls back to the old indentation if there are any problems at all.

## Test plan

I updated the test plan to include a visual inspection for the lens indentation.