### PR TITLE
Document synchronization: fix bugs and improve performance

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentContentChangeEvent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentContentChangeEvent.kt
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class ProtocolTextDocumentContentChangeEvent(
+    val range: Range,
+    val text: String,
+)

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -23,7 +23,8 @@ class CodyCaretListener(val project: Project) : CaretListener {
       return
     }
 
-    ProtocolTextDocument.fromEditor(e.editor)?.let { textDocument ->
+    ProtocolTextDocument.fromEditorWithOffsetSelection(e.editor, e.newPosition)?.let { textDocument
+      ->
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocumentDidChange(textDocument)
       }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -10,11 +10,11 @@ import com.sourcegraph.config.ConfigUtil
 
 class CodySelectionListener(val project: Project) : SelectionListener {
   override fun selectionChanged(e: SelectionEvent) {
-    if (!ConfigUtil.isCodyEnabled()) {
+    if (!ConfigUtil.isCodyEnabled() || e.editor == null) {
       return
     }
 
-    ProtocolTextDocument.fromEditor(e.editor)?.let { textDocument ->
+    ProtocolTextDocument.fromEditorWithRangeSelection(e.editor)?.let { textDocument ->
       CodyAgentService.withAgent(project) { agent ->
         agent.server.textDocumentDidChange(textDocument)
       }


### PR DESCRIPTION
This PR makes several changes to document synchronization:

* Caret changes now no longer send the full text contents. This was redundant since the text hadn't changed.
* Selection changes. Same as caret changes, no more redundant content traffic.
* Document changes. We still do full document synchronization, but we do it unconditionally now. There were cases where we disabled synchronization (undo in progress, and autocomplete was disabled).

These improvements should both address performance issues as well as correctness bugs (esp. disabling of synchronization during document changes).

Co-Author: @RXminuS 

## Test plan

Manually tested with the command

```
❯ tail -f build/sourcegraph/cody-agent-trace.json  | grep -A 30 textDocument/didChange
```
* Make changes to the caret/selection and observe that the content is no longer populated
* Disable autocomplete, and confirm that we still send `textDocument/didChange` notifications (we don't do this on main).

I have not tried yet to reproduce the undo behavior.

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
