### PR TITLE
Improve fixup session handling and disposal

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -79,20 +79,24 @@ class CodyAgentService(private val project: Project) : Disposable {
       }
 
       agent.client.onWorkspaceEdit = Function { params ->
+        val activeSession = FixupService.getInstance(project).getActiveSession()
         try {
-          FixupService.getInstance(project).getActiveSession()?.performWorkspaceEdit(params)
+          activeSession?.performWorkspaceEdit(params)
           true
         } catch (e: RuntimeException) {
+          activeSession?.dispose()
           logger.error(e)
           false
         }
       }
 
       agent.client.onTextDocumentEdit = Function { params ->
+        val activeSession = FixupService.getInstance(project).getActiveSession()
         try {
-          FixupService.getInstance(project).getActiveSession()?.performInlineEdits(params.edits)
+          activeSession?.performInlineEdits(params.edits)
           true
         } catch (e: RuntimeException) {
+          activeSession?.dispose()
           logger.error(e)
           false
         }
@@ -250,6 +254,7 @@ class CodyAgentService(private val project: Project) : Disposable {
               try {
                 callback.accept(agent)
               } catch (e: Exception) {
+                logger.warn(e)
                 onFailure.accept(e)
               }
             }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -74,7 +74,7 @@ class CodyAgentService(private val project: Project) : Disposable {
 
       agent.client.onEditTaskDidDelete = Consumer { params ->
         FixupService.getInstance(project).getActiveSession()?.let {
-          if (params.id == it.taskId) it.dismiss()
+          if (params.id == it.taskId) it.dispose()
         }
       }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -86,7 +86,7 @@ class FixupService(val project: Project) : Disposable {
       // We want to enable parallel edits in JetBrains soon, so this would be a wasted effort.
       if (currentSession.isShowingAcceptLens()) {
         currentSession.accept()
-        currentSession.dismiss()
+        currentSession.dispose()
       } else throw IllegalStateException("Cannot start new session when one is already active")
     }
     activeSession = newSession

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditDismissAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditDismissAction.kt
@@ -13,6 +13,6 @@ import com.sourcegraph.cody.edit.FixupService
 // So we have our own Action for it.
 class EditDismissAction : InlineEditAction() {
   override fun performAction(e: AnActionEvent, project: Project) {
-    FixupService.getInstance(project).getActiveSession()?.dismiss()
+    FixupService.getInstance(project).getActiveSession()?.dispose()
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -88,14 +88,6 @@ abstract class FixupSession(
         } catch (x: Exception) {
           logger.debug("Session cleanup error", x)
         }
-
-        runInEdt {
-          try { // Disposing inlay requires EDT.
-            Disposer.dispose(this)
-          } catch (x: Exception) {
-            logger.warn("Error disposing fixup session $this", x)
-          }
-        }
       }
 
   @Volatile private var undoInProgress: Boolean = false
@@ -180,8 +172,8 @@ abstract class FixupSession(
       // Tasks remain in this state until explicit accept/undo/cancel.
       CodyTaskState.Applied -> showAcceptGroup()
       // Then they transition to finished.
-      CodyTaskState.Finished -> cancellationToken.dispose()
-      CodyTaskState.Error -> cancellationToken.dispose()
+      CodyTaskState.Finished -> dispose()
+      CodyTaskState.Error -> dispose()
       CodyTaskState.Pending -> {}
     }
   }
@@ -248,7 +240,7 @@ abstract class FixupSession(
 
   fun cancel() {
     if (taskId == null) {
-      dismiss()
+      dispose()
     } else {
       CodyAgentService.withAgent(project) { agent ->
         agent.server.cancelEditTask(TaskIdParam(taskId!!))
@@ -275,10 +267,6 @@ abstract class FixupSession(
 
   fun afterSessionFinished(action: Runnable) {
     completionFuture.thenRun(action)
-  }
-
-  fun dismiss() {
-    cancellationToken.dispose()
   }
 
   fun performWorkspaceEdit(workspaceEditParams: WorkspaceEditParams) {
@@ -411,6 +399,7 @@ abstract class FixupSession(
     if (project.isDisposed) return
     performedActions.forEach { it.dispose() }
     editor.document.removeDocumentListener(documentListener)
+    lensGroup?.dispose()
     cancellationToken.dispose()
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -411,6 +411,7 @@ abstract class FixupSession(
     if (project.isDisposed) return
     performedActions.forEach { it.dispose() }
     editor.document.removeDocumentListener(documentListener)
+    cancellationToken.dispose()
   }
 
   fun isShowingWorkingLens(): Boolean {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensGroupFactory.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.edit.widget
 
-import com.intellij.openapi.diagnostic.Logger
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.edit.sessions.FixupSession
@@ -8,7 +7,6 @@ import javax.swing.Icon
 
 /** Handles assembling standard groups of lenses. */
 class LensGroupFactory(val session: FixupSession) {
-  private val logger = Logger.getInstance(LensGroupFactory::class.java)
 
   fun createTaskWorkingGroup(): LensWidgetGroup {
     return LensWidgetGroup(session, session.editor).apply {


### PR DESCRIPTION
Possible a step towards fixing https://github.com/sourcegraph/cody-issues/issues/314.

## Test plan
1. Try to get to the "invalid state" when the inline actions are disabled
