### PR TITLE
Undo: revert change - disable document synchronization during undo

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -41,6 +42,10 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
   private fun handleDocumentEvent(event: DocumentEvent) {
     val editor = FileEditorManager.getInstance(project).selectedTextEditor
     if (editor?.document != event.document) {
+      return
+    }
+
+    if (CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
       return
     }
 


### PR DESCRIPTION
The PR https://github.com/sourcegraph/jetbrains/pull/1607 introduced a change where we start synchronizing when
`CommandProcessor.getInstance().isUndoTransparentActionInProgress` returns true. This PR reverts this change since we have heard reports that something is acting weirdly around undo after merging this change.

## Test plan

Not tested because I wasn't able to reproduce the behavior of the regression.

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
