### PR TITLE
fix: handle empty documents and convert 1-based to 0-based line numbers

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -56,7 +56,6 @@ abstract class FixupSession(
     val project: Project,
     var editor: Editor
 ) : Disposable {
-
   private val logger = Logger.getInstance(FixupSession::class.java)
   private val fixupService = FixupService.getInstance(project)
   private val documentListener by lazy { FixupSessionDocumentListener(this) }
@@ -147,12 +146,13 @@ abstract class FixupSession(
   }
 
   private fun ensureSelectionRange(agent: CodyAgent, textFile: ProtocolTextDocument) {
-    val selection = textFile.selection ?: return
-    selectionRange = selection.toRangeMarker(document, true)
-    agent.server
-        .getFoldingRanges(GetFoldingRangeParams(uri = textFile.uri, range = selection))
-        .thenApply { result -> selectionRange = result.range.toRangeMarker(document, true) }
-        .get()
+      val selection = textFile.selection ?: return
+      selectionRange = selection.toRangeMarker(document, true)
+      agent
+          .server
+          .getFoldingRanges(GetFoldingRangeParams(uri = textFile.uri, range = selection))
+          .thenApply { result -> selectionRange = result.range.toRangeMarker(document, true) }
+          .get()
   }
 
   fun update(task: EditTask) {


### PR DESCRIPTION

![zero](https://github.com/sourcegraph/jetbrains/assets/68532117/55be663e-5631-4bc9-877d-ad2edb9b6635)

CHANGES:

- For an empty document, return a zero-width selection at the start of the document
- Subtract 1 to convert 1-based line numbers to 0-based line numbers before sending to Agent
- Keep current selection as is when sending the document to the agent
- Add selection information to ProtocolTextDocument created from Editor

FIX:
- active cursor without selection would break Cody
- random leftover code at the end of unit test files due to incorrect line number used
- inserting code at the incorrect line

## Test plan

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->

Verify the following works in the supported editor:
- Open the Jetbrains repo in this build
- Put your cursor inside a function and run the Doc & Test command 
- Highlight a function to run the Doc & Testcommand

## Limitation

- Active cursor without selection only works on Editor that has folding range support
- This means it would break Cody if you open a typescript repo in IDE
  - We can look into this in a follow up to prevent Cody from stop working due to error returned by Agent