### PR TITLE
Testing: make the agent start during integration tests

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
 java adoptopenjdk-11.0.21+9
+nodejs 20.4.0
+pnpm 8.6.7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -425,5 +425,8 @@ tasks {
     }
   }
 
-  test { dependsOn(project.tasks.getByPath("buildCody")) }
+  test {
+    systemProperty("cody-agent.directory", buildCodyDir.parent)
+    dependsOn(project.tasks.getByPath("buildCody"))
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.initialization
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEventMulticasterEx
 import com.intellij.openapi.project.Project
@@ -30,10 +31,14 @@ class PostStartupActivity : StartupActivity.DumbAware {
   // deserves more investigation.
   override fun runActivity(project: Project) {
     TelemetryInitializerActivity().runActivity(project)
+
     SettingsMigration().runActivity(project)
     SelectOneOfTheAccountsAsActive().runActivity(project)
     CodyAuthNotificationActivity().runActivity(project)
-    CheckUpdatesTask(project).queue()
+    ApplicationManager.getApplication().executeOnPooledThread {
+      // Scheduling because this task takes ~2s to run
+      CheckUpdatesTask(project).queue()
+    }
     if (ConfigUtil.isCodyEnabled()) CodyAgentService.getInstance(project).startAgent(project)
     CodyStatusService.resetApplication(project)
     EndOfTrialNotificationScheduler.createAndStart(project)

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PrettyTimer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PrettyTimer.kt
@@ -1,0 +1,37 @@
+package com.sourcegraph.cody.initialization
+
+import java.time.Duration
+import java.time.Instant
+
+class PrettyTimer {
+  val start = Instant.now()
+
+  fun elapsed(): Duration {
+    return Duration.between(start, Instant.now())
+  }
+
+  companion object {
+    @JvmStatic
+    fun <T> debugTask(name: String, fn: () -> T): T {
+      val timer = PrettyTimer()
+      val result = fn()
+      println("Task '$name' - $timer")
+      return result
+    }
+  }
+
+  override fun toString(): String {
+    val duration = elapsed()
+    val hours = duration.toHours()
+    val minutes = duration.toMinutes() % 60
+    val seconds = duration.seconds % 60
+    val millis = duration.toMillis() % 1000
+
+    return when {
+      hours > 0 -> String.format("%dhr%02dmin%02ds", hours, minutes, seconds)
+      minutes > 0 -> String.format("%dmin%02ds", minutes, seconds)
+      seconds > 0 -> String.format("%ds%03dms", seconds, millis)
+      else -> String.format("%dms", millis)
+    }
+  }
+}


### PR DESCRIPTION
Previously, the agent wasn't starting in our tests because we didn't set the right system property. Now, the agent manages to start correctly during the tests.

While debugging this, I made a few other small improvements:

- Fix .tool-version file so we use the right node/pnpm version. Note that this file had the wrong name (.tool-version instead of .tool-versions)
- Move "Check updates" task off the blocking path during activation. Starting the agent was taking ~2s longer than it should have because we were checking if the Cody plugin had an available update before starting. If you have a very slow network connection, this overhead would have been even worse.

## Test plan

Tested locally. Confirmed that the run 2s faster.
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
