### PR TITLE
Send only incremental content updates on the document change

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,4 @@
 import com.jetbrains.plugin.structure.base.utils.isDirectory
-import org.jetbrains.changelog.markdownToHTML
-import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
@@ -14,39 +11,39 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util.EnumSet
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
+import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
 val isForceBuild = properties("forceBuild") == "true"
 val isForceAgentBuild =
-  isForceBuild ||
-          properties("forceCodyBuild") == "true" ||
-          properties("forceAgentBuild") == "true"
+    isForceBuild ||
+        properties("forceCodyBuild") == "true" ||
+        properties("forceAgentBuild") == "true"
 val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") == "true"
 
 // As https://www.jetbrains.com/updates/updates.xml adds a new "IntelliJ IDEA" YYYY.N version, add
 // it to this list.
 // Remove unsupported old versions from this list.
 val versionsOfInterest =
-  listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
+    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
 val versionsToValidate =
-  when (project.properties["validation"]?.toString()) {
-    "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
-    null,
-    "full" -> versionsOfInterest
-
-    else ->
-      error(
-        "Unexpected validation property: \"validation\" should be \"lite\" or \"full\" (default) was \"${project.properties["validation"]}\""
-      )
-  }
+    when (project.properties["validation"]?.toString()) {
+      "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
+      null,
+      "full" -> versionsOfInterest
+      else ->
+          error(
+              "Unexpected validation property: \"validation\" should be \"lite\" or \"full\" (default) was \"${project.properties["validation"]}\"")
+    }
 val skippedFailureLevels =
-  EnumSet.of(
-    FailureLevel.DEPRECATED_API_USAGES,
-    FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
-    FailureLevel.EXPERIMENTAL_API_USAGES,
-    FailureLevel.NOT_DYNAMIC
-  )!!
+    EnumSet.of(
+        FailureLevel.DEPRECATED_API_USAGES,
+        FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
+        FailureLevel.EXPERIMENTAL_API_USAGES,
+        FailureLevel.NOT_DYNAMIC)!!
 
 plugins {
   id("java")
@@ -129,23 +126,23 @@ fun copyRecursively(input: File, output: File) {
   val inputPath = input.toPath()
   val outputPath = output.toPath()
   Files.walkFileTree(
-    inputPath,
-    object : SimpleFileVisitor<java.nio.file.Path>() {
-      override fun visitFile(
-        file: java.nio.file.Path?,
-        attrs: BasicFileAttributes?
-      ): FileVisitResult {
-        if (file != null) {
-          val destination = outputPath.resolve(file.fileName)
-          if (!destination.parent.isDirectory) {
-            Files.createDirectories(destination.parent)
+      inputPath,
+      object : SimpleFileVisitor<java.nio.file.Path>() {
+        override fun visitFile(
+            file: java.nio.file.Path?,
+            attrs: BasicFileAttributes?
+        ): FileVisitResult {
+          if (file != null) {
+            val destination = outputPath.resolve(file.fileName)
+            if (!destination.parent.isDirectory) {
+              Files.createDirectories(destination.parent)
+            }
+            println("Copy ${inputPath.relativize(file)}")
+            Files.copy(file, outputPath.resolve(file.fileName), StandardCopyOption.REPLACE_EXISTING)
           }
-          println("Copy ${inputPath.relativize(file)}")
-          Files.copy(file, outputPath.resolve(file.fileName), StandardCopyOption.REPLACE_EXISTING)
+          return super.visitFile(file, attrs)
         }
-        return super.visitFile(file, attrs)
-      }
-    })
+      })
 }
 
 fun unzip(input: File, output: File, excludeMatcher: PathMatcher? = null) {
@@ -182,7 +179,7 @@ fun unzip(input: File, output: File, excludeMatcher: PathMatcher? = null) {
 }
 
 val githubArchiveCache =
-  Paths.get(System.getProperty("user.home"), ".sourcegraph", "caches", "jetbrains").toFile()
+    Paths.get(System.getProperty("user.home"), ".sourcegraph", "caches", "jetbrains").toFile()
 
 tasks {
   val codeSearchCommit = "9d86a4f7d183e980acfe5d6b6468f06aaa0d8acf"
@@ -223,7 +220,7 @@ tasks {
       workingDir(jetbrainsDir)
     }
     val buildOutput =
-      jetbrainsDir.resolve("src").resolve("main").resolve("resources").resolve("dist")
+        jetbrainsDir.resolve("src").resolve("main").resolve("resources").resolve("dist")
     copyRecursively(buildOutput, destinationDir)
     return destinationDir
   }
@@ -245,11 +242,11 @@ tasks {
     if (!fromEnvironmentVariable.isNullOrEmpty()) {
       // "~" works fine from the terminal, however it breaks IntelliJ's run configurations
       val pathString =
-        if (fromEnvironmentVariable.startsWith("~")) {
-          System.getProperty("user.home") + fromEnvironmentVariable.substring(1)
-        } else {
-          fromEnvironmentVariable
-        }
+          if (fromEnvironmentVariable.startsWith("~")) {
+            System.getProperty("user.home") + fromEnvironmentVariable.substring(1)
+          } else {
+            fromEnvironmentVariable
+          }
       return Paths.get(pathString).toFile()
     }
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
@@ -298,15 +295,14 @@ tasks {
   // should be consistently set in different local dev environments, like `./gradlew :runIde`,
   // `./gradlew test` or when testing inside IntelliJ
   val agentProperties =
-    mapOf<String, Any>(
-      "cody-agent.trace-path" to "$buildDir/sourcegraph/cody-agent-trace.json",
-      "cody-agent.directory" to buildCodyDir.parent,
-      "sourcegraph.verbose-logging" to "true",
-      "cody-agent.panic-when-out-of-sync" to
+      mapOf<String, Any>(
+          "cody-agent.trace-path" to "$buildDir/sourcegraph/cody-agent-trace.json",
+          "cody-agent.directory" to buildCodyDir.parent,
+          "sourcegraph.verbose-logging" to "true",
+          "cody-agent.panic-when-out-of-sync" to
               (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "false"),
-      "cody.autocomplete.enableFormatting" to
-              (project.property("cody.autocomplete.enableFormatting") ?: "true")
-    )
+          "cody.autocomplete.enableFormatting" to
+              (project.property("cody.autocomplete.enableFormatting") ?: "true"))
 
   fun getIdeaInstallDir(ideaVersion: String): File? {
     val gradleHome = project.gradle.gradleUserHomeDir
@@ -337,30 +333,29 @@ tasks {
     // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's
     // manifest
     pluginDescription.set(
-      projectDir
-        .resolve("README.md")
-        .readText()
-        .lines()
-        .run {
-          val start = "<!-- Plugin description -->"
-          val end = "<!-- Plugin description end -->"
+        projectDir
+            .resolve("README.md")
+            .readText()
+            .lines()
+            .run {
+              val start = "<!-- Plugin description -->"
+              val end = "<!-- Plugin description end -->"
 
-          if (!containsAll(listOf(start, end))) {
-            throw GradleException(
-              "Plugin description section not found in README.md:\n$start ... $end"
-            )
-          }
-          subList(indexOf(start) + 1, indexOf(end))
-        }
-        .joinToString("\n")
-        .run { markdownToHTML(this) },
+              if (!containsAll(listOf(start, end))) {
+                throw GradleException(
+                    "Plugin description section not found in README.md:\n$start ... $end")
+              }
+              subList(indexOf(start) + 1, indexOf(end))
+            }
+            .joinToString("\n")
+            .run { markdownToHTML(this) },
     )
   }
 
   buildPlugin {
     dependsOn(project.tasks.getByPath("buildCody"))
     from(
-      fileTree(buildCodyDir) { include("*") },
+        fileTree(buildCodyDir) { include("*") },
     ) {
       into("agent/")
     }
@@ -393,10 +388,9 @@ tasks {
     val platformRuntimeVersion = project.findProperty("platformRuntimeVersion")
     if (platformRuntimeVersion != null) {
       val ideaInstallDir =
-        getIdeaInstallDir(platformRuntimeVersion.toString())
-          ?: throw GradleException(
-            "Could not find IntelliJ install for $platformRuntimeVersion"
-          )
+          getIdeaInstallDir(platformRuntimeVersion.toString())
+              ?: throw GradleException(
+                  "Could not find IntelliJ install for $platformRuntimeVersion")
       ideDir.set(ideaInstallDir)
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,7 @@
 import com.jetbrains.plugin.structure.base.utils.isDirectory
+import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
@@ -11,39 +14,39 @@ import java.nio.file.attribute.BasicFileAttributes
 import java.util.EnumSet
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
-import org.jetbrains.changelog.markdownToHTML
-import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 fun properties(key: String) = project.findProperty(key).toString()
 
 val isForceBuild = properties("forceBuild") == "true"
 val isForceAgentBuild =
-    isForceBuild ||
-        properties("forceCodyBuild") == "true" ||
-        properties("forceAgentBuild") == "true"
+  isForceBuild ||
+          properties("forceCodyBuild") == "true" ||
+          properties("forceAgentBuild") == "true"
 val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") == "true"
 
 // As https://www.jetbrains.com/updates/updates.xml adds a new "IntelliJ IDEA" YYYY.N version, add
 // it to this list.
 // Remove unsupported old versions from this list.
 val versionsOfInterest =
-    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
+  listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
 val versionsToValidate =
-    when (project.properties["validation"]?.toString()) {
-      "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
-      null,
-      "full" -> versionsOfInterest
-      else ->
-          error(
-              "Unexpected validation property: \"validation\" should be \"lite\" or \"full\" (default) was \"${project.properties["validation"]}\"")
-    }
+  when (project.properties["validation"]?.toString()) {
+    "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
+    null,
+    "full" -> versionsOfInterest
+
+    else ->
+      error(
+        "Unexpected validation property: \"validation\" should be \"lite\" or \"full\" (default) was \"${project.properties["validation"]}\""
+      )
+  }
 val skippedFailureLevels =
-    EnumSet.of(
-        FailureLevel.DEPRECATED_API_USAGES,
-        FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
-        FailureLevel.EXPERIMENTAL_API_USAGES,
-        FailureLevel.NOT_DYNAMIC)!!
+  EnumSet.of(
+    FailureLevel.DEPRECATED_API_USAGES,
+    FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
+    FailureLevel.EXPERIMENTAL_API_USAGES,
+    FailureLevel.NOT_DYNAMIC
+  )!!
 
 plugins {
   id("java")
@@ -126,23 +129,23 @@ fun copyRecursively(input: File, output: File) {
   val inputPath = input.toPath()
   val outputPath = output.toPath()
   Files.walkFileTree(
-      inputPath,
-      object : SimpleFileVisitor<java.nio.file.Path>() {
-        override fun visitFile(
-            file: java.nio.file.Path?,
-            attrs: BasicFileAttributes?
-        ): FileVisitResult {
-          if (file != null) {
-            val destination = outputPath.resolve(file.fileName)
-            if (!destination.parent.isDirectory) {
-              Files.createDirectories(destination.parent)
-            }
-            println("Copy ${inputPath.relativize(file)}")
-            Files.copy(file, outputPath.resolve(file.fileName), StandardCopyOption.REPLACE_EXISTING)
+    inputPath,
+    object : SimpleFileVisitor<java.nio.file.Path>() {
+      override fun visitFile(
+        file: java.nio.file.Path?,
+        attrs: BasicFileAttributes?
+      ): FileVisitResult {
+        if (file != null) {
+          val destination = outputPath.resolve(file.fileName)
+          if (!destination.parent.isDirectory) {
+            Files.createDirectories(destination.parent)
           }
-          return super.visitFile(file, attrs)
+          println("Copy ${inputPath.relativize(file)}")
+          Files.copy(file, outputPath.resolve(file.fileName), StandardCopyOption.REPLACE_EXISTING)
         }
-      })
+        return super.visitFile(file, attrs)
+      }
+    })
 }
 
 fun unzip(input: File, output: File, excludeMatcher: PathMatcher? = null) {
@@ -179,7 +182,7 @@ fun unzip(input: File, output: File, excludeMatcher: PathMatcher? = null) {
 }
 
 val githubArchiveCache =
-    Paths.get(System.getProperty("user.home"), ".sourcegraph", "caches", "jetbrains").toFile()
+  Paths.get(System.getProperty("user.home"), ".sourcegraph", "caches", "jetbrains").toFile()
 
 tasks {
   val codeSearchCommit = "9d86a4f7d183e980acfe5d6b6468f06aaa0d8acf"
@@ -220,7 +223,7 @@ tasks {
       workingDir(jetbrainsDir)
     }
     val buildOutput =
-        jetbrainsDir.resolve("src").resolve("main").resolve("resources").resolve("dist")
+      jetbrainsDir.resolve("src").resolve("main").resolve("resources").resolve("dist")
     copyRecursively(buildOutput, destinationDir)
     return destinationDir
   }
@@ -242,11 +245,11 @@ tasks {
     if (!fromEnvironmentVariable.isNullOrEmpty()) {
       // "~" works fine from the terminal, however it breaks IntelliJ's run configurations
       val pathString =
-          if (fromEnvironmentVariable.startsWith("~")) {
-            System.getProperty("user.home") + fromEnvironmentVariable.substring(1)
-          } else {
-            fromEnvironmentVariable
-          }
+        if (fromEnvironmentVariable.startsWith("~")) {
+          System.getProperty("user.home") + fromEnvironmentVariable.substring(1)
+        } else {
+          fromEnvironmentVariable
+        }
       return Paths.get(pathString).toFile()
     }
     val url = "https://github.com/sourcegraph/cody/archive/$codyCommit.zip"
@@ -295,13 +298,15 @@ tasks {
   // should be consistently set in different local dev environments, like `./gradlew :runIde`,
   // `./gradlew test` or when testing inside IntelliJ
   val agentProperties =
-      mapOf<String, Any>(
-          "cody-agent.trace-path" to "$buildDir/sourcegraph/cody-agent-trace.json",
-          "cody-agent.directory" to buildCodyDir.parent,
-          "sourcegraph.verbose-logging" to "true",
-          "cody-agent.panic-when-out-of-sync" to "true",
-          "cody.autocomplete.enableFormatting" to
-              (project.property("cody.autocomplete.enableFormatting") ?: "true"))
+    mapOf<String, Any>(
+      "cody-agent.trace-path" to "$buildDir/sourcegraph/cody-agent-trace.json",
+      "cody-agent.directory" to buildCodyDir.parent,
+      "sourcegraph.verbose-logging" to "true",
+      "cody-agent.panic-when-out-of-sync" to
+              (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "false"),
+      "cody.autocomplete.enableFormatting" to
+              (project.property("cody.autocomplete.enableFormatting") ?: "true")
+    )
 
   fun getIdeaInstallDir(ideaVersion: String): File? {
     val gradleHome = project.gradle.gradleUserHomeDir
@@ -332,29 +337,30 @@ tasks {
     // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's
     // manifest
     pluginDescription.set(
-        projectDir
-            .resolve("README.md")
-            .readText()
-            .lines()
-            .run {
-              val start = "<!-- Plugin description -->"
-              val end = "<!-- Plugin description end -->"
+      projectDir
+        .resolve("README.md")
+        .readText()
+        .lines()
+        .run {
+          val start = "<!-- Plugin description -->"
+          val end = "<!-- Plugin description end -->"
 
-              if (!containsAll(listOf(start, end))) {
-                throw GradleException(
-                    "Plugin description section not found in README.md:\n$start ... $end")
-              }
-              subList(indexOf(start) + 1, indexOf(end))
-            }
-            .joinToString("\n")
-            .run { markdownToHTML(this) },
+          if (!containsAll(listOf(start, end))) {
+            throw GradleException(
+              "Plugin description section not found in README.md:\n$start ... $end"
+            )
+          }
+          subList(indexOf(start) + 1, indexOf(end))
+        }
+        .joinToString("\n")
+        .run { markdownToHTML(this) },
     )
   }
 
   buildPlugin {
     dependsOn(project.tasks.getByPath("buildCody"))
     from(
-        fileTree(buildCodyDir) { include("*") },
+      fileTree(buildCodyDir) { include("*") },
     ) {
       into("agent/")
     }
@@ -387,9 +393,10 @@ tasks {
     val platformRuntimeVersion = project.findProperty("platformRuntimeVersion")
     if (platformRuntimeVersion != null) {
       val ideaInstallDir =
-          getIdeaInstallDir(platformRuntimeVersion.toString())
-              ?: throw GradleException(
-                  "Could not find IntelliJ install for $platformRuntimeVersion")
+        getIdeaInstallDir(platformRuntimeVersion.toString())
+          ?: throw GradleException(
+            "Could not find IntelliJ install for $platformRuntimeVersion"
+          )
       ideDir.set(ideaInstallDir)
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -102,10 +102,12 @@ private constructor(
       val oldFragment = event.oldFragment.toString()
       val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
       val startPosition = editor.offsetToLogicalPosition(event.offset).codyPosition()
+      // allocate List once to avoid three unnecessary duplicate allocations
+      val oldFragmentLines = oldFragment.lines()
       val endCharacter =
-          if (oldFragment.lines().size > 1) oldFragment.lines().last().length
+          if (oldFragmentLines.size > 1) oldFragmentLines.last().length
           else startPosition.character + oldFragment.length
-      val endPosition = Position(startPosition.line + oldFragment.lines().size - 1, endCharacter)
+      val endPosition = Position(startPosition.line + oldFragmentLines.size - 1, endCharacter)
 
       return ProtocolTextDocument(
           uri = uriFor(file),

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -4,11 +4,12 @@ import com.intellij.codeInsight.codeVision.ui.popup.layouter.bottom
 import com.intellij.codeInsight.codeVision.ui.popup.layouter.right
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.LogicalPosition
+import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.vfs.VirtualFile
 import java.awt.Point
 import java.nio.file.FileSystems
-import java.util.*
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 
@@ -94,6 +95,25 @@ private constructor(
       val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
       return ProtocolTextDocument(
           uri = uriFor(file), selection = getSelection(editor), testing = getTestingParams(editor))
+    }
+
+    @JvmStatic
+    fun fromEditorForDocumentEvent(editor: Editor, event: DocumentEvent): ProtocolTextDocument? {
+      val oldFragment = event.oldFragment.toString()
+      val file = FileDocumentManager.getInstance().getFile(editor.document) ?: return null
+      val startPosition = editor.offsetToLogicalPosition(event.offset).codyPosition()
+      val endCharacter =
+          if (oldFragment.lines().size > 1) oldFragment.lines().last().length
+          else startPosition.character + oldFragment.length
+      val endPosition = Position(startPosition.line + oldFragment.lines().size - 1, endCharacter)
+
+      return ProtocolTextDocument(
+          uri = uriFor(file),
+          content = null,
+          contentChanges =
+              listOf(
+                  ProtocolTextDocumentContentChangeEvent(
+                      Range(startPosition, endPosition), event.newFragment.toString())))
     }
 
     @JvmStatic

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -25,6 +25,7 @@ class CodyCaretListener(val project: Project) : CaretListener {
 
     ProtocolTextDocument.fromEditorWithOffsetSelection(e.editor, e.newPosition)?.let { textDocument
       ->
+      EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocumentDidChange(textDocument)
       }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -56,7 +56,8 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
     // This is esp. important with incremental document synchronization where the server goes out
     // of sync if it doesn't get all changes.
 
-    ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
+    ProtocolTextDocument.fromEditorForDocumentEvent(editor, event)?.let { textDocument ->
+      EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent ->
         agent.server.textDocumentDidChange(textDocument)
 
@@ -67,7 +68,6 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
           agent.server.autocompleteClearLastCandidate()
         }
       }
-
       val changeOffset = event.offset + event.newLength
       if (editor.caretModel.offset == changeOffset) {
         CodyAutocompleteManager.instance.triggerAutocomplete(

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -19,6 +19,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
     try {
       source.selectedTextEditor?.let { editor ->
         val protocolTextFile = fromVirtualFile(editor, file)
+        EditorChangesBus.documentChanged(editor.project, protocolTextFile)
         withAgent(source.project) { agent: CodyAgent ->
           agent.server.textDocumentDidOpen(protocolTextFile)
         }
@@ -32,6 +33,7 @@ class CodyFileEditorListener : FileEditorManagerListener {
     try {
       source.selectedTextEditor?.let { editor ->
         val protocolTextFile = fromVirtualFile(editor, file)
+        EditorChangesBus.documentChanged(editor.project, protocolTextFile)
         withAgent(source.project) { agent: CodyAgent ->
           agent.server.textDocumentDidClose(protocolTextFile)
         }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
@@ -17,6 +17,7 @@ class CodyFocusChangeListener(val project: Project) : FocusChangeListener {
     CodyAgentCodebase.getInstance(project).onFileOpened(file)
 
     ProtocolTextDocument.fromEditor(editor)?.let { textDocument ->
+      EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocumentDidFocus(textDocument)
       }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -9,12 +9,14 @@ import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.config.ConfigUtil
 
 class CodySelectionListener(val project: Project) : SelectionListener {
+
   override fun selectionChanged(e: SelectionEvent) {
     if (!ConfigUtil.isCodyEnabled() || e.editor == null) {
       return
     }
 
     ProtocolTextDocument.fromEditorWithRangeSelection(e.editor)?.let { textDocument ->
+      EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent ->
         agent.server.textDocumentDidChange(textDocument)
       }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/EditorChangesBus.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/EditorChangesBus.kt
@@ -1,0 +1,18 @@
+package com.sourcegraph.cody.listeners
+
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
+
+typealias EditorChangesListener = (project: Project?, textDocument: ProtocolTextDocument) -> Unit
+
+object EditorChangesBus {
+  @Volatile var listeners: List<EditorChangesListener> = listOf()
+
+  fun addListener(notify: EditorChangesListener) {
+    listeners = listeners + notify
+  }
+
+  fun documentChanged(project: Project?, textDocument: ProtocolTextDocument) {
+    listeners.forEach { it(project, textDocument) }
+  }
+}

--- a/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
@@ -1,11 +1,13 @@
 package com.sourcegraph.cody.agent.protocol
 
+import com.intellij.openapi.application.WriteAction
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.sourcegraph.cody.listeners.EditorChangesBus
 import junit.framework.TestCase
 
 class ProtocolTextDocumentTest : BasePlatformTestCase() {
-  private val content = "line 1\nline 2\nline 3\n"
+  private val content = "Start line 1\nline 2\nline 3\nline 4\nline 5 End"
   private val filename = "test.txt"
   private val file: VirtualFile by lazy { myFixture.createFile(filename, content) }
 
@@ -53,6 +55,147 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
         ProtocolTextDocument.fromVirtualFile(myFixture.editor, emptyFile).selection)
   }
 
-  // TODO: assert behavior of cody selection listener
-  // TODO: reproduce caret events
+  fun test_selectionListener() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    myFixture.editor.testing_selectSubstring("line 1\nl")
+    assertEquals(
+        myFixture.editor.selectionModel.selectedText,
+        myFixture.editor.testing_substring(lastTextDocument!!.selection!!))
+  }
+
+  fun test_caretListener() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    myFixture.editor.caretModel.moveToOffset(5)
+    assertEquals(Range(Position(0, 5), Position(0, 5)), lastTextDocument!!.selection!!)
+  }
+
+  fun test_openListener() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    myFixture.openFileInEditor(myFixture.createFile("newFile.txt", ""))
+
+    assertEquals("file:///src/newFile.txt", lastTextDocument!!.uri)
+  }
+
+  fun test_documentListener_appendAndPrepend() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    fun appendOrPrepend(additionalContext: String, isAppend: Boolean) {
+      val currentContent = myFixture.editor.document.text
+      val newContent =
+          if (isAppend) "${currentContent}$additionalContext"
+          else "$additionalContext$currentContent"
+      WriteAction.run<RuntimeException> { file.setBinaryContent(newContent.toByteArray()) }
+
+      assertEquals(null, lastTextDocument!!.content)
+      assertEquals(1, lastTextDocument!!.contentChanges!!.size)
+      assertEquals(additionalContext, lastTextDocument!!.contentChanges!!.first().text)
+
+      val offset = if (isAppend) currentContent.length else 0
+      assertEquals(
+          Range(
+              Position.fromOffset(myFixture.editor.document, offset),
+              Position.fromOffset(myFixture.editor.document, offset),
+          ),
+          lastTextDocument!!.contentChanges!!.first().range)
+    }
+
+    appendOrPrepend("appended", isAppend = true)
+    appendOrPrepend("\nand moooore \n \n *** \n", isAppend = true)
+    appendOrPrepend("prepended", isAppend = false)
+    appendOrPrepend("and of course\nmore   \n \n \n #$% \n", isAppend = false)
+  }
+
+  fun test_documentListener_remove() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    fun remove(removedContent: String) {
+      val newContent = myFixture.editor.document.text.replace(removedContent, "")
+
+      val removalStartOffset = myFixture.editor.document.text.indexOf(removedContent)
+      val removalEndOffset = removalStartOffset + removedContent.length
+      val removalStartPosition = Position.fromOffset(myFixture.editor.document, removalStartOffset)
+      val removalEndPosition = Position.fromOffset(myFixture.editor.document, removalEndOffset)
+
+      WriteAction.run<RuntimeException> { file.setBinaryContent(newContent.toByteArray()) }
+
+      assertEquals(null, lastTextDocument!!.content)
+      assertEquals(1, lastTextDocument!!.contentChanges!!.size)
+      assertEquals("", lastTextDocument!!.contentChanges!!.first().text)
+      assertEquals(
+          Range(removalStartPosition, removalEndPosition),
+          lastTextDocument!!.contentChanges!!.first().range)
+    }
+
+    remove("e 3")
+    remove("1\nline 2\nli")
+    remove("4\nline")
+    remove(" End")
+    remove("Start ")
+  }
+
+  fun test_documentListener_replace() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    fun replace(oldSubstring: String, newSubstring: String) {
+      val currentContent = myFixture.editor.document.text
+      val newContent = currentContent.replace(oldSubstring, newSubstring)
+
+      val startOffset = currentContent.indexOf(oldSubstring)
+      val endOffset = startOffset + oldSubstring.length
+      val startPosition = Position.fromOffset(myFixture.editor.document, startOffset)
+      val endPosition = Position.fromOffset(myFixture.editor.document, endOffset)
+
+      WriteAction.run<RuntimeException> { file.setBinaryContent(newContent.toByteArray()) }
+
+      assertEquals(null, lastTextDocument!!.content)
+      assertEquals(1, lastTextDocument!!.contentChanges!!.size)
+      assertEquals(newSubstring, lastTextDocument!!.contentChanges!!.first().text)
+      assertEquals(
+          Range(startPosition, endPosition), lastTextDocument!!.contentChanges!!.first().range)
+    }
+
+    replace("e 3", "sdf")
+    replace("1\nline 2\nli", "ala\n")
+    replace("4\nline", "random")
+    replace(" End", "\n\n\naa\n")
+    replace("Start ", "")
+  }
+
+  fun test_documentListener_insert() {
+    var lastTextDocument: ProtocolTextDocument? = null
+    EditorChangesBus.addListener { _, textDocument -> lastTextDocument = textDocument }
+
+    fun insert(afterSubstring: String, insertSubstring: String) {
+      val currentContent = myFixture.editor.document.text
+      val startOffset = currentContent.indexOf(afterSubstring)
+      val endOffset = startOffset
+      val startPosition = Position.fromOffset(myFixture.editor.document, startOffset)
+      val endPosition = Position.fromOffset(myFixture.editor.document, endOffset)
+
+      val newContent =
+          StringBuilder(currentContent).apply { insert(startOffset, insertSubstring) }.toString()
+      WriteAction.run<RuntimeException> { file.setBinaryContent(newContent.toByteArray()) }
+
+      assertEquals(null, lastTextDocument!!.content)
+      assertEquals(1, lastTextDocument!!.contentChanges!!.size)
+      assertEquals(insertSubstring, lastTextDocument!!.contentChanges!!.first().text)
+      assertEquals(
+          Range(startPosition, endPosition), lastTextDocument!!.contentChanges!!.first().range)
+    }
+
+    insert("ne 3", "yes")
+    insert("1\nline 2\n", "oooooo\n")
+    insert("4\nline ", "\n\n\n\n\n\n\n")
+    insert(" End", "this is the \n end\n\n\n\n")
+    insert("Start ", "@@@\n\n")
+  }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/agent/protocol/extensions.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/protocol/extensions.kt
@@ -21,3 +21,11 @@ fun Editor.testing_substring(range: Range): String {
   return this.document.text.substring(
       this.testing_offset(range.start), this.testing_offset(range.end))
 }
+
+fun Editor.testing_range(substring: String): Range {
+  val startOffset = this.document.text.indexOf(substring)
+  val endOffset = this.document.text.indexOf(substring) + substring.length
+  return Range(
+      Position.fromOffset(this.document, startOffset),
+      Position.fromOffset(this.document, endOffset))
+}


### PR DESCRIPTION
## Changes

Instead of sending full content we are now sending only modified fragments.
That should:
* decrease amount of traffic
* improve accuracy of the diffs (previously we were calculating them on the agent side, which sometimes cannot be guaranteed to be correct)

## Test plan
- Manually tested all inline edit and cody completion features
- Ran unit tests