### PR TITLE
Panic mode: bug fixes

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFileEditorListener.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.sourcegraph.cody.agent.CodyAgent
@@ -17,12 +18,13 @@ class CodyFileEditorListener : FileEditorManagerListener {
 
   override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
     try {
-      source.selectedTextEditor?.let { editor ->
-        val protocolTextFile = fromVirtualFile(editor, file)
-        EditorChangesBus.documentChanged(editor.project, protocolTextFile)
-        withAgent(source.project) { agent: CodyAgent ->
-          agent.server.textDocumentDidOpen(protocolTextFile)
-        }
+      val textEditor = source.getSelectedEditor(file) as? TextEditor ?: return
+      val editor = textEditor.editor
+      val protocolTextFile = fromVirtualFile(editor, file)
+      EditorChangesBus.documentChanged(editor.project, protocolTextFile)
+
+      withAgent(source.project) { agent: CodyAgent ->
+        agent.server.textDocumentDidOpen(protocolTextFile)
       }
     } catch (x: Exception) {
       logger.warn("Error in fileOpened method for file: ${file.path}", x)
@@ -46,6 +48,8 @@ class CodyFileEditorListener : FileEditorManagerListener {
   companion object {
     private val logger = Logger.getInstance(CodyFileEditorListener::class.java)
 
+    // When IDEA starts for the first time, we send duplicate `textDocument/didOpen` notifications
+    // with `fileOpened` above. This function is only needed when we restart the agent process.
     fun registerAllOpenedFiles(project: Project, codyAgent: CodyAgent) {
 
       ApplicationManager.getApplication().invokeLater {

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -10,18 +10,18 @@ import com.sourcegraph.config.ConfigUtil
 
 class CodySelectionListener(val project: Project) : SelectionListener {
 
-  override fun selectionChanged(e: SelectionEvent) {
-    if (!ConfigUtil.isCodyEnabled() || e.editor == null) {
+  override fun selectionChanged(event: SelectionEvent) {
+    if (!ConfigUtil.isCodyEnabled() || event.editor == null) {
       return
     }
 
-    ProtocolTextDocument.fromEditorWithRangeSelection(e.editor)?.let { textDocument ->
+    ProtocolTextDocument.fromEditorWithRangeSelection(event.editor, event)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent ->
         agent.server.textDocumentDidChange(textDocument)
       }
     }
 
-    CodyAutocompleteManager.instance.clearAutocompleteSuggestions(e.editor)
+    CodyAutocompleteManager.instance.clearAutocompleteSuggestions(event.editor)
   }
 }


### PR DESCRIPTION
This commit addresses three issues with document synchronization:

- Panic mode now only sends properties that are guaranteed to be correct. When paired with the changes in https://github.com/sourcegraph/cody/pull/4291, this eliminates false-positive panics. Previously, the submitted information and "source of truth" information could already by out-of-sync before it even left the JetBrains client due to the multithreaded nature of IDEA.
- Selection change handler now computes the selection from `SelectionEvent` instead of `Editor` to eliminate the risk that the editor's selection model changes in another thread as we're constructing parameters for textDocument/didChange.
- File open handlers now use an `Editor` with the same URI as the provided `VirtualFile`. Previously, we used `selectedTextEditor` that could have a different URI.

## Test plan

Manually tested locally. I can still reproduce one panic with the following minimized changes

https://github.com/sourcegraph/jetbrains/assets/1408093/18ceff9d-b919-4cd4-8812-88538c5e5461



<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
