### PR TITLE
FixupSession: handle exceptions during edit session

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -102,30 +102,33 @@ abstract class FixupSession(
     CodyAgentService.withAgent(project) { agent ->
       workAroundUninitializedCodebase()
 
-      fixupService.startNewSession(this)
+      try {
+        fixupService.startNewSession(this)
+        // Spend a turn to get folding ranges before showing lenses.
+        ensureSelectionRange(agent, textFile)
+        showWorkingGroup()
 
-      // Spend a turn to get folding ranges before showing lenses.
-      ensureSelectionRange(agent, textFile)
-
-      showWorkingGroup()
-
-      makeEditingRequest(agent)
-          .handle { result, error ->
-            if (error != null || result == null) {
-              showErrorGroup("Error while generating doc string: $error")
-            } else {
-              selectionRange = adjustToDocumentRange(result.selectionRange)
+        makeEditingRequest(agent)
+            .handle { result, error ->
+              if (error != null || result == null) {
+                showErrorGroup("Error while generating doc string: $error")
+              } else {
+                selectionRange = adjustToDocumentRange(result.selectionRange)
+              }
+              null
             }
-            null
-          }
-          .exceptionally { error: Throwable? ->
-            if (!(error is CancellationException || error is CompletionException)) {
-              showErrorGroup("Error while generating code: ${error?.localizedMessage}")
+            .exceptionally { error: Throwable? ->
+              if (!(error is CancellationException || error is CompletionException)) {
+                showErrorGroup("Error while generating code: ${error?.localizedMessage}")
+              }
+              cancel()
+              null
             }
-            cancel()
-            null
-          }
-          .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+            .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+      } catch (e: Exception) {
+        showErrorGroup("Edit failed: ${e.localizedMessage}")
+        cancel()
+      }
     }
   }
 
@@ -144,10 +147,17 @@ abstract class FixupSession(
   private fun ensureSelectionRange(agent: CodyAgent, textFile: ProtocolTextDocument) {
     val selection = textFile.selection ?: return
     selectionRange = selection.toRangeMarker(document, true)
-    agent.server
-        .getFoldingRanges(GetFoldingRangeParams(uri = textFile.uri, range = selection))
-        .thenApply { result -> selectionRange = result.range.toRangeMarker(document, true) }
-        .get()
+
+    try {
+      val result =
+          agent
+              .server
+              .getFoldingRanges(GetFoldingRangeParams(uri = textFile.uri, range = selection))
+              .get()
+      selectionRange = result.range.toRangeMarker(document, true)
+    } catch (e: Exception) {
+      logger.warn("Error getting folding range", e)
+    }
   }
 
   fun update(task: EditTask) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -150,8 +150,7 @@ abstract class FixupSession(
 
     try {
       val result =
-          agent
-              .server
+          agent.server
               .getFoldingRanges(GetFoldingRangeParams(uri = textFile.uri, range = selection))
               .get()
       selectionRange = result.range.toRangeMarker(document, true)


### PR DESCRIPTION
CLOSE https://github.com/sourcegraph/cody-issues/issues/355

- Wrap the entire edit session in a try-catch block to handle any exceptions that may occur
- Log a user-friendly error message when an exception is caught, instead of just canceling the session
- Improve the error handling in the `ensureSelectionRange` function by catching and logging any exceptions that occur when getting the folding ranges without blocking the session from starting
- Add a new error message when an exception occurs during the editing action

The behavior of the FixupSession class has changed to better handle exceptions during the edit session

## Test plan

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->


https://github.com/sourcegraph/jetbrains/assets/68532117/fb83cf15-8a5c-447e-add8-8f1a753ccf25


1. Open a repository in a JetBrains IDE where folding range is not available (e.g Typescript)
2. Place your cursor inside a function
3. Execute an edit command (edit / doc / test)
4. Verify Cody is able to complete the request
  - Before: request will fail and you will not be able to run any edit commands until restart


