### PR TITLE
Fix mouse cursor when it leaves a lens action button

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -88,8 +88,6 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
 
   var inlay: Inlay<EditorCustomElementRenderer>? = null
 
-  private var prevCursor: Cursor? = null
-
   private var lastComputedIndent = RECOMPUTE
 
   var isInWorkingGroup = false
@@ -314,26 +312,15 @@ class LensWidgetGroup(val session: FixupSession, parentComponent: Editor) :
     val lastWidget = lastHoveredWidget
 
     if (widget is LensAction) {
-      if (prevCursor != Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)) {
-        prevCursor = e.editor.contentComponent.cursor
-      }
       e.editor.contentComponent.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
     } else {
-      if (prevCursor != null) {
-        e.editor.contentComponent.cursor = prevCursor!!
-        prevCursor = null
-      }
+      e.editor.contentComponent.cursor = Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)
     }
 
     // Check if the mouse has moved from one widget to another or from/to outside.
     if (widget != lastWidget) {
       lastWidget?.onMouseExit(e)
       lastHoveredWidget = widget // null if now outside
-      if (widget is LensAction) {
-        if (prevCursor != Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)) {
-          e.editor.contentComponent.cursor = Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR)
-        }
-      }
       widget?.onMouseEnter(e)
       inlay?.update() // force repaint
     }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/widget/LensWidgetGroup.kt
@@ -26,7 +26,6 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.Range
 import com.sourcegraph.cody.edit.sessions.FixupSession
-import org.jetbrains.annotations.NotNull
 import java.awt.Cursor
 import java.awt.Font
 import java.awt.FontMetrics
@@ -38,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Supplier
 import kotlin.math.roundToInt
+import org.jetbrains.annotations.NotNull
 
 operator fun Point.component1() = this.x
 


### PR DESCRIPTION
The mouse cursor turns to a hand when over a `LensAction` button-shaped widget, since it acts like clickable link. It was not restoring properly when the cursor left the button bounds, remaining as a hand. It also had overcomplicated logic. This PR addresses both of those issues.

## Test plan

Manually tested.