### PR TITLE
Add some user facing notifications

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyStartingNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyStartingNotification.kt
@@ -1,0 +1,42 @@
+package com.sourcegraph.cody.agent
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupListener
+import com.intellij.openapi.ui.popup.LightweightWindowEvent
+import com.sourcegraph.Icons
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+
+
+class CodyStartingNotification :
+    Notification(
+        NotificationGroups.SOURCEGRAPH_ERRORS,
+        CodyBundle.getString("notification.general.cody-not-running.title"),
+        CodyBundle.getString("notification.general.cody-not-running.detail"),
+        NotificationType.INFORMATION),
+    NotificationFullContent {
+
+    init {
+        icon = Icons.CodyLogo
+    }
+
+    override fun notify(project: Project?) {
+        // only show if not already being shown
+        if (instance == null) {
+            instance = this
+            super.notify(project)
+            balloon?.addListener(object : JBPopupListener {
+                override fun onClosed(event: LightweightWindowEvent) {
+                    instance = null
+                }
+            })
+        }
+    }
+
+    companion object {
+        var instance: CodyStartingNotification? = null
+    }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyStartingNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyStartingNotification.kt
@@ -10,7 +10,6 @@ import com.sourcegraph.Icons
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
 
-
 class CodyStartingNotification :
     Notification(
         NotificationGroups.SOURCEGRAPH_ERRORS,
@@ -19,24 +18,25 @@ class CodyStartingNotification :
         NotificationType.INFORMATION),
     NotificationFullContent {
 
-    init {
-        icon = Icons.CodyLogo
-    }
+  init {
+    icon = Icons.CodyLogo
+  }
 
-    override fun notify(project: Project?) {
-        // only show if not already being shown
-        if (instance == null) {
-            instance = this
-            super.notify(project)
-            balloon?.addListener(object : JBPopupListener {
-                override fun onClosed(event: LightweightWindowEvent) {
-                    instance = null
-                }
-            })
-        }
+  override fun notify(project: Project?) {
+    // only show if not already being shown
+    if (instance == null) {
+      instance = this
+      super.notify(project)
+      balloon?.addListener(
+          object : JBPopupListener {
+            override fun onClosed(event: LightweightWindowEvent) {
+              instance = null
+            }
+          })
     }
+  }
 
-    companion object {
-        var instance: CodyStartingNotification? = null
-    }
+  companion object {
+    var instance: CodyStartingNotification? = null
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/EditingNotAvailableNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/EditingNotAvailableNotification.kt
@@ -1,13 +1,11 @@
 package com.sourcegraph.cody.agent
 
-
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
 import com.sourcegraph.Icons
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
-
 
 class EditingNotAvailableNotification :
     Notification(
@@ -17,7 +15,7 @@ class EditingNotAvailableNotification :
         NotificationType.WARNING),
     NotificationFullContent {
 
-    init {
-        icon = Icons.RepoIgnored
-    }
+  init {
+    icon = Icons.RepoIgnored
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/EditingNotAvailableNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/EditingNotAvailableNotification.kt
@@ -1,0 +1,23 @@
+package com.sourcegraph.cody.agent
+
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.sourcegraph.Icons
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+
+
+class EditingNotAvailableNotification :
+    Notification(
+        NotificationGroups.SOURCEGRAPH_ERRORS,
+        CodyBundle.getString("notifications.edits.editing-not-available.title"),
+        CodyBundle.getString("notifications.edits.editing-not-available.detail"),
+        NotificationType.WARNING),
+    NotificationFullContent {
+
+    init {
+        icon = Icons.RepoIgnored
+    }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -10,7 +10,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.agent.CodyStartingNotification
-import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.EditingNotAvailableNotification
 import com.sourcegraph.cody.edit.sessions.DocumentCodeSession
 import com.sourcegraph.cody.edit.sessions.FixupSession
@@ -71,7 +70,7 @@ class FixupService(val project: Project) : Disposable {
       logger.warn("Edit code invoked when Cody not enabled")
       return false
     }
-    if(CodyStatusService.getCurrentStatus() == CodyStatus.CodyAgentNotRunning) {
+    if (CodyStatusService.getCurrentStatus() == CodyStatus.CodyAgentNotRunning) {
       runInEdt { CodyStartingNotification().notify(project) }
       logger.warn("The agent is not connected")
       return false

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -9,12 +9,17 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.sourcegraph.cody.agent.CodyStartingNotification
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.EditingNotAvailableNotification
 import com.sourcegraph.cody.edit.sessions.DocumentCodeSession
 import com.sourcegraph.cody.edit.sessions.FixupSession
 import com.sourcegraph.cody.edit.sessions.TestCodeSession
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.ignore.IgnorePolicy
+import com.sourcegraph.cody.statusbar.CodyStatus
+import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.config.ConfigUtil.isCodyEnabled
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.concurrent.atomic.AtomicReference
@@ -66,7 +71,13 @@ class FixupService(val project: Project) : Disposable {
       logger.warn("Edit code invoked when Cody not enabled")
       return false
     }
+    if(CodyStatusService.getCurrentStatus() == CodyStatus.CodyAgentNotRunning) {
+      runInEdt { CodyStartingNotification().notify(project) }
+      logger.warn("The agent is not connected")
+      return false
+    }
     if (!CodyEditorUtil.isEditorValidForAutocomplete(editor)) {
+      runInEdt { EditingNotAvailableNotification().notify(project) }
       logger.warn("Edit code invoked when editing not available")
       return false
     }

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -188,6 +188,12 @@ action.cody.triggerAutocomplete.text=Autocomplete
 gotit.autocomplete.header=Your first Cody Autocomplete
 gotit.autocomplete.message=This is how Cody displays autocomplete suggestions.<br>Press <b>{0}</b> to insert it into the editor.<br>Press <b>{1}</b> and <b>{2}</b> to cycle through alternatives.
 
+# User Friendly Error Notifications
+notification.general.cody-not-running.title=Cody is starting...
+notification.general.cody-not-running.detail=Please wait a few seconds or check the Cody logs for errors.
+notifications.edits.editing-not-available.title=Cody can't edit this file
+notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
+
 # Cody Ignore
 ignore.action-in-ignored-file.detail=This file has been ignored by an admin. Autocomplete, commands, and other Cody features are disabled.
 ignore.action-in-ignored-file.learn-more-cta=Learn about Cody Ignore


### PR DESCRIPTION
Fixes [#359](https://github.com/sourcegraph/cody-issues/issues/359)

![CleanShot 2024-05-26 at 02 02 02@2x](https://github.com/sourcegraph/jetbrains/assets/3949285/cf4c89d6-d39c-40fd-93a9-9963967de704)

Could be made nicer by automatically removing the notification when the agent starts...but that seems overkill at this point.

## Test plan
- Manually verified that if the agent isn't running we show the notification