### PR TITLE
BROKEN - DO NOT MERGE: added a simple 30ms debounce to textDocument/didChange

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/TextChangeDebouncer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/TextChangeDebouncer.kt
@@ -1,0 +1,61 @@
+package com.sourcegraph.cody.agent
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+class TextChangeDebouncer(val project: Project) {
+
+  private val scheduler = Executors.newScheduledThreadPool(1)
+  private var lastUri: String? = null
+  private var scheduledFuture: ScheduledFuture<*>? = null
+  private val delay = DEBOUNCE_INTERVAL
+  private val timeUnit = TimeUnit.MILLISECONDS
+
+  @Synchronized
+  fun debounce(document: ProtocolTextDocument, forceSkipDebounce: Boolean = false) {
+    // If URI has changed (i.e. switched tabs or documents), send the first one immediately.
+    if (BYPASS_DEBOUNCE || forceSkipDebounce || document.uri != lastUri) {
+      scheduledFuture?.cancel(false)
+      sendTextDocumentDidChange(document)
+      lastUri = document.uri
+    } else {
+      // New change arrived, so restart debounce timer.
+      scheduledFuture?.cancel(false)
+      scheduledFuture = scheduler.schedule({ sendTextDocumentDidChange(document) }, delay, timeUnit)
+    }
+  }
+
+  private fun sendTextDocumentDidChange(document: ProtocolTextDocument) {
+    try {
+      CodyAgentService.withAgent(project) { agent -> agent.server.textDocumentDidChange(document) }
+    } catch (x: Exception) {
+      logger.warn("Error in sendTextDocumentDidChange method for file: ${document.uri}", x)
+    }
+  }
+
+  companion object {
+    private val logger = Logger.getInstance(CodyAgent::class.java)
+
+    // Here are some empirical numbers I found for the performance, by doing this
+    // set of steps for different debounce intervals, all in the same fresh file:
+    // - make a large selection quickly by dragging the mouse
+    // - hammer on the keys to remove the selected text and fill about 80 columns
+    // - hold the arrow key down to move the caret about 30 lines as fast as it goes
+    //
+    // Results for how many times sendTextDocumentDidChange above is called,
+    // averaging 2 test runs for each config:
+    //   0ms debounce: 270 times
+    //   5ms debounce: 190 times
+    //  10ms debounce: 150 times
+    //  30ms debounce: 40 times -- roughly 33 calls per second. Good enough.
+    private const val DEBOUNCE_INTERVAL = 30L
+
+    // A flag for turning debounce entirely off, for comparing performance, debugging, etc.
+    private val BYPASS_DEBOUNCE: Boolean =
+        System.getProperty("cody.bypassTextChangeDebounce") == "true"
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -4,7 +4,6 @@ import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
 import com.intellij.openapi.project.Project
-import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
@@ -26,9 +25,7 @@ class CodyCaretListener(val project: Project) : CaretListener {
     ProtocolTextDocument.fromEditorWithOffsetSelection(e.editor, e.newPosition)?.let { textDocument
       ->
       EditorChangesBus.documentChanged(project, textDocument)
-      CodyAgentService.withAgent(project) { agent: CodyAgent ->
-        agent.server.textDocumentDidChange(textDocument)
-      }
+      CodyAgentService.getInstance(project).sendTextDocumentDidChange(textDocument)
     }
 
     CodyAutocompleteManager.instance.clearAutocompleteSuggestions(e.editor)

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -58,9 +58,9 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
 
     ProtocolTextDocument.fromEditorForDocumentEvent(editor, event)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
-      CodyAgentService.withAgent(project) { agent ->
-        agent.server.textDocumentDidChange(textDocument)
+      CodyAgentService.getInstance(project).sendTextDocumentDidChange(textDocument)
 
+      CodyAgentService.withAgent(project) { agent ->
         // This notification must be sent after the above, see tracker comment for more
         // details.
         AcceptCodyAutocompleteAction.tracker.getAndSet(null)?.let { completionID ->

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -17,9 +17,7 @@ class CodySelectionListener(val project: Project) : SelectionListener {
 
     ProtocolTextDocument.fromEditorWithRangeSelection(event.editor, event)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
-      CodyAgentService.withAgent(project) { agent ->
-        agent.server.textDocumentDidChange(textDocument)
-      }
+      CodyAgentService.getInstance(project).sendTextDocumentDidChange(textDocument)
     }
 
     CodyAutocompleteManager.instance.clearAutocompleteSuggestions(event.editor)


### PR DESCRIPTION
This commit introduces document sync panics, as far as I can tell. Would love someone else's eyes on it.

Desync bugs on this branch are easiest to trigger by messing with the selection while edit tasks are in progress until it breaks.

Putting it up so if someone has free time & inclination they can take a peek.

## Test plan

Manually tested so far. 