### PR TITLE
Display completions with non-boring Unicode code points correctly, especially on Windows

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
@@ -3,12 +3,9 @@ package com.sourcegraph.cody.autocomplete.render
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.ui.JBColor
 import com.sourcegraph.cody.autocomplete.render.InlayModelUtil.getAllInlaysForEditor
-import java.awt.Font
-import kotlin.math.ceil
 
 object AutocompleteRenderUtil {
   @JvmStatic

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/AutocompleteRenderUtil.kt
@@ -12,16 +12,6 @@ import kotlin.math.ceil
 
 object AutocompleteRenderUtil {
   @JvmStatic
-  fun fontYOffset(font: Font, editor: Editor): Double {
-    val metrics =
-        FontInfo.getFontMetrics(font, FontInfo.getFontRenderContext(editor.contentComponent))
-    val fontBaseline =
-        font.createGlyphVector(metrics.fontRenderContext, "Hello world!").visualBounds.height
-    val linePadding = (editor.lineHeight - fontBaseline) / 2
-    return ceil(fontBaseline + linePadding)
-  }
-
-  @JvmStatic
   fun getTextAttributesForEditor(editor: Editor): TextAttributes =
       try {
         editor.colorsScheme.getAttributes(

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteBlockElementRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteBlockElementRenderer.kt
@@ -34,10 +34,11 @@ class CodyAutocompleteBlockElementRenderer(
       targetRegion: Rectangle,
       textAttributes: TextAttributes
   ) {
-    g.font = font
+      val fontInfo = fontInfoForText(text)
+    g.font = fontInfo.font
     g.color = themeAttributes.foregroundColor
     val x = targetRegion.x
-    val baseYOffset = fontYOffset()
+    val baseYOffset = fontYOffset(fontInfo).toInt()
     for ((i, line) in text.lines().withIndex()) {
       val y = targetRegion.y + baseYOffset + i * editor.lineHeight
       g.drawString(line, x, y)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteBlockElementRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteBlockElementRenderer.kt
@@ -34,7 +34,7 @@ class CodyAutocompleteBlockElementRenderer(
       targetRegion: Rectangle,
       textAttributes: TextAttributes
   ) {
-      val fontInfo = fontInfoForText(text)
+    val fontInfo = fontInfoForText(text)
     g.font = fontInfo.font
     g.color = themeAttributes.foregroundColor
     val x = targetRegion.x

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.kt
@@ -4,13 +4,18 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.colors.EditorFontType
+import com.intellij.openapi.editor.colors.impl.FontPreferencesImpl
+import com.intellij.openapi.editor.impl.ComplementaryFontsRegistry
 import com.intellij.openapi.editor.impl.EditorImpl
+import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.sourcegraph.cody.agent.protocol.AutocompleteItem
 import com.sourcegraph.config.ConfigUtil.getCustomAutocompleteColor
 import com.sourcegraph.config.ConfigUtil.isCustomAutocompleteColorEnabled
 import java.awt.Font
+import java.awt.font.FontRenderContext
 import java.util.function.Supplier
+import kotlin.math.ceil
 
 abstract class CodyAutocompleteElementRenderer(
     val text: String,
@@ -32,16 +37,19 @@ abstract class CodyAutocompleteElementRenderer(
         else textAttributesFallback.get()
   }
 
-  override fun calcWidthInPixels(inlay: Inlay<*>): Int {
-    val editor = inlay.editor as EditorImpl
-    return editor.getFontMetrics(Font.PLAIN).stringWidth(text)
-  }
+  override fun calcWidthInPixels(inlay: Inlay<*>): Int = fontInfoForText(text).fontMetrics().stringWidth(text)
 
-  protected val font: Font
-    get() {
-      val editorFont = editor.colorsScheme.getFont(EditorFontType.PLAIN)
-      return editorFont.deriveFont(Font.ITALIC) ?: editorFont
+  protected fun fontInfoForText(text: String): FontInfo
+    {
+        val preferences = FontPreferencesImpl()
+        editor.colorsScheme.fontPreferences.copyTo(preferences)
+        return ComplementaryFontsRegistry.getFontAbleToDisplay(text, 0, text.length, Font.ITALIC, preferences, FontInfo.getFontRenderContext(editor.contentComponent))
     }
 
-  protected fun fontYOffset(): Int = AutocompleteRenderUtil.fontYOffset(font, editor).toInt()
+    fun fontYOffset(fontInfo: FontInfo): Double {
+        val fontBaseline =
+            fontInfo.font.createGlyphVector(fontInfo.fontRenderContext, "Hello world!").visualBounds.height
+        val linePadding = (editor.lineHeight - fontBaseline) / 2
+        return ceil(fontBaseline + linePadding)
+    }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteElementRenderer.kt
@@ -3,17 +3,14 @@ package com.sourcegraph.cody.autocomplete.render
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.EditorCustomElementRenderer
 import com.intellij.openapi.editor.Inlay
-import com.intellij.openapi.editor.colors.EditorFontType
 import com.intellij.openapi.editor.colors.impl.FontPreferencesImpl
 import com.intellij.openapi.editor.impl.ComplementaryFontsRegistry
-import com.intellij.openapi.editor.impl.EditorImpl
 import com.intellij.openapi.editor.impl.FontInfo
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.sourcegraph.cody.agent.protocol.AutocompleteItem
 import com.sourcegraph.config.ConfigUtil.getCustomAutocompleteColor
 import com.sourcegraph.config.ConfigUtil.isCustomAutocompleteColorEnabled
 import java.awt.Font
-import java.awt.font.FontRenderContext
 import java.util.function.Supplier
 import kotlin.math.ceil
 
@@ -37,19 +34,28 @@ abstract class CodyAutocompleteElementRenderer(
         else textAttributesFallback.get()
   }
 
-  override fun calcWidthInPixels(inlay: Inlay<*>): Int = fontInfoForText(text).fontMetrics().stringWidth(text)
+  override fun calcWidthInPixels(inlay: Inlay<*>): Int =
+      fontInfoForText(text).fontMetrics().stringWidth(text)
 
-  protected fun fontInfoForText(text: String): FontInfo
-    {
-        val preferences = FontPreferencesImpl()
-        editor.colorsScheme.fontPreferences.copyTo(preferences)
-        return ComplementaryFontsRegistry.getFontAbleToDisplay(text, 0, text.length, Font.ITALIC, preferences, FontInfo.getFontRenderContext(editor.contentComponent))
-    }
+  protected fun fontInfoForText(text: String): FontInfo {
+    val preferences = FontPreferencesImpl()
+    editor.colorsScheme.fontPreferences.copyTo(preferences)
+    return ComplementaryFontsRegistry.getFontAbleToDisplay(
+        text,
+        0,
+        text.length,
+        Font.ITALIC,
+        preferences,
+        FontInfo.getFontRenderContext(editor.contentComponent))
+  }
 
-    fun fontYOffset(fontInfo: FontInfo): Double {
-        val fontBaseline =
-            fontInfo.font.createGlyphVector(fontInfo.fontRenderContext, "Hello world!").visualBounds.height
-        val linePadding = (editor.lineHeight - fontBaseline) / 2
-        return ceil(fontBaseline + linePadding)
-    }
+  fun fontYOffset(fontInfo: FontInfo): Double {
+    val fontBaseline =
+        fontInfo.font
+            .createGlyphVector(fontInfo.fontRenderContext, "Hello world!")
+            .visualBounds
+            .height
+    val linePadding = (editor.lineHeight - fontBaseline) / 2
+    return ceil(fontBaseline + linePadding)
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteSingleLineRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteSingleLineRenderer.kt
@@ -19,7 +19,7 @@ class CodyAutocompleteSingleLineRenderer(
       targetRegion: Rectangle,
       textAttributes: TextAttributes
   ) {
-      val fontInfo = fontInfoForText(text)
+    val fontInfo = fontInfoForText(text)
     g.font = fontInfo.font
     g.color = themeAttributes.foregroundColor
     val x = targetRegion.x

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteSingleLineRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/render/CodyAutocompleteSingleLineRenderer.kt
@@ -19,10 +19,11 @@ class CodyAutocompleteSingleLineRenderer(
       targetRegion: Rectangle,
       textAttributes: TextAttributes
   ) {
-    g.font = font
+      val fontInfo = fontInfoForText(text)
+    g.font = fontInfo.font
     g.color = themeAttributes.foregroundColor
     val x = targetRegion.x
-    val y = targetRegion.y + fontYOffset()
+    val y = targetRegion.y + fontYOffset(fontInfo).toInt()
     g.drawString(text, x, y)
   }
 }


### PR DESCRIPTION
Fixes #1467, fixes the Persian text rendering part of #1451, fixes #1040

## Test plan

Tested manually by setting Cody's autocomplete color to purple, writing comments suggestive of non-Latin alphabets, and triggering completions.

Note, Korean completion displays correctly on Windows:

![Screenshot 2024-05-27 144653](https://github.com/sourcegraph/jetbrains/assets/55120/8c8c93ff-5274-42da-8f76-04c5709635ae)

Note, the yellow close quote & parenthesis are not overlapping the wide Japanese kanji characters:

![Screenshot 2024-05-27 144947](https://github.com/sourcegraph/jetbrains/assets/55120/fd7b0e84-4d3b-4f3c-9a6b-24b0eed3b1ef)

"Tada":

![Screenshot 2024-05-27 150225](https://github.com/sourcegraph/jetbrains/assets/55120/0ccf9c88-7541-4612-b90d-36468204afd7)

Uses color fonts on macOS:

![Screenshot 2024-05-27 at 15 07 55](https://github.com/sourcegraph/jetbrains/assets/55120/662e4190-366f-46d4-bef4-aa6423ec4fc3)
