### PR TITLE
Display Cody messages in a console view, show the console on ERROR or PANIC

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=ca1549ce2a1a5fafec1ce1b0496554b340f929f4
+cody.commit=92429eff660d50aa0eb28040faa3818039411628

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -48,6 +48,8 @@ public class CodyAgentClient {
   // Callback for the "workspace/edit" request from the agent.
   @Nullable Function<WorkspaceEditParams, Boolean> onWorkspaceEdit;
 
+  @Nullable Consumer<DebugMessage> onDebugMessage;
+
   @JsonNotification("editTask/didUpdate")
   public CompletableFuture<Void> editTaskDidUpdate(EditTask params) {
     return acceptOnEventThread("editTask/didUpdate", onEditTaskDidUpdate, params);
@@ -160,6 +162,9 @@ public class CodyAgentClient {
   @JsonNotification("debug/message")
   public void debugMessage(@NotNull DebugMessage msg) {
     logger.warn(String.format("%s: %s", msg.getChannel(), msg.getMessage()));
+    if (onDebugMessage != null) {
+      onDebugMessage.accept(msg);
+    }
   }
 
   @JsonNotification("webview/postMessage")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -12,11 +12,13 @@ import com.sourcegraph.cody.chat.AgentChatSessionService
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.context.RemoteRepoSearcher
 import com.sourcegraph.cody.edit.FixupService
+import com.sourcegraph.cody.error.CodyConsole
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.listeners.CodyFileEditorListener
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.utils.CodyEditorUtil
-import java.util.*
+import java.util.Timer
+import java.util.TimerTask
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -133,6 +135,10 @@ class CodyAgentService(private val project: Project) : Disposable {
 
       agent.client.onIgnoreDidChange = Consumer {
         IgnoreOracle.getInstance(project).onIgnoreDidChange()
+      }
+
+      agent.client.onDebugMessage = Consumer { message ->
+        CodyConsole.getInstance(project).addMessage(message)
       }
 
       if (!project.isDisposed) {

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -1,0 +1,56 @@
+package com.sourcegraph.cody.error
+
+import com.intellij.execution.filters.TextConsoleBuilderFactory
+import com.intellij.execution.ui.ConsoleViewContentType
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindowManager
+import com.intellij.ui.content.Content
+import com.sourcegraph.cody.agent.protocol.DebugMessage
+
+@Service(Service.Level.PROJECT)
+class CodyConsole(project: Project) {
+  private val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
+  private val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Problems View")
+  var content: Content? = null
+
+  val isEnabled = System.getProperty("sourcegraph.verbose-logging") == "true" ||
+          System.getProperty("cody-agent.panic-when-out-of-sync") == "true"
+
+  fun addMessage(message: DebugMessage) {
+    if (isEnabled) {
+      runInEdt {
+        if (message.message.contains("ERROR") || message.message.contains("PANIC")) {
+          toolWindow?.show()
+          content?.let { toolWindow?.contentManager?.setSelectedContent(it) }
+          consoleView.print(
+            "${message.channel}: ${message.message}\n", ConsoleViewContentType.ERROR_OUTPUT
+          )
+        } else {
+          consoleView.print(
+            "${message.channel}: ${message.message}\n", ConsoleViewContentType.NORMAL_OUTPUT
+          )
+        }
+      }
+    }
+  }
+
+  init {
+    if (isEnabled) {
+      runInEdt {
+        val factory = toolWindow?.contentManager?.factory
+        content = factory?.createContent(consoleView.component, "Cody Console", true)
+        content?.let { toolWindow?.contentManager?.addContent(it) }
+      }
+    }
+  }
+
+  companion object {
+    @JvmStatic
+    fun getInstance(project: Project): CodyConsole {
+      return project.service<CodyConsole>()
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -16,7 +16,8 @@ class CodyConsole(project: Project) {
   private val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Problems View")
   var content: Content? = null
 
-  val isEnabled = System.getProperty("sourcegraph.verbose-logging") == "true" ||
+  val isEnabled =
+      System.getProperty("sourcegraph.verbose-logging") == "true" ||
           System.getProperty("cody-agent.panic-when-out-of-sync") == "true"
 
   fun addMessage(message: DebugMessage) {
@@ -26,12 +27,10 @@ class CodyConsole(project: Project) {
           toolWindow?.show()
           content?.let { toolWindow?.contentManager?.setSelectedContent(it) }
           consoleView.print(
-            "${message.channel}: ${message.message}\n", ConsoleViewContentType.ERROR_OUTPUT
-          )
+              "${message.channel}: ${message.message}\n", ConsoleViewContentType.ERROR_OUTPUT)
         } else {
           consoleView.print(
-            "${message.channel}: ${message.message}\n", ConsoleViewContentType.NORMAL_OUTPUT
-          )
+              "${message.channel}: ${message.message}\n", ConsoleViewContentType.NORMAL_OUTPUT)
         }
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
@@ -20,7 +20,6 @@ class CodyFocusChangeListener(val project: Project) : FocusChangeListener {
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocumentDidFocus(textDocument)
-        println(textDocument)
       }
       IgnoreOracle.getInstance(project).focusedFileDidChange(textDocument.uri)
     }


### PR DESCRIPTION
## Changes

1. Cody debug logs lands in a separate window if sync testing or verbose logging is enabled
2. in case of ERROR or PANIC console window is displayed automatically

Changes on the Cody side: https://github.com/sourcegraph/cody/pull/4314

![image](https://github.com/sourcegraph/jetbrains/assets/1519649/6830668d-f976-4ce7-a985-54216de89de4)

## Test plan

N/A