### PR TITLE
Do not skip `textDocument/didChange` on `isUndoTransparentActionInProgress` in `CodyDocumentListener.kt`

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -2,7 +2,6 @@ package com.sourcegraph.cody.listeners
 
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
-import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -42,10 +41,6 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
   private fun handleDocumentEvent(event: DocumentEvent) {
     val editor = FileEditorManager.getInstance(project).selectedTextEditor
     if (editor?.document != event.document) {
-      return
-    }
-
-    if (CommandProcessor.getInstance().isUndoTransparentActionInProgress) {
       return
     }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/1648.

Having the scenario like in the Test plan IntelliJ processes two events.
1️⃣ The first event adds `"\n "` (a new line and a space). I am not 100% why there is the space there. I assume that IntelliJ tries to calculate the indent for the new line based on the previous line.
2️⃣ The second event removes the redundant space. IntelliJ realises that the space is redundant and removes it.

Before this change, we ignored the second event (we did not send it to the agent).

## Test plan
```kotlin
class A {
 }<cursor>
```
1. Having above ☝️ 
2. Insert a new line
3. Write a character 

Expected:
no panic


