### PR TITLE
Fixed the keyboard shortcuts for "Accept" and "Show diff".

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditShowDiffAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditShowDiffAction.kt
@@ -9,13 +9,11 @@ import com.intellij.diff.contents.FileContent
 import com.intellij.diff.util.DiffUserDataKeys
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataKey
-import com.intellij.openapi.editor.Document
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.fileEditor.FileDocumentManager
 
 class EditShowDiffAction : CompareFileWithEditorAction() {
   override fun isAvailable(e: AnActionEvent): Boolean {
-    e.dataContext.getData(DIFF_SESSION_DATA_KEY) ?: return false
     e.dataContext.getData(EDITOR_DATA_KEY) ?: return false
     return true
   }
@@ -54,6 +52,5 @@ class EditShowDiffAction : CompareFileWithEditorAction() {
 
   companion object {
     val EDITOR_DATA_KEY = DataKey.create<Editor>("editor")
-    val DIFF_SESSION_DATA_KEY = DataKey.create<Document>("diff_session")
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -207,18 +207,16 @@
         <action id="cody.command.Explain"
                 icon="/icons/chat/chat_command.svg"
                 class="com.sourcegraph.cody.chat.actions.ExplainCommand">
-            <keyboard-shortcut first-keystroke="control shift E"
-                               keymap="Mac OS X 10.5+"/>
-            <keyboard-shortcut first-keystroke="alt shift 1" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="control shift E" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="alt shift 1" keymap="$default"/>
             <add-to-group group-id="CodyEditorActions" anchor="last"/>
         </action>
 
         <action id="cody.command.Smell"
                 icon="/icons/chat/chat_command.svg"
                 class="com.sourcegraph.cody.chat.actions.SmellCommand">
-            <keyboard-shortcut first-keystroke="control shift S"
-                               keymap="Mac OS X 10.5+"/>
-            <keyboard-shortcut first-keystroke="alt shift 2" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="control shift S" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="alt shift 2" keymap="$default"/>
             <add-to-group group-id="CodyEditorActions" anchor="last"/>
         </action>
 
@@ -260,8 +258,8 @@
                 text="Accept Edit"
                 description="Accept the fixup">
             <!-- Intended as ctrl shift PLUS but that is not recognized by IntelliJ. -->
-            <keyboard-shortcut first-keystroke="ctrl shift EQUALS" keymap="$default"/>
-            <keyboard-shortcut first-keystroke="ctrl shift EQUALS" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="Mac OS X 10.5+"/>
         </action>
 
         <action id="cody.inlineEditCancelAction"
@@ -286,8 +284,8 @@
                 class="com.sourcegraph.cody.edit.EditShowDiffAction"
                 text="Show Diff"
                 description="Show a diff view of the fixup">
-            <keyboard-shortcut first-keystroke="ctrl shift QUOTE" keymap="$default"/>
-            <keyboard-shortcut first-keystroke="ctrl shift QUOTE" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift QUOTE" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift QUOTE" keymap="Mac OS X 10.5+"/>
         </action>
 
         <action id="cody.inlineEditDismissAction"
@@ -300,16 +298,16 @@
                 class="com.sourcegraph.cody.statusbar.OpenLogAction"
                 text="Open Log"
                 description="Opens Cody log">
-            <keyboard-shortcut first-keystroke="ctrl shift L" keymap="$default"/>
-            <keyboard-shortcut first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
         </action>
 
         <action id="cody.editCancelOrUndoAction"
                 class="com.sourcegraph.cody.edit.actions.EditCancelOrUndoAction"
                 text="Cancel or Undo Current Edit"
                 description="Activates the cancel or undo lens, whichever is showing.">
-            <keyboard-shortcut first-keystroke="ctrl shift BACK_SPACE" keymap="$default"/>
-            <keyboard-shortcut first-keystroke="ctrl shift BACK_SPACE" keymap="Mac OS X 10.5+"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift BACK_SPACE" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift BACK_SPACE" keymap="Mac OS X 10.5+"/>
         </action>
 
         <group id="SourcegraphEditor" popup="true" searchable="false">


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody-issues/issues/379.

IIRC IntelliJ automagically converts Windows keyboard shortcuts that use Ctrl into Mac OS shortcuts that use Cmd. This somehow causes an additional mapping to appear, e.g. `Cmd-Shift-'` for `Ctrl-Shift-'`; however, this additional mapping doesn't actually work.

It seems that, when IntelliJ is launched by `./gradlew runIDE`, the `$default` keymap happens to be called "Windows" even on Mac OS. At least this is what I observed in a debug session; in the UI, however, the keymap that's selected by default is "macOS". I haven't investigated this in depth, but this looks like a bug in IntelliJ.

Whatever the actual cause, setting [`replace-all="true"`](https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html#idea-plugin__actions__action__keyboard-shortcut) wherever we define more than one shortcut has solved this problem.

After #1409, there are no places in the code where `DIFF_SESSION_DATA_KEY` is added to the action data context. As a consequence, the algorithm for mapping the keyboard shortcut to an action (which IntelliJ does dynamically every time) decided that this action is disabled, and removed it from the list of possible action mappings.

## Test plan

Tested manually.