### PR TITLE
added error handling to the Document and Edit actions

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/DocumentCodeSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/DocumentCodeSession.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.edit.sessions
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgent
@@ -13,6 +14,16 @@ class DocumentCodeSession(
     project: Project,
 ) : FixupSession(controller, project, editor) {
   override fun makeEditingRequest(agent: CodyAgent): CompletableFuture<EditTask> {
-    return agent.server.commandsDocument()
+
+    return try {
+      agent.server.commandsDocument()
+    } catch (x: Exception) {
+      logger.warn("Failed to execute editCommands/document request", x)
+      CompletableFuture.failedFuture(x)
+    }
+  }
+
+  companion object {
+    private val logger = Logger.getInstance(DocumentCodeSession::class.java)
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/EditCodeSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/EditCodeSession.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.edit.sessions
 
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
@@ -22,7 +23,16 @@ class EditCodeSession(
 ) : FixupSession(controller, editor.project!!, editor) {
 
   override fun makeEditingRequest(agent: CodyAgent): CompletableFuture<EditTask> {
-    val params = InlineEditParams(instructions, chatModelProvider.model, mode)
-    return agent.server.commandsEdit(params)
+    return try {
+      val params = InlineEditParams(instructions, chatModelProvider.model, mode)
+      agent.server.commandsEdit(params)
+    } catch (x: Exception) {
+      logger.warn("Failed to execute editCommands/document request", x)
+      CompletableFuture.failedFuture(x)
+    }
+  }
+
+  companion object {
+    private val logger = Logger.getInstance(EditCodeSession::class.java)
   }
 }


### PR DESCRIPTION
This allows the Agent to restart if they encounter an IO error -- it wouldn't restart previously

## Test plan

Manually tested in debugger for now because it's tricky to cause this particular code path to trigger in a test.