### PR TITLE
Fix issue where `textDocument/edit` applies changes to the wrong file before `workspace/edit` during Generate Unit Tests

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -94,6 +94,7 @@ class CodyAgentService(private val project: Project) : Disposable {
       agent.client.onTextDocumentEdit = Function { params ->
         val activeSession = FixupService.getInstance(project).getActiveSession()
         try {
+          activeSession?.updateEditorIfNeeded(params.uri)
           activeSession?.performInlineEdits(params.edits)
           true
         } catch (e: RuntimeException) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixupSession.kt
@@ -339,7 +339,7 @@ abstract class FixupSession(
     }
   }
 
-  private fun updateEditorIfNeeded(path: String) {
+  internal fun updateEditorIfNeeded(path: String) {
     val vf =
         CodyEditorUtil.findFileOrScratch(project, path)
             ?: throw IllegalArgumentException("Could not find file $path")


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody-issues/issues/402.

## Test plan
1. Generate Unit Tests
2. The original file is not modified by the Inline Edit generating the tests
