### PR TITLE
Do not show the document on `textDocument/openUntitledDocument`

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -119,7 +119,6 @@ class CodyAgentService(private val project: Project) : Disposable {
             result.complete(false)
             return@invokeAndWait
           }
-          CodyEditorUtil.showDocument(project, vf)
           result.complete(true)
         }
         result.get()


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/cody-issues/issues/403.

This PR fixes the problem partially. There are no visible symptoms anymore but we leave an `untitled`-schemed document among `agentDocuments`. Every time a user triggers autocompletion [`getRelevantFiles`](https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/vscode/src/completions/context/retrievers/jaccard-similarity/jaccard-similarity-retriever.ts?L116%3A1-219%3A1) is called and it sends `textDocument/openUntitledDocument` notification for the `untitled`-schemed files. 

## Test plan
1. Generate Unit Tests
2. Switch back to the original file
3. Trigger autocomplete