### PR TITLE
add clients/jetbrains label to error reports

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -37,7 +37,7 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
   public fun getEncodedUrl(throwableText: String, additionalInfo: String? = null): String {
     return "https://github.com/sourcegraph/jetbrains/issues/new" +
         "?template=bug_report.yml" +
-        "&labels=bug,team/jetbrains" +
+        "&labels=bug,clients/jetbrains" +
         "&projects=sourcegraph/381" +
         "&title=${encode(getTitle(throwableText))}" +
         "&version=${encode(getVersion())}" +


### PR DESCRIPTION
adding `clients/jetbrains` label to help with triage process in linear when we receive bug reports in github

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
