### PR TITLE
Document synchronization: rewrite document change listener

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,6 +305,8 @@ tasks {
           "sourcegraph.verbose-logging" to "true",
           "cody-agent.panic-when-out-of-sync" to
               (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "true"),
+          "cody-agent.fullDocumentSyncEnabled" to
+              (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "false"),
           "cody.autocomplete.enableFormatting" to
               (project.property("cody.autocomplete.enableFormatting") ?: "true"))
 


### PR DESCRIPTION
Previously, incremental document synchronization was hitting on regular panics in various scenarios including when the file had tab characters. This PR is an attempt to fix this issue by rewriting the document change handler.

## Test plan

Break it @RXminuS 

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
