### PR TITLE
Specify the maximum supported IntelliJ version to 2024.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // As https://www.jetbrains.com/updates/updates.xml adds a new "IntelliJ IDEA" YYYY.N version, add
 // it to this list.
 // Remove unsupported old versions from this list.
+// Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in this list.
 val versionsOfInterest =
     listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
 val versionsToValidate =

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,8 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // As https://www.jetbrains.com/updates/updates.xml adds a new "IntelliJ IDEA" YYYY.N version, add
 // it to this list.
 // Remove unsupported old versions from this list.
-// Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in this list.
+// Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
+// this list.
 val versionsOfInterest =
     listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
 val versionsToValidate =

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.1
-pluginUntilBuild=*
+pluginUntilBuild=241.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2022.1


### PR DESCRIPTION
Fixes sourcegraph/cody-issues#240 to unblock 6.0 release.

We can handle this better by unifying the plugin versions we verify and the versions we support. So may want to revert this change after the release is out.

## Test plan

```
./gradlew :runPluginVerifier
```
