### PR TITLE
Make the Add/Edit repositories popup dialog activate more readily

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/context/EnterpriseEnhancedContextStateController.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/EnterpriseEnhancedContextStateController.kt
@@ -338,4 +338,8 @@ class EnterpriseEnhancedContextStateController(
       state.remoteRepositories.addAll(reposToWriteToState)
     }
   }
+
+  fun requestUIUpdate() {
+    ApplicationManager.getApplication().executeOnPooledThread(this::updateUI)
+  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -199,8 +199,6 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
     private const val ENTER_MAP_KEY = "enter"
   }
 
-  // TODO: We need to kick off setting the agent state with
-  // controller.loadFrom...(getContextState()) etc.
   private var controller =
       EnterpriseEnhancedContextStateController(
           project,
@@ -256,28 +254,17 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
           fun targetForEvent(e: MouseEvent): Any? =
               tree.getClosestPathForLocation(e.x, e.y)?.lastPathComponent
 
-          // We cache the target of the mouse press, so that if the tree expands before the click
-          // event is generated, we can detect the mouse click event is on a different node and
-          // suppress the popup.
-          private var pressedTarget: Any? = null
-
           override fun mousePressed(e: MouseEvent) {
             super.mousePressed(e)
-            pressedTarget = targetForEvent(e)
-          }
-
-          override fun mouseClicked(e: MouseEvent) {
-            var clickTarget = targetForEvent(e)
-            if (e.clickCount == 1 &&
-                e.button == MouseEvent.BUTTON1 &&
-                pressedTarget === clickTarget &&
-                clickTarget is ContextTreeEditReposNode) {
+            if (targetForEvent(e) is ContextTreeEditReposNode) {
               repoPopupController
                   .createPopup(tree.width, endpointName, controller.rawSpec)
                   .showAbove(tree)
             }
           }
         })
+
+    controller.requestUIUpdate()
   }
 
   @RequiresEdt

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/EnhancedContextPanel.kt
@@ -256,7 +256,8 @@ class EnterpriseEnhancedContextPanel(project: Project, chatSession: ChatSession)
 
           override fun mousePressed(e: MouseEvent) {
             super.mousePressed(e)
-            if (targetForEvent(e) is ContextTreeEditReposNode) {
+            if (targetForEvent(e) is ContextTreeEditReposNode &&
+                (e.button == MouseEvent.BUTTON1 || e.isPopupTrigger)) {
               repoPopupController
                   .createPopup(tree.width, endpointName, controller.rawSpec)
                   .showAbove(tree)

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/RemoteRepoPopupController.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/RemoteRepoPopupController.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.editor.ex.FocusChangeListener
 import com.intellij.openapi.editor.highlighter.EditorHighlighterFactory
-import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.JBPopup
 import com.intellij.openapi.ui.popup.JBPopupFactory
@@ -34,8 +33,10 @@ import java.awt.BorderLayout
 import java.awt.Dimension
 import javax.swing.JPanel
 import javax.swing.border.CompoundBorder
+import kotlin.math.max
 
 const val MAX_REMOTE_REPOSITORY_COUNT = 10
+const val MIN_POPUP_WIDTH = 400
 
 class RemoteRepoPopupController(val project: Project) {
   var onAccept: (spec: String) -> Unit = {}
@@ -101,8 +102,9 @@ class RemoteRepoPopupController(val project: Project) {
     editor.contentComponent.apply { border = CompoundBorder(JBUI.Borders.empty(2), border) }
 
     val panel = JPanel(BorderLayout()).apply { add(editor.component, BorderLayout.CENTER) }
-    val shortcut = KeymapUtil.getShortcutsText(CommonShortcuts.CTRL_ENTER.shortcuts)
+    val scaledWidth = max(width, JBDimension(MIN_POPUP_WIDTH, 0).width)
     val scaledHeight = JBDimension(0, 160).height
+    val size = Dimension(scaledWidth, scaledHeight)
 
     var popup: JBPopup? = null
     popup =
@@ -132,7 +134,7 @@ class RemoteRepoPopupController(val project: Project) {
                     false
                   }
                   setMayBeParent(true)
-                  setMinSize(Dimension(width, scaledHeight))
+                  setMinSize(size)
                   setRequestFocus(true)
                   setResizable(true)
                   addListener(
@@ -164,7 +166,7 @@ class RemoteRepoPopupController(val project: Project) {
 
     // If not explicitly set, the popup's minimum size is applied after the popup is shown, which is
     // too late to compute placement in showAbove.
-    popup.size = Dimension(width, scaledHeight)
+    popup.size = size
 
     return popup
   }


### PR DESCRIPTION
Fixes sourcegraph/cody-issues#427 by supporting tiny drags versus clicks, narrow chat sidebars, etc.

## Test plan

Tested manually:

- Open the enhanced repo selector and try double clicking add/edit repositories rapidly
- Add some repositories and try rapidly selecting/deselecting them, then quickly edit repositories
- Position window lower right of monitor, make chat sidebar narrow, try adding a repository
- Activate with left and "right" (depends on platform) clicks, but not middle button clicks, etc.