### PR TITLE
Document Synchronization: stop using logical positions

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -23,8 +23,7 @@ class CodyCaretListener(val project: Project) : CaretListener {
       return
     }
 
-    ProtocolTextDocument.fromEditorWithOffsetSelection(e.editor, e.newPosition)?.let { textDocument
-      ->
+    ProtocolTextDocument.fromEditorWithOffsetSelection(e.editor, e)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->
         agent.server.textDocumentDidChange(textDocument)


### PR DESCRIPTION
As we recently discovered, logical positions interpret character positions differently than the agent server. For example, in IDEA, the tab character is interpret as two characters while the agent server interprets it as one character. This PR replaces usage of logical positions with manually calculated line/character positions.

## Test plan

Green CI
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
