### PR TITLE
Revert "Drop support for 2022.1 to unblock 6.0 release. (#1712)"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,8 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // Remove unsupported old versions from this list.
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
 // this list.
-val versionsOfInterest = listOf("2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
+val versionsOfInterest =
+    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
@@ -41,6 +42,7 @@ val versionsToValidate =
     }
 val skippedFailureLevels =
     EnumSet.of(
+        FailureLevel.COMPATIBILITY_PROBLEMS, // blocked by: compatibility hack for IJ 2022.1 / 2024+
         FailureLevel.DEPRECATED_API_USAGES,
         FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
         FailureLevel.EXPERIMENTAL_API_USAGES,

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ pluginName=Sourcegraph
 pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=222
+pluginSinceBuild=221.1
 pluginUntilBuild=241.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.2
+platformVersion=2022.1
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin,java

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=fe37ceea77a17f9f6e6a3209097e7dd9c00eb456
+cody.commit=01bc8503f09092c178ca8806d5202c9686edd812

--- a/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
+++ b/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
@@ -8,8 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class CodyActionGroup extends DefaultActionGroup {
 
-  @Override
-  public ActionUpdateThread getActionUpdateThread() {
+  ActionUpdateThread getActionUpdateThread() {
     return ActionUpdateThread.EDT;
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
@@ -93,7 +93,7 @@ private fun <A : Account, Cred, R> create(
             addCustomUpdater { isEnabled && model.activeAccount != accountsList.selectedValue }
           }
 
-          override fun getActionUpdateThread(): ActionUpdateThread {
+          fun getActionUpdateThread(): ActionUpdateThread {
             return ActionUpdateThread.BGT
           }
 

--- a/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextToolbarButton.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/context/ui/ContextToolbarButton.kt
@@ -11,7 +11,7 @@ open class ContextToolbarButton(
     private val buttonAction: () -> Unit = {}
 ) : DumbAwareActionButton(name, icon) {
 
-  override fun getActionUpdateThread(): ActionUpdateThread {
+  fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.sourcegraph.config.ConfigUtil
 
 class InternalsStatusBarActionGroup : DefaultActionGroup() {
-  override fun getActionUpdateThread(): ActionUpdateThread {
+  fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -11,7 +11,7 @@ import com.sourcegraph.config.ConfigUtil
 
 class CodyStatusBarActionGroup : DefaultActionGroup() {
 
-  override fun getActionUpdateThread(): ActionUpdateThread {
+  fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareEDTAction.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareEDTAction.kt
@@ -21,7 +21,7 @@ abstract class DumbAwareEDTAction : DumbAwareAction {
       icon: Icon?
   ) : super(text, description, icon)
 
-  override fun getActionUpdateThread(): ActionUpdateThread {
+  fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 }


### PR DESCRIPTION
This reverts commit 5af5bf6b525da385b5a39f2286090289cd5df77e.

## Test plan

N/A