### PR TITLE
Change "edit" keyboard shortcut to alt-shift-enter on Windows and Linux

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -248,7 +248,7 @@
                 class="com.sourcegraph.cody.edit.actions.EditOpenOrRetryAction"
                 description="Opens the Edit Code dialog">
             <add-to-group group-id="CodyEditorActions" anchor="first"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift ENTER" keymap="$default"/>
+            <keyboard-shortcut replace-all="true" first-keystroke="alt shift ENTER" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift ENTER" keymap="Mac OS X 10.5+"/>
         </action>
 


### PR DESCRIPTION
Fixes #1709 by changing "edit" keyboard shortcut to alt-shift-enter on Windows, Linux

## Test plan

Locally tested:

- On macOS, ctrl-shift-enter triggers edits (alt-shift-enter does some window rearranging, so we can't use that)
- On Windows, alt-shift-enter triggers edits (ctrl-shift-enter does "complete statement", so we can't use that)