### PR TITLE
Disable Inline Edit actions when a user is not signed in (fixes #1517)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseChatAction.kt
@@ -24,7 +24,7 @@ abstract class BaseChatAction : DumbAwareEDTAction() {
 
   override fun update(event: AnActionEvent) {
     val project = event.project ?: return
-    val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
+    val hasActiveAccount = CodyAuthenticationManager.getInstance(project).hasActiveAccount()
     event.presentation.isEnabled = hasActiveAccount
     if (!event.presentation.isEnabled) {
       event.presentation.description =

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseChatAction.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.sourcegraph.cody.CodyToolWindowFactory
 import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
 abstract class BaseChatAction : DumbAwareEDTAction() {
@@ -24,7 +25,11 @@ abstract class BaseChatAction : DumbAwareEDTAction() {
   override fun update(event: AnActionEvent) {
     val project = event.project ?: return
     val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
-    event.presentation.isEnabledAndVisible = hasActiveAccount
+    event.presentation.isEnabled = hasActiveAccount
+    if (!event.presentation.isEnabled) {
+      event.presentation.description =
+          CodyBundle.getString("action.sourcegraph.disabled.description")
+    }
   }
 
   private fun showToolbar(project: Project) =

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -147,7 +147,9 @@ class CodyAuthenticationManager(val project: Project) : Disposable {
     }
   }
 
-  fun hasNoActiveAccount() = getInstance(project).getActiveAccount() == null
+  fun hasActiveAccount() = getInstance(project).getActiveAccount() != null
+
+  fun hasNoActiveAccount() = !hasActiveAccount()
 
   override fun dispose() {
     scheduler.shutdown()

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
@@ -6,9 +6,21 @@ import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.common.CodyBundle
 
 abstract class InlineEditAction : AnAction(), DumbAware {
   private val logger = Logger.getInstance(InlineEditAction::class.java)
+
+  override fun update(event: AnActionEvent) {
+    val project = event.project ?: return
+    val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
+    event.presentation.isEnabled = hasActiveAccount
+    if (!event.presentation.isEnabled) {
+      event.presentation.description =
+          CodyBundle.getString("action.sourcegraph.disabled.description")
+    }
+  }
 
   abstract fun performAction(e: AnActionEvent, project: Project)
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
@@ -14,7 +14,7 @@ abstract class InlineEditAction : AnAction(), DumbAware {
 
   override fun update(event: AnActionEvent) {
     val project = event.project ?: return
-    val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
+    val hasActiveAccount = CodyAuthenticationManager.getInstance(project).hasActiveAccount()
     event.presentation.isEnabled = hasActiveAccount
     if (!event.presentation.isEnabled) {
       event.presentation.description =

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
@@ -12,7 +12,7 @@ open class NonInteractiveEditCommandAction(runAction: (Editor, FixupService) -> 
     super.update(event)
 
     val project = event.project ?: return
-    val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
+    val hasActiveAccount = CodyAuthenticationManager.getInstance(project).hasActiveAccount()
     event.presentation.isEnabled =
         hasActiveAccount && !FixupService.getInstance(project).isEditInProgress()
     if (!event.presentation.isEnabled) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/NonInteractiveEditCommandAction.kt
@@ -2,14 +2,22 @@ package com.sourcegraph.cody.edit.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.editor.Editor
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.edit.FixupService
+import com.sourcegraph.common.CodyBundle
 
 open class NonInteractiveEditCommandAction(runAction: (Editor, FixupService) -> Unit) :
     EditCommandAction(runAction) {
-  override fun update(e: AnActionEvent) {
-    super.update(e)
+  override fun update(event: AnActionEvent) {
+    super.update(event)
 
-    val project = e.project ?: return
-    e.presentation.isEnabled = !FixupService.getInstance(project).isEditInProgress()
+    val project = event.project ?: return
+    val hasActiveAccount = !CodyAuthenticationManager.getInstance(project).hasNoActiveAccount()
+    event.presentation.isEnabled =
+        hasActiveAccount && !FixupService.getInstance(project).isEditInProgress()
+    if (!event.presentation.isEnabled) {
+      event.presentation.description =
+          CodyBundle.getString("action.sourcegraph.disabled.description")
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.statusbar
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
 
@@ -14,7 +15,9 @@ class CodyDisableAutocompleteAction : DumbAwareEDTAction("Disable Cody Autocompl
 
   override fun update(e: AnActionEvent) {
     super.update(e)
+    val hasActiveAccount =
+        e.project?.let { !CodyAuthenticationManager.getInstance(it).hasNoActiveAccount() } ?: false
     e.presentation.isEnabledAndVisible =
-        ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled()
+        ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled() && hasActiveAccount
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -16,7 +16,7 @@ class CodyDisableAutocompleteAction : DumbAwareEDTAction("Disable Cody Autocompl
   override fun update(e: AnActionEvent) {
     super.update(e)
     val hasActiveAccount =
-        e.project?.let { !CodyAuthenticationManager.getInstance(it).hasNoActiveAccount() } ?: false
+        e.project?.let { CodyAuthenticationManager.getInstance(it).hasActiveAccount() } ?: false
     e.presentation.isEnabledAndVisible =
         ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled() && hasActiveAccount
   }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.statusbar
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
+import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
@@ -24,11 +25,14 @@ class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""
+    val hasActiveAccount =
+        e.project?.let { !CodyAuthenticationManager.getInstance(it).hasNoActiveAccount() } ?: false
     e.presentation.isEnabledAndVisible =
         languageForFocusedEditor != null &&
             ConfigUtil.isCodyEnabled() &&
             ConfigUtil.isCodyAutocompleteEnabled() &&
-            !isLanguageBlacklisted
+            !isLanguageBlacklisted &&
+            hasActiveAccount
     e.presentation.text = "Disable Cody Autocomplete for $languageName"
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
@@ -26,7 +26,7 @@ class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""
     val hasActiveAccount =
-        e.project?.let { !CodyAuthenticationManager.getInstance(it).hasNoActiveAccount() } ?: false
+        e.project?.let { CodyAuthenticationManager.getInstance(it).hasActiveAccount() } ?: false
     e.presentation.isEnabledAndVisible =
         languageForFocusedEditor != null &&
             ConfigUtil.isCodyEnabled() &&

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -30,12 +30,15 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
       addAll(listOfNotNull(deriveWarningAction()))
       addSeparator()
       addAll(
+          CodyManageAccountsAction(),
+          CodyOpenSettingsAction(),
+      )
+      addSeparator()
+      addAll(
           CodyEnableAutocompleteAction(),
           CodyDisableAutocompleteAction(),
           CodyEnableLanguageForAutocompleteAction(),
           CodyDisableLanguageForAutocompleteAction(),
-          CodyManageAccountsAction(),
-          CodyOpenSettingsAction(),
       )
     }
   }

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -165,6 +165,7 @@ action.sourcegraph.openFindPopup.text=Find with Sourcegraph...
 action.sourcegraph.openFindPopup.description=Search all your repos on Sourcegraph
 action.sourcegraph.login.text=Log in to Sourcegraph
 action.sourcegraph.login.description=Log in to Sourcegraph
+action.sourcegraph.disabled.description=Log In to Sourcegraph to enable Cody features
 
 # Chat Actions
 action.cody.openChat.text=Open Chat

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -165,7 +165,7 @@ action.sourcegraph.openFindPopup.text=Find with Sourcegraph...
 action.sourcegraph.openFindPopup.description=Search all your repos on Sourcegraph
 action.sourcegraph.login.text=Log in to Sourcegraph
 action.sourcegraph.login.description=Log in to Sourcegraph
-action.sourcegraph.disabled.description=Log In to Sourcegraph to enable Cody features
+action.sourcegraph.disabled.description=Log in to Sourcegraph to enable Cody features
 
 # Chat Actions
 action.cody.openChat.text=Open Chat


### PR DESCRIPTION
Fixes #1517.

## Test plan
1. Log out 
2. Review Cody actions (context menu, Edit Code... in particular)

Actions should be visible but disabled.

## Before 
![image](https://github.com/sourcegraph/jetbrains/assets/19799111/a8ac01b4-f7ab-4782-9cfc-072821015045)

Disable Actions visible in the status widget action group when a user is not logged in.
Disable Actions are above Settings and Mange Accounts (which is not very inviting).

## Now
![image](https://github.com/sourcegraph/jetbrains/assets/19799111/d4dc91a1-198f-4e7c-be13-fa871d0701ae)
![image](https://github.com/sourcegraph/jetbrains/assets/19799111/1d70ee16-0b12-4c8c-8590-aac6b226f45e)
