### PR TITLE
Override getActionUpdateThread in InlineEditAction.kt

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/InlineEditAction.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.edit.actions
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys
@@ -11,6 +12,10 @@ import com.sourcegraph.common.CodyBundle
 
 abstract class InlineEditAction : AnAction(), DumbAware {
   private val logger = Logger.getInstance(InlineEditAction::class.java)
+
+  fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.EDT
+  }
 
   override fun update(event: AnActionEvent) {
     val project = event.project ?: return


### PR DESCRIPTION
The error occurred to me once. 

## Test plan
1. Inline Edit actions do not cause internal errors about `getActionUpdateThread` 
