### PR TITLE
Make the CODY_AGENT_DEBUG=true setting work even if CODY_DIR is not set.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -400,6 +400,15 @@ You do not launch VS Code run configurations from the command palette.
 Instead, use ctrl-shift-D to open the Run and Debug view, and you can
 see the configuration dropdown at the top.
 
+## Tracing TypeScript Performance
+
+Chrome Tracing can be used to get CPU and memory profiles of Agent and the TypeScript extension code.
+
+1. Set `CODY_AGENT_DEBUG_INSPECT=true` in your run configuration/environment.
+2. Launch the target.
+3. Open DevTools however you're accustomed to do that, for example, `chrome://inspect` and click "inspect" next to the debuggee.
+4. Use the Performance tab to record CPU, memory profiles, etc.
+
 ## Known Issues
 
 - Force-stopping the target often corrupts IntelliJ's project indexes,

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -158,7 +158,11 @@ private constructor(
                 agentDirectory()?.resolve("index.js")
                     ?: throw CodyAgentException(
                         "Sourcegraph Cody + Code Search plugin path not found")
-            listOf(binaryPath, script.toFile().absolutePath)
+            if (shouldSpawnDebuggableAgent()) {
+              listOf(binaryPath, "--inspect", "--enable-source-maps", script.toFile().absolutePath)
+            } else {
+              listOf(binaryPath, script.toFile().absolutePath)
+            }
           }
 
       val processBuilder = ProcessBuilder(command)


### PR DESCRIPTION
For collecting performance data it is handy to run Agent with `--inspect`, even if you're not building it. Enable this by making `CODY_AGENT_DEBUG` work even if `CODY_DIR` is not set.

## Test plan

Manually tested. Run the steps in CONTRIBUTING.md and collect and analyze a trace.