### PR TITLE
Show a warning notification on deleting a file being generated (fixes #1740)

### DIFF
--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -193,7 +193,7 @@ gotit.autocomplete.message=This is how Cody displays autocomplete suggestions.<b
 # User Friendly Error Notifications
 notification.general.cody-not-running.title=Cody is starting...
 notification.general.cody-not-running.detail=Please wait a few seconds or check the Cody logs for errors.
-notifications.edits.editing-not-available.title=Cody can't edit this file
+notifications.edits.editing-not-available.title=Cody can't edit the file
 notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
 
 # Context Filters


### PR DESCRIPTION
Fixes #1740.

## Test plan
1. Generate Unit Tests
2. Remove the generated file (you must be super fast)
