### PR TITLE
Cancel task when the generated file is closed (fixes #1677)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -78,6 +78,7 @@ class FixupService(val project: Project) : Disposable {
     if (!CodyEditorUtil.isEditorValidForAutocomplete(editor)) {
       runInEdt { EditingNotAvailableNotification().notify(project) }
       logger.warn("Edit code invoked when editing not available")
+      getActiveSession()?.cancel()
       return false
     }
     val policy = IgnoreOracle.getInstance(project).policyForEditor(editor)


### PR DESCRIPTION
Fixes #1677.


## Test plan
1. Generate Unit Tests
2. Close the newly created file 
