### PR TITLE
Windows: use x64 emulation on ARM64

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -244,7 +244,17 @@ private constructor(
 
     private fun nodeBinaryName(): String {
       val os = if (SystemInfoRt.isMac) "macos" else if (SystemInfoRt.isWindows) "win" else "linux"
-      val arch = if (CpuArch.isArm64()) "arm64" else "x64"
+      val arch =
+          if (CpuArch.isArm64()) {
+            if (SystemInfoRt.isWindows) {
+              // Use x86 emulation on arm64 Windows
+              "x64"
+            } else {
+              "arm64"
+            }
+          } else {
+            "x64"
+          }
       return "node-" + os + "-" + arch + binarySuffix()
     }
 


### PR DESCRIPTION
Previously, Cody didn't work on ARM64 Windows computers because we don't distribute an ARM64 Node.js binary for the Cody agent. This PR fixes the problem by falling back to the x64 Node.js binary, which should be executable on ARM64 Windows computers via emulation.

## Test plan

@danielmarquespt verified this work with an ARM64 VM.

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
