### PR TITLE
Better handling of the situation when the authentication token is invalidated or expired

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -108,7 +108,8 @@ class CodyToolWindowContent(private val project: Project) {
   @RequiresEdt
   fun refreshPanelsVisibility() {
     val codyAuthenticationManager = CodyAuthenticationManager.getInstance(project)
-    if (codyAuthenticationManager.getAccounts().isEmpty()) {
+    if (codyAuthenticationManager.getAccounts().isEmpty() ||
+        codyAuthenticationManager.getActiveAccountTier().getNow(null) == null) {
       allContentLayout.show(allContentPanel, SIGN_IN_PANEL)
       return
     }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -115,21 +115,15 @@ private constructor(
                   addEnhancedContext = chatPanel.isEnhancedContextEnabled(),
                   contextFiles = contextItems)
 
-          try {
-            val request =
-                agent.server.chatSubmitMessage(
-                    ChatSubmitMessageParams(connectionId.get().get(), message))
+          val request =
+              agent.server.chatSubmitMessage(
+                  ChatSubmitMessageParams(connectionId.get().get(), message))
 
-            GraphQlLogger.logCodyEvent(project, "chat-question", "submitted")
+          GraphQlLogger.logCodyEvent(project, "chat-question", "submitted")
 
-            createCancellationToken(
-                onCancel = { request.cancel(true) },
-                onFinish = { GraphQlLogger.logCodyEvent(project, "chat-question", "executed") })
-          } catch (e: Exception) {
-            createCancellationToken(onCancel = {}, onFinish = {})
-            handleException(e)
-            throw e
-          }
+          createCancellationToken(
+              onCancel = { request.cancel(true) },
+              onFinish = { GraphQlLogger.logCodyEvent(project, "chat-question", "executed") })
         },
         onFailure = { e ->
           createCancellationToken(onCancel = {}, onFinish = {})


### PR DESCRIPTION
Partially fixes #1498.

## Test plan

1. Open a project. Log into Cody if needed.
2. Start a new chat and send some messages.
3. Open the "Access tokens" page in your browser and delete your token.
   * Alternatively, just wait until the token expires.
4. Try sending a new message in the same chat window. The error should say "Invalid access token." 
5. Generate a new token and paste it into the account settings within IntelliJ.
6. Any new or restored chat should work. Inline edits should also work.

## Test plan 2
1. Start a new chat. Send a message and make sure you get a response.
2. Turn off the Internet connection and try to send another message.
3. Restore the Internet connection and send a third message.
4. The second message should file with ENOTFOUND, but the third one should get a response.

## Known problems

* After the invalid token has been replaced manually, the currently open chat stops working. However, if you create a new chat and restore the previous one from history, it will work.
* Inline actions are not disabled when the token is invalid. However, invoking them has no effects (not even an error message).

## Screenshots

* View just after loading the project, when there is an active account but its token has expired (or has been cancelled)
   <img width="812" alt="Screenshot 2024-06-07 at 14 11 36" src="https://github.com/sourcegraph/jetbrains/assets/1336259/a7bdc860-15ad-46ec-916d-c9d83ef9cc4f">

* The token has been manually invalidated after the first chat message, but before the second one
   <img width="1060" alt="Screenshot 2024-06-07 at 14 45 58" src="https://github.com/sourcegraph/jetbrains/assets/1336259/ac0494ef-4644-4b53-8b74-fa12203109ad">

