### PR TITLE
Simplify error reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,6 @@ description: "File a bug report for any of the JetBrains IDEs: IntelliJ, Goland,
 title: "bug: "
 labels:
   - bug
-  - team/jetbrains
 projects:
   - sourcegraph/381
 body:
@@ -16,13 +15,8 @@ body:
         Thanks for taking the time to fill out this bug report! Please include as much information as possible to help us fix the issue. 
 
         Tip: You can attach images or videos by dragging it into the text box.
-  - type: input
-    attributes:
-      label: Cody Version
-      description: Please specify the exact Cody extension version you're reporting for.
-    validations:
-      required: true
-  - type: textarea
+  - id: about
+    type: textarea
     attributes:
       label: IDE Information
       description: Trigger the action "About" (Shift Shift -> Actions), click on "Copy and Close" and paste the output here.
@@ -30,14 +24,8 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: Describe the bug
-      description: Description of what the bug is. Please include steps on how to reproduce the behaviour.
-    validations:
-      required: true
-  - type: textarea
-    attributes:
-      label: Expected behavior
-      description: Description of what you expected to happen.
+      label: Bug Description
+      description: Please describe the bug. Include steps for reproducing the behavior and actual and expected results.
     validations:
       required: true
   - id: logs

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -178,7 +178,7 @@ private constructor(
               else -> CodyBundle.getString("chat.rate-limit-error.explain")
             }
           } else {
-            val errorReportLink = CodyErrorSubmitter().getEncodedUrl(chatError.message)
+            val errorReportLink = CodyErrorSubmitter().getEncodedUrl(project, chatError.message)
             CodyBundle.getString("chat.general-error").fmt(errorReportLink, chatError.message)
           }
 
@@ -193,7 +193,8 @@ private constructor(
       CodyAgentService.setAgentError(project, e)
 
       val message = ((e.cause as? CodyAgentException) ?: e).message ?: e.toString()
-      val errorReportLink = CodyErrorSubmitter().getEncodedUrl(e.getThrowableText(), message)
+      val errorReportLink =
+          CodyErrorSubmitter().getEncodedUrl(project, e.getThrowableText(), message)
       addErrorMessageAsAssistantMessage(
           CodyBundle.getString("chat.general-error").fmt(errorReportLink, message))
     } finally {

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/ReportCodyBugAction.kt
@@ -2,10 +2,11 @@ package com.sourcegraph.cody.statusbar
 
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.cody.error.CodyErrorSubmitter
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
 class ReportCodyBugAction : DumbAwareEDTAction("Open GitHub To Report Cody Issue") {
-  override fun actionPerformed(p0: AnActionEvent) {
-    BrowserUtil.open("https://github.com/sourcegraph/jetbrains/issues/new?template=bug_report.yml")
+  override fun actionPerformed(event: AnActionEvent) {
+    BrowserUtil.open(CodyErrorSubmitter().getEncodedUrl(event.project))
   }
 }


### PR DESCRIPTION
I added a mechanism to automatically derive the about info. A user no longer needs to find and copy paste it.
I simplified the bug report template. Some users showed frustration about the reporting system - too many required fields that are not filled eventually. A single required field remains.

## Test plan
1. Do the report 😃 
