### PR TITLE
Updated the versions of dependencies and build plugins.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,10 +51,9 @@ val skippedFailureLevels =
 plugins {
   id("java")
   id("jvm-test-suite")
-  // Dependencies are locked at this version to work with JDK 11 on CI.
-  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+  id("org.jetbrains.kotlin.jvm") version "1.9.24"
   id("org.jetbrains.intellij") version "1.17.3"
-  id("org.jetbrains.changelog") version "1.3.1"
+  id("org.jetbrains.changelog") version "2.2.0"
   id("com.diffplug.spotless") version "6.25.0"
 }
 
@@ -85,11 +84,11 @@ dependencies {
   // ActionUpdateThread.jar contains copy of the
   // com.intellij.openapi.actionSystem.ActionUpdateThread class
   compileOnly(files("libs/ActionUpdateThread.jar"))
-  implementation("org.commonmark:commonmark:0.21.0")
-  implementation("org.commonmark:commonmark-ext-gfm-tables:0.21.0")
-  implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.21.0")
-  implementation("com.googlecode.java-diff-utils:diffutils:1.3.0")
-  testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
+  implementation("org.commonmark:commonmark:0.22.0")
+  implementation("org.commonmark:commonmark-ext-gfm-tables:0.22.0")
+  implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.23.1")
+  implementation("io.github.java-diff-utils:java-diff-utils:4.12")
+  testImplementation("org.awaitility:awaitility-kotlin:4.2.1")
   testImplementation("org.mockito:mockito-core:5.12.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.0.0")

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -1,5 +1,8 @@
 package com.sourcegraph.cody.autocomplete
 
+import com.github.difflib.DiffUtils
+import com.github.difflib.patch.DeltaType
+import com.github.difflib.patch.Patch
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
@@ -65,9 +68,6 @@ import com.sourcegraph.utils.CodyEditorUtil.isCommandExcluded
 import com.sourcegraph.utils.CodyEditorUtil.isEditorValidForAutocomplete
 import com.sourcegraph.utils.CodyEditorUtil.isImplicitAutocompleteEnabledForEditor
 import com.sourcegraph.utils.CodyFormatter
-import difflib.Delta
-import difflib.DiffUtils
-import difflib.Patch
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -376,7 +376,7 @@ class CodyAutocompleteManager {
     // The diff algorithm returns a list of "deltas" that give us the minimal number of additions we
     // need to make to the document.
     val patch = diff(originalText, defaultItem.insertText)
-    if (!patch.deltas.all { delta -> delta.type == Delta.TYPE.INSERT }) {
+    if (!patch.deltas.all { delta -> delta.type == DeltaType.INSERT }) {
       if (triggerKind == InlineCompletionTriggerKind.INVOKE ||
           UserLevelConfig.isVerboseLoggingEnabled()) {
         logger.warn("Skipping autocomplete with non-insert deltas: $patch")

--- a/src/test/java/com/sourcegraph/cody/autocomplete/AutocompleteDiffTest.java
+++ b/src/test/java/com/sourcegraph/cody/autocomplete/AutocompleteDiffTest.java
@@ -1,6 +1,6 @@
 package com.sourcegraph.cody.autocomplete;
 
-import difflib.Patch;
+import com.github.difflib.patch.Patch;
 import junit.framework.TestCase;
 
 public class AutocompleteDiffTest extends TestCase {


### PR DESCRIPTION
These are the upgrades that **don't** break compatibility with 2022.1. See https://github.com/sourcegraph/cody-issues/issues/240#issuecomment-2133634581.

Unfortunately, we cannot upgrade to Kotlin 2.0.0, because the latest version of `org.awaitility:awaitility-kotlin` still requires Kotlin 1.9.22.

## Test plan

- Ensure that the CI is green.
- Run the integration tests after setting up the environment properly.
- Check manually that the plugin loads in IntelliJ 2022.1 without problems.