### PR TITLE
Build: add Gradle settings to auto-download missing JDK

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,10 @@
 rootProject.name = "Sourcegraph"
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+}
+
 val isCiServer = System.getenv().containsKey("CI")
 
 buildCache { local { isEnabled = !isCiServer } }
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,7 @@
 rootProject.name = "Sourcegraph"
 
-plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
-}
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("0.4.0") }
 
 val isCiServer = System.getenv().containsKey("CI")
 
 buildCache { local { isEnabled = !isCiServer } }
-


### PR DESCRIPTION
Previously, I was unable to import the JetBrains plugin codebase into IntelliJ on my Windows computer because I didn't have a compatible installation of Java 11. This diff configures Gradle to automatically download the JDK so that I can import the build into IntelliJ on Windows without a custom setup.

Following docs here https://docs.gradle.org/8.1.1/userguide/toolchains.html#sub:download_repositories

## Test plan
Imported the build into IntelliJ on Windows.
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
