### PR TITLE
Removed the override of wrapper.gradleVersion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -384,8 +384,6 @@ tasks {
     withType<KotlinCompile> { kotlinOptions.jvmTarget = it }
   }
 
-  wrapper { gradleVersion = properties("gradleVersion") }
-
   patchPluginXml {
     version.set(properties("pluginVersion"))
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,6 @@ platformVersion=2022.1
 platformPlugins=Git4Idea,PerforceDirectPlugin,java
 # Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
 javaVersion=11
-# Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion=8.8
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ platformPlugins=Git4Idea,PerforceDirectPlugin,java
 # Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
 javaVersion=11
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion=8.1.1
+gradleVersion=8.8
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
This is a follow-up to #1770.

The `wrapper.gradleVersion` [property](https://docs.gradle.org/8.1.1/userguide/gradle_wrapper.html#customizing_wrapper) affects only the `wrapper` task, which we run only once in a while when updating the wrapper. It is also [possible](https://stackoverflow.com/a/36385128) to specify the desired version as a command-line parameter, which is what we usually do anyway.

With that in mind, I actually don't see any point in defining this property here. 

## Test plan

N/A