### PR TITLE
Run `testUndo`

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -113,9 +113,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertNoActiveSession()
   }
 
-  // `testUndo` is currently disabled because it is flaky. Undo correctly reverts the change, but
-  // immediately after that we are receiving `textDocument/edit` which brings the change back.
-  fun skip_testUndo() {
+  fun testUndo() {
     val originalDocument = myFixture.editor.document.text
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_ACCEPT_GROUP)
     assertNotSame(


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-2437/fix-testundo.

## Test plan
1. greeen ci
