### PR TITLE
Make sure win-ca-roots.exe is included in the plugin build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.BasicFileAttributes
-import java.util.*
+import java.util.EnumSet
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
 import org.jetbrains.changelog.markdownToHTML
@@ -328,11 +328,7 @@ tasks {
       commandLine("pnpm", "run", "build:agent")
     }
     copy {
-      from(agentDir.resolve("dist")) {
-        include("index.js")
-        include("index.js.map")
-        include("*.wasm")
-      }
+      from(agentDir.resolve("dist"))
       into(buildCodyDir)
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=b4cb8f6445a47c2777074bed2139a7d9d8394a29
+cody.commit=a5f917c1759deb5d3d2f1ec9744746ef5b8e2243


### PR DESCRIPTION
## Changes

Follow up to the https://github.com/sourcegraph/cody/pull/4618

## Test plan

```
➜ CODY_DIR=/Users/pkukielka/Work/sourcegraph/cody ./gradlew :buildPlugin

➜ unzip -l build/distributions/Sourcegraph-6.0-localbuild.zip | grep exe
 69252760  06-19-2024 16:09   Sourcegraph/agent/node-win-x64.exe
    82944  06-19-2024 16:09   Sourcegraph/agent/win-ca-roots.exe
```