### PR TITLE
Do not restore chat sessions without connectionId

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSessionService.kt
@@ -36,11 +36,13 @@ class AgentChatSessionService(private val project: Project) {
       chatSessions.find { it.hasConnectionId(connectionId) }
 
   fun restoreAllSessions(agent: CodyAgent) {
-    chatSessions.forEach { agentChatSession ->
-      HistoryService.getInstance(project)
-          .findActiveAccountChat(agentChatSession.getInternalId())
-          ?.let { agentChatSession.updateFromState(agent, it) }
-    }
+    chatSessions
+        .filter { agentChatSession -> agentChatSession.getConnectionId() != null }
+        .forEach { agentChatSession ->
+          HistoryService.getInstance(project)
+              .findActiveAccountChat(agentChatSession.getInternalId())
+              ?.let { agentChatSession.updateFromState(agent, it) }
+        }
   }
 
   companion object {


### PR DESCRIPTION
Related to https://github.com/sourcegraph/jetbrains/issues/1763.

## Test plan
1. Start IDE
2. ensure `chat/restore` is not called 
