### PR TITLE
Add telemetry v2 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=57a07b906833dba45334cf720a51949c5693430a
+cody.commit=1a155d5432370b31a1b1cf7a1b78412f237f66b0

--- a/src/main/java/com/sourcegraph/cody/agent/protocol/TelemetryEventParameters.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/protocol/TelemetryEventParameters.kt
@@ -1,0 +1,8 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class TelemetryEventParameters(
+    val version: Long? = null,
+    val interactionID: String? = null,
+    val metadata: Map<String, Long>? = null,
+    val privateMetadata: Map<String, String>? = null,
+)

--- a/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
+++ b/src/main/java/com/sourcegraph/cody/chat/CodeEditorFactory.java
@@ -1,18 +1,9 @@
 package com.sourcegraph.cody.chat;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.editor.CaretModel;
-import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorFactory;
-import com.intellij.openapi.editor.EditorSettings;
-import com.intellij.openapi.editor.event.DocumentEvent;
-import com.intellij.openapi.editor.event.DocumentListener;
-import com.intellij.openapi.editor.event.EditorMouseEvent;
-import com.intellij.openapi.editor.event.EditorMouseListener;
-import com.intellij.openapi.editor.event.EditorMouseMotionListener;
+import com.intellij.openapi.editor.*;
+import com.intellij.openapi.editor.event.*;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
@@ -20,15 +11,16 @@ import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.util.ui.JBInsets;
 import com.sourcegraph.cody.chat.ui.CodeEditorButtons;
 import com.sourcegraph.cody.chat.ui.CodeEditorPart;
+import com.sourcegraph.cody.telemetry.TelemetryV2;
 import com.sourcegraph.cody.ui.AttributionButtonController;
 import com.sourcegraph.cody.ui.TransparentButton;
 import com.sourcegraph.telemetry.GraphQlLogger;
-import java.awt.Dimension;
-import java.awt.Insets;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
-import java.awt.event.*;
+import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.time.Duration;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -179,9 +171,8 @@ public class CodeEditorFactory {
       timer.start();
 
       lastCopiedText = text;
-      ApplicationManager.getApplication()
-          .executeOnPooledThread(
-              () -> GraphQlLogger.logCodeGenerationEvent(project, "copyButton", "clicked", text));
+      GraphQlLogger.logCodeGenerationEvent(project, "copyButton", "clicked", text);
+      TelemetryV2.Companion.sendCodeGenerationEvent(project, "copyButton", "clicked", text);
     };
   }
 
@@ -209,10 +200,8 @@ public class CodeEditorFactory {
               }
             });
 
-        ApplicationManager.getApplication()
-            .executeOnPooledThread(
-                () ->
-                    GraphQlLogger.logCodeGenerationEvent(project, "insertButton", "clicked", text));
+        GraphQlLogger.logCodeGenerationEvent(project, "insertButton", "clicked", text);
+        TelemetryV2.Companion.sendCodeGenerationEvent(project, "insertButton", "clicked", text);
       }
     };
   }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -31,6 +31,7 @@ import com.sourcegraph.cody.agent.protocol.RemoteRepoListParams
 import com.sourcegraph.cody.agent.protocol.RemoteRepoListResponse
 import com.sourcegraph.cody.agent.protocol.ServerInfo
 import com.sourcegraph.cody.agent.protocol.TaskIdParam
+import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.chat.ConnectionId
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
@@ -50,6 +51,9 @@ interface CodyAgentServer {
 
   @JsonRequest("autocomplete/execute")
   fun autocompleteExecute(params: AutocompleteParams?): CompletableFuture<AutocompleteResult>
+
+  @JsonRequest("telemetry/recordEvent")
+  fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
 
   @JsonRequest("graphql/logEvent") fun logEvent(event: Event): CompletableFuture<Void?>
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TelemetryEvent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/TelemetryEvent.kt
@@ -1,0 +1,7 @@
+package com.sourcegraph.cody.agent.protocol
+
+data class TelemetryEvent(
+    val feature: String,
+    val action: String,
+    val parameters: TelemetryEventParameters?
+)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.chat.ui
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import com.intellij.ui.ColorUtil
 import com.intellij.util.ui.SwingHelper
@@ -123,9 +122,7 @@ class SingleMessagePanel(
         AttributionSearchCommand(project).onSnippetFinished(lastPart.text, connectionId, listener)
       }
 
-      ApplicationManager.getApplication().executeOnPooledThread {
-        GraphQlLogger.logCodeGenerationEvent(project, "chatResponse", "hasCode", lastPart.text)
-      }
+      GraphQlLogger.logCodeGenerationEvent(project, "chatResponse", "hasCode", lastPart.text)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.listeners
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.editor.event.BulkAwareDocumentListener
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -12,6 +11,7 @@ import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction
 import com.sourcegraph.cody.chat.CodeEditorFactory
+import com.sourcegraph.cody.telemetry.TelemetryV2
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
 import com.sourcegraph.telemetry.GraphQlLogger
 
@@ -21,9 +21,9 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
     val pastedCode = event.newFragment.toString()
     if (pastedCode.isNotBlank() && CodeEditorFactory.lastCopiedText == pastedCode) {
       CodeEditorFactory.lastCopiedText = null
-      ApplicationManager.getApplication().executeOnPooledThread {
-        GraphQlLogger.logCodeGenerationEvent(project, "keyDown:Paste", "clicked", pastedCode)
-      }
+      GraphQlLogger.logCodeGenerationEvent(project, "keyDown:Paste", "clicked", pastedCode)
+      TelemetryV2.sendCodeGenerationEvent(
+          project, feature = "keyDown", action = "paste", pastedCode)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
@@ -1,0 +1,40 @@
+package com.sourcegraph.cody.telemetry
+
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.TelemetryEvent
+import com.sourcegraph.cody.agent.protocol.TelemetryEventParameters
+
+class TelemetryV2 {
+  companion object {
+    fun sendTelemetryEvent(
+        project: Project,
+        feature: String,
+        action: String,
+        parameters: TelemetryEventParameters? = null
+    ) {
+      CodyAgentService.withAgent(project) { agent ->
+        agent.server.recordEvent(
+            TelemetryEvent(feature = "cody.$feature", action = action, parameters = parameters))
+      }
+    }
+
+    fun sendCodeGenerationEvent(project: Project, feature: String, action: String, code: String) {
+      val op =
+          if (action.startsWith("copy")) "copy"
+          else if (action.startsWith("insert")) "insert" else "save"
+
+      val metadata =
+          mapOf("lineCount" to code.lines().count().toLong(), "charCount" to code.length.toLong())
+
+      val privateMetadata = mapOf("op" to op, "source" to "chat")
+
+      sendTelemetryEvent(
+          project = project,
+          feature = feature,
+          action = action,
+          parameters =
+              TelemetryEventParameters(metadata = metadata, privateMetadata = privateMetadata))
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.telemetry
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
@@ -7,15 +8,41 @@ import com.sourcegraph.cody.agent.protocol.TelemetryEventParameters
 
 class TelemetryV2 {
   companion object {
+    private val intellijProductCodeMap =
+        mapOf(
+            "IU" to 1L, // IntelliJ IDEA Ultimate
+            "IC" to 2L, // IntelliJ IDEA Community
+            "IE" to 3L, // IntelliJ IDEA Educational
+            "PS" to 4L, // PhpStorm
+            "WS" to 5L, // WebStorm
+            "PY" to 6L, // PyCharm Professional
+            "PC" to 7L, // PyCharm Community
+            "PE" to 8L, // PyCharm Educational
+            "RM" to 9L, // RubyMine
+            "OC" to 10L, // AppCode
+            "CL" to 11L, // CLion
+            "GO" to 12L, // GoLand
+            "DB" to 13L, // DataGrip
+            "RD" to 14L, // Rider
+            "AI" to 15L, // Android Studio
+        )
+
     fun sendTelemetryEvent(
         project: Project,
         feature: String,
         action: String,
         parameters: TelemetryEventParameters? = null
     ) {
+      val build = ApplicationInfo.getInstance().build
+      val versionParameters =
+          mapOf(
+              "ideProductCode" to intellijProductCodeMap.getOrDefault(build.productCode, 0L),
+              "ideBaselineVersion" to build.baselineVersion.toLong())
+      val newParameters = parameters?.copy(metadata = parameters.metadata?.plus(versionParameters))
+
       CodyAgentService.withAgent(project) { agent ->
         agent.server.recordEvent(
-            TelemetryEvent(feature = "cody.$feature", action = action, parameters = parameters))
+            TelemetryEvent(feature = "cody.$feature", action = action, parameters = newParameters))
       }
     }
 


### PR DESCRIPTION
Fixes CODY-913

## Changes

Add support for telemetry v2 and migrate few of the existing calls (not all of them need to be migrated to v2 as some v2 events now comes from agent).

## Test plan

1. Ask cody to generate custom code
2. Copy/paste it using the button, or insert it at cursor
3. Check appropriate looker board to see if event exists (I will paste a screenshot later)