### PR TITLE
Respect plugin version form gradle.properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -429,6 +429,11 @@ tasks {
     }
   }
 
+  patchPluginXml {
+    sinceBuild = properties("pluginSinceBuild")
+    untilBuild = properties("pluginUntilBuild")
+  }
+
   runIde {
     dependsOn(project.tasks.getByPath("buildCody"))
     jvmArgs("-Djdk.module.illegalAccess.silent=true")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,18 +9,6 @@
     <change-notes>
         <![CDATA[Update notes are available on <a href="https://github.com/sourcegraph/jetbrains/releases">GitHub</a>.]]></change-notes>
 
-    <!--
-        See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-        for insight into build numbers and IntelliJ Platform versions.
-        - 2020.2 was the first version to have JCEF enabled by default
-            -> https://plugins.jetbrains.com/docs/intellij/jcef.html
-        - Version 2020.2 and 2020.3 have issues with adding custom HTTP headers to requests from within the JCEF view
-             -> https://github.com/sourcegraph/sourcegraph/issues/37475#issuecomment-1171355831
-        - Version 2022.1 is the version introducing the Kotlin UI DSL API we are using at the moment
-          - if the need arises, we may try to implement backwards compatibility to 2021.3
-    -->
-    <idea-version since-build="221.5080.210"/>
-
     <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
 
     <depends>com.intellij.modules.lang</depends>


### PR DESCRIPTION
## Test plan

1. Build plugin using `./gradlew buildPlugin`
2. Unpack the plugin jar and check if versions are set correctly inside plugin.xml