### PR TITLE
Do not throw ProcessCanceledException in tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -537,6 +537,7 @@ tasks {
   named("check") { dependsOn("integrationTest") }
 
   test {
+    jvmArgs("-Didea.ProcessCanceledException=disabled")
     agentProperties.forEach { (key, value) -> systemProperty(key, value) }
     dependsOn("buildCody")
   }


### PR DESCRIPTION
## Changes

ProcessCanceledException exception is indicating that the currently running operation was terminated and should finish as soon as possible. Usually, this exception should not be caught, swallowed, logged, or handled in any way. Instead, it should be rethrown so that the infrastructure can handle it correctly. This exception can happen during almost any IDE activity, e.g. any PSI query, com.intellij.openapi.extensions.ExtensionPointName.getExtensions, com.intellij.openapi.actionSystem.AnAction.update, etc.

In our tests it is a problem because they completes before `VcsContentAnnotationSettings` service is able to finish initialisation. It is not a problem for a production code. 
Easiest fix seems to be disabling `ProcessCanceledException` for tests.

```
Caused by: com.intellij.openapi.progress.ProcessCanceledException: com.intellij.serviceContainer.AlreadyDisposedException: Cannot create 
ServiceAdapter(descriptor=ServiceDescriptor(interface='null', 
			serviceImplementation='com.intellij.openapi.vcs.contentAnnotation.VcsContentAnnotationSettings', 
			testServiceImplementation='null', 
			headlessImplementation='null', 
			overrides=false, 
			configurationSchemaKey='null', 
			preload=FALSE, 
			client=null), 
			pluginDescriptor=PluginDescriptor(name=IDEA CORE, 
			id=com.intellij, 
			descriptorPath=plugin.xml, 
			path=~/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2022.1/c91a19824ffcb28872ecd2761c83b250f703ff21/ideaIC-2022.1/lib, 
			version=221.5080.210, 
			package=null, 
			isBundled=true)) because container is already disposed (container=Project(name=_toOffsetReturnsCorrectOffsetOnEmptyFile, 
			containerState=disposed temporarily, 
			componentStore=/tmp/unitTest_notifies_observer_2iJxZTHC49M0UuRdsU0aJWP1Yhk/light_temp_2iJxZeAWuChAXHeDbNrZYwPct1N.ipr) (disposed))
	at com.intellij.serviceContainer.ContainerUtilKt.throwAlreadyDisposedError(containerUtil.kt:39)
```

## Test plan

N/A