### PR TITLE
Enable testGetsWorkingGroupLens

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -37,7 +37,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
         selection.startOffset == caret && selection.endOffset == caret)
   }
 
-  fun skip_testGetsWorkingGroupLens() {
+  fun testGetsWorkingGroupLens() {
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_WORKING_GROUP)
     assertInlayIsShown()
 
@@ -46,7 +46,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertNotNull("Lens group should be displayed", lenses)
 
     val widgets = lenses!!.widgets
-    assertEquals("Lens group should have 6 widgets", 8, widgets.size)
+    assertEquals("Lens group should have 8 widgets", 8, widgets.size)
     assertTrue("Zeroth lens group should be an icon", widgets[0] is LensIcon)
     assertTrue("First lens group is space separator label", (widgets[1] as LensLabel).text == " ")
     assertTrue("Second lens group is a spinner", widgets[2] is LensSpinner)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -134,6 +134,10 @@ class FixupService(val project: Project) : Disposable {
     synchronized(fixupSessionStateListeners) { fixupSessionStateListeners.add(listener) }
   }
 
+  fun removeListener(listener: ActiveFixupSessionStateListener) {
+    synchronized(fixupSessionStateListeners) { fixupSessionStateListeners.remove(listener) }
+  }
+
   fun isEditInProgress(): Boolean {
     return activeSession?.isShowingWorkingLens() ?: false
   }


### PR DESCRIPTION
Related to https://linear.app/sourcegraph/issue/CODY-1909/ci-tests-are-flaky#comment-da664388.

Interesting. I ma sure the test failed for me locally and in CI. Possibly it is just flaky 🫤 

I will look into it 🕵️ 

## Test plan
1. Green CI
