### PR TITLE
Check if project is disposed in CodyAuthenticationManager before notifying the message bus

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -106,7 +106,9 @@ class CodyAuthenticationManager(val project: Project) : Disposable {
 
     accountTierFuture.thenApply { currentAccountTier ->
       if (previousAccountTier != currentAccountTier) {
-        publisher.afterAction(AccountSettingChangeContext(accountTierChanged = true))
+        if (!project.isDisposed) {
+          publisher.afterAction(AccountSettingChangeContext(accountTierChanged = true))
+        }
       }
     }
 
@@ -134,7 +136,9 @@ class CodyAuthenticationManager(val project: Project) : Disposable {
 
     isTokenInvalidFuture.thenApply { isTokenInvalid ->
       if (previousIsTokenInvalid != isTokenInvalid) {
-        publisher.afterAction(AccountSettingChangeContext(isTokenInvalidChanged = true))
+        if (!project.isDisposed) {
+          publisher.afterAction(AccountSettingChangeContext(isTokenInvalidChanged = true))
+        }
       }
     }
 
@@ -176,7 +180,9 @@ class CodyAuthenticationManager(val project: Project) : Disposable {
     if (oldToken != newToken && account == getActiveAccount()) {
       CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
         agent.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
-        publisher.afterAction(AccountSettingChangeContext(accessTokenChanged = true))
+        if (!project.isDisposed) {
+          publisher.afterAction(AccountSettingChangeContext(accessTokenChanged = true))
+        }
       }
     }
   }
@@ -202,9 +208,11 @@ class CodyAuthenticationManager(val project: Project) : Disposable {
       if (serverUrlChanged || tierChanged) {
         CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
           agent.server.configurationDidChange(ConfigUtil.getAgentConfiguration(project))
-          publisher.afterAction(
-              AccountSettingChangeContext(
-                  serverUrlChanged = serverUrlChanged, accountTierChanged = tierChanged))
+          if (!project.isDisposed) {
+            publisher.afterAction(
+                AccountSettingChangeContext(
+                    serverUrlChanged = serverUrlChanged, accountTierChanged = tierChanged))
+          }
         }
       }
     }


### PR DESCRIPTION
## Test plan
The issue seems to be hard to reproduce. Possibly it can appear when you close and reopen the project in the right moment. The right moment is b/w focusing the IDE window and sending the receiving the graphql response from the server.

---

Let's try to merge it quickly to unblock others. I will try to review the docs related to disposables and review the intellij's code. I have a feeling that we are doing smth wrong. We should not have to add so many checks.