### PR TITLE
Fix issues CODY-2598 and CODY-2600

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -184,6 +184,8 @@ should match whatever we have most recently set them to; they change now and the
 * The hotkeys displayed in the hint should be correct.
 * The colors chosen should be clearly visible on all themes.
 * It is OK if the hint is not visible in some places because it's offscreen.
+* The hint should not appear in any views/panes in the IDE other than code editor tabs.
+* The hint should not appear if there is an active edit session.
 
 ### Explain Code
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionListener.kt
@@ -10,7 +10,7 @@ import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.config.ConfigUtil
 
 class CodySelectionListener(val project: Project) : SelectionListener {
-  private val inlayManager = CodySelectionInlayManager()
+  private val inlayManager = CodySelectionInlayManager(project)
 
   override fun selectionChanged(event: SelectionEvent) {
     if (!ConfigUtil.isCodyEnabled() ||


### PR DESCRIPTION
We were showing the hotkey help inlay in inappropriate situations:

- in random panes/views that allow selections, such as the console window
- when an inline edit is currently active

## Test plan

Updated manual test plan to check for these two cases.