### PR TITLE
Fix "Get started" button in onboarding panel

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -128,6 +128,7 @@ class CodyToolWindowContent(private val project: Project) {
       allContentLayout.show(allContentPanel, ONBOARDING_PANEL)
       return
     }
+    allContentLayout.show(allContentPanel, MAIN_PANEL)
   }
 
   @RequiresEdt


### PR DESCRIPTION
My bad. I accidentally removed it (I was trying to persist the opened tab in Cody tool window). sorry.

## Test plan
1. Having empty account list (no account signed in)
2. Sign into a new account
