### PR TITLE
Moved the plugin verifier to a separate CI job.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,10 +55,22 @@ jobs:
       - run: ./gradlew buildPlugin
       # - run: ./gradlew runPluginVerifier -Pvalidation=lite
       - run: ./gradlew --stop
-      - name: IntelliJ Plugin Verifier
-        uses: thepieterdc/intellij-plugin-verifier-action@1.3.0
+      - uses: actions/upload-artifact@v4
         with:
-          plugin: './build/distributions/Sourcegraph-*.zip'
+          name: plugin.zip
+          path: './build/distributions/Sourcegraph-*.zip'
+  plugin-verifier:
+    name: IntelliJ Plugin Verifier
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: plugin.zip
+      - uses: thepieterdc/intellij-plugin-verifier-action@1.3.0
+        with:
+          plugin: plugin.zip
           verifier_version: 1.369
           versions: |
             2021.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: plugin.zip
+      - run: |
+          pwd
+          ls -l
+          find . -type f -name 'plugin.zip'
       - name: Verify Plugin on IntelliJ Platforms
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,13 +65,6 @@ jobs:
     needs:
       - test
     steps:
-      - name: Free disk space
-        run: |
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          df -h
       - uses: actions/download-artifact@v4
         with:
           name: plugin.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          plugin-location: plugin.zip
+          plugin-location: '*.zip'
           ide-versions: |
             ideaIC:2021.1
             ideaIC:2024.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: thepieterdc/intellij-plugin-verifier-action@1.3.0
         with:
           plugin: plugin.zip
-          verifier_version: 1.369
+          # verifier_version: 1.369
           versions: |
             2021.1
             2024.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
           name: test-report
           path: build/reports/tests/
       - run: ./gradlew buildPlugin
-      # - run: ./gradlew runPluginVerifier -Pvalidation=lite
       - run: ./gradlew --stop
       - uses: actions/upload-artifact@v4
         with:
@@ -68,10 +67,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: plugin.zip
-      - run: |
-          pwd
-          ls -l
-          find . -type f -name 'plugin.zip'
       - name: Verify Plugin on IntelliJ Platforms
         id: verify
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@v2.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,5 +53,13 @@ jobs:
           name: test-report
           path: build/reports/tests/
       - run: ./gradlew buildPlugin
-      - run: ./gradlew runPluginVerifier -Pvalidation=lite
+      # - run: ./gradlew runPluginVerifier -Pvalidation=lite
       - run: ./gradlew --stop
+      - name: IntelliJ Plugin Verifier
+        uses: thepieterdc/intellij-plugin-verifier-action@1.3.0
+        with:
+          plugin: './build/distributions/Sourcegraph-*.zip'
+          verifier_version: 1.369
+          versions: |
+            2021.1
+            2024.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,4 +82,11 @@ jobs:
             ideaIC:2021.1
             ideaIC:2024.1
           failure-levels: |
-            COMPATIBILITY_PROBLEMS
+            COMPATIBILITY_WARNINGS
+            INTERNAL_API_USAGES
+            OVERRIDE_ONLY_API_USAGES
+            NON_EXTENDABLE_API_USAGES
+            PLUGIN_STRUCTURE_WARNINGS
+            MISSING_DEPENDENCIES
+            INVALID_PLUGIN
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,14 @@ jobs:
       # Skip Code Search build in CI because it's slow, and we don't use it anyway for testing purposes.
       - run: echo "SKIP_CODE_SEARCH_BUILD=true" >> $GITHUB_ENV
       - run: ./gradlew spotlessCheck
-      # - run: ./gradlew check
+      - run: ./gradlew check
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/
-      - run: ./gradlew buildPlugin -x test
+      - run: ./gradlew buildPlugin
       # - run: ./gradlew runPluginVerifier -Pvalidation=lite
       - run: ./gradlew --stop
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
           find . -type f -name 'plugin.zip'
       - name: Verify Plugin on IntelliJ Platforms
         id: verify
-        uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+        uses: ChrisCarini/intellij-platform-plugin-verifier-action@v2.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,13 @@ jobs:
     needs:
       - test
     steps:
+      - name: Free disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          df -h
       - uses: actions/download-artifact@v4
         with:
           name: plugin.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,14 @@ jobs:
       # Skip Code Search build in CI because it's slow, and we don't use it anyway for testing purposes.
       - run: echo "SKIP_CODE_SEARCH_BUILD=true" >> $GITHUB_ENV
       - run: ./gradlew spotlessCheck
-      - run: ./gradlew check
+      # - run: ./gradlew check
       - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-report
           path: build/reports/tests/
-      - run: ./gradlew buildPlugin
+      - run: ./gradlew buildPlugin -x test
       # - run: ./gradlew runPluginVerifier -Pvalidation=lite
       - run: ./gradlew --stop
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,6 @@ jobs:
             INVALID_PLUGIN
       - uses: actions/upload-artifact@v4
         with:
-          name: plugin-verifier-reports.log
-          path: ${{steps.verify.outputs.verification-output-log-filename}}
+          name: plugin-verifier-reports
+          path: 'verification-*'
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,14 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: plugin.zip
-      - uses: thepieterdc/intellij-plugin-verifier-action@1.3.0
+      - name: Verify Plugin on IntelliJ Platforms
+        uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          plugin: plugin.zip
-          # verifier_version: 1.369
-          versions: |
-            2021.1
-            2024.1
+          plugin-location: plugin.zip
+          ide-versions: |
+            ideaIC:2021.1
+            ideaIC:2024.1
+          failure-levels: |
+            COMPATIBILITY_PROBLEMS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,7 @@ jobs:
           ls -l
           find . -type f -name 'plugin.zip'
       - name: Verify Plugin on IntelliJ Platforms
+        id: verify
         uses: ChrisCarini/intellij-platform-plugin-verifier-action@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,4 +90,8 @@ jobs:
             PLUGIN_STRUCTURE_WARNINGS
             MISSING_DEPENDENCIES
             INVALID_PLUGIN
+      - uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-reports.log
+          path: ${{steps.verify.outputs.verification-output-log-filename}}
         


### PR DESCRIPTION
Closes #1836.

Things to be improved later:

- Try to set up caching for the [downloaded](https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/blob/d4677a90c77ed1dbb564bd91ce67dbee92ff0ab8/entrypoint.sh#L346) IntelliJ distributions
- Read the platform versions from a [file](https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action?tab=readme-ov-file#configuration-file-for-ideversion)

## Test plan

Green CI, the verifier reports should be available as artifacts