### PR TITLE
Skip the flaky test: testGetsWorkingGroupLens

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -139,7 +139,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertNoActiveSession()
   }
 
-  fun testUndo() {
+  fun skip_testUndo() {
     val originalDocument = myFixture.editor.document.text
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_ACCEPT_GROUP)
     assertNotSame(

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -39,7 +39,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
         selection.startOffset == caret && selection.endOffset == caret)
   }
 
-  fun testGetsWorkingGroupLens() {
+  fun skip_testGetsWorkingGroupLens() {
     val assertsExecuted = AtomicInteger(0)
     val showWorkingGroupSessionStateListener =
         object : FixupService.ActiveFixupSessionStateListener {


### PR DESCRIPTION
Opens https://linear.app/sourcegraph/issue/CODY-2665/fix-flaky-test-testgetsworkinggrouplens.
Opens https://linear.app/sourcegraph/issue/CODY-2667/fix-flaky-test-testundo.

## Test plan
1. Green CI 
