### PR TITLE
Fix problems action

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -118,6 +118,8 @@ interface CodyAgentServer {
 
   @JsonRequest("editCommands/document") fun commandsDocument(): CompletableFuture<EditTask>
 
+  @JsonRequest("editCommands/fix") fun commandsFix(): CompletableFuture<EditTask>
+
   @JsonRequest("editCommands/code")
   fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -13,6 +13,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.CodyStartingNotification
 import com.sourcegraph.cody.agent.EditingNotAvailableNotification
 import com.sourcegraph.cody.edit.sessions.DocumentCodeSession
+import com.sourcegraph.cody.edit.sessions.FixProblemSession
 import com.sourcegraph.cody.edit.sessions.FixupSession
 import com.sourcegraph.cody.edit.sessions.TestCodeSession
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
@@ -59,6 +60,15 @@ class FixupService(val project: Project) : Disposable {
     runInEdt {
       if (isEligibleForInlineEdit(editor)) {
         TestCodeSession(this, editor, editor.project ?: return@runInEdt)
+      }
+    }
+  }
+
+  /** Entry point for the fix problem command, called by the action handler. */
+  fun startFixProblem(editor: Editor) {
+    runInEdt {
+      if (isEligibleForInlineEdit(editor)) {
+        FixProblemSession(this, editor, editor.project ?: return@runInEdt)
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/FixProblemAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/FixProblemAction.kt
@@ -1,0 +1,10 @@
+package com.sourcegraph.cody.edit.actions
+
+class FixProblemAction :
+    NonInteractiveEditCommandAction({ editor, fixupService ->
+      fixupService.startFixProblem(editor)
+    }) {
+  companion object {
+    const val ID: String = "cody.fixProblemAction"
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixProblemSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/sessions/FixProblemSession.kt
@@ -1,0 +1,31 @@
+package com.sourcegraph.cody.edit.sessions
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgent
+import com.sourcegraph.cody.agent.protocol.EditTask
+import com.sourcegraph.cody.edit.FixupService
+import java.util.concurrent.CompletableFuture
+
+class FixProblemSession(
+    controller: FixupService,
+    editor: Editor,
+    project: Project,
+) : FixupSession(controller, project, editor) {
+
+  override fun makeEditingRequest(agent: CodyAgent): CompletableFuture<EditTask> {
+    return try {
+      agent.server.commandsFix()
+    } catch (x: Exception) {
+      logger.warn("Failed to execute editCommands/document request", x)
+      CompletableFuture.failedFuture(x)
+    }
+  }
+
+  override val commandName = "Fix"
+
+  companion object {
+    private val logger = Logger.getInstance(FixProblemSession::class.java)
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -294,6 +294,11 @@
             <override-text place="GoToAction" text="Cody: Generate Unit Tests"/>
         </action>
 
+        <action id="cody.fixProblemAction"
+          class="com.sourcegraph.cody.edit.actions.FixProblemAction" text="Fix Problems">
+            <add-to-group group-id="CodyEditorActions" anchor="first"/>
+        </action>
+
         <action id="cody.documentCodeAction"
                 icon="/icons/edit/document_code.svg"
                 class="com.sourcegraph.cody.edit.actions.DocumentCodeAction"


### PR DESCRIPTION
Partially implements #117.

### To do before merging
* Implement the `editCommands/fix` request on the agent side

### To do in a follow-up PR
* Code inspection and "Quick fix" annotation

### Out of scope 
* Hotkey and icon for the new action

## Test plan

TODO