### PR TITLE
Add telemetry for rate limits notifications and upsell

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -58,7 +58,7 @@ class CodyToolWindowContent(private val project: Project) {
 
     allContentPanel.add(tabbedPane.component, MAIN_PANEL, CHAT_PANEL_INDEX)
     allContentPanel.add(SignInWithSourcegraphPanel(project), SIGN_IN_PANEL, SIGN_IN_PANEL_INDEX)
-    val codyOnboardingGuidancePanel = CodyOnboardingGuidancePanel()
+    val codyOnboardingGuidancePanel = CodyOnboardingGuidancePanel(project)
     codyOnboardingGuidancePanel.addMainButtonActionListener {
       CodyApplicationSettings.instance.isOnboardingGuidanceDismissed = true
       refreshPanelsVisibility()

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -30,6 +30,7 @@ import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.EnhancedContextState
 import com.sourcegraph.cody.history.state.MessageState
+import com.sourcegraph.cody.telemetry.TelemetryV2
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
@@ -175,6 +176,11 @@ private constructor(
             val errorReportLink = CodyErrorSubmitter().getEncodedUrl(project, chatError.message)
             CodyBundle.getString("chat.general-error").fmt(errorReportLink, chatError.message)
           }
+
+      val feature =
+          if (rateLimitError?.upgradeIsAvailable == true) "upsellUsageLimitCTA"
+          else "abuseUsageLimitCTA"
+      TelemetryV2.sendTelemetryEvent(project, feature, "shown")
 
       addErrorMessageAsAssistantMessage(errorMessage)
     } finally {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/SignInWithSourcegraphPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/SignInWithSourcegraphPanel.kt
@@ -2,7 +2,11 @@ package com.sourcegraph.cody.chat
 
 import com.intellij.ide.DataManager
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
-import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionPlaces
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataContextWrapper
+import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.ex.ActionUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.VerticalFlowLayout
@@ -12,7 +16,9 @@ import com.intellij.ui.components.AnActionLink
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.Icons
-import com.sourcegraph.cody.auth.SsoAuthMethod.*
+import com.sourcegraph.cody.auth.SsoAuthMethod.GITHUB
+import com.sourcegraph.cody.auth.SsoAuthMethod.GITLAB
+import com.sourcegraph.cody.auth.SsoAuthMethod.GOOGLE
 import com.sourcegraph.cody.auth.ui.SignInWithEnterpriseInstanceAction
 import com.sourcegraph.cody.chat.ui.UIComponents
 import com.sourcegraph.cody.config.CodyAccountsHost
@@ -40,7 +46,7 @@ class SignInWithSourcegraphPanel(private val project: Project) : JPanel() {
       UIComponents.createMainButton(GOOGLE.value, Icons.SignIn.Google)
 
   init {
-    val jEditorPane = createHtmlViewer()
+    val jEditorPane = createHtmlViewer(project)
     jEditorPane.text =
         ("<html><body><h2>Welcome to Cody</h2>" +
             "<p>Understand and write code faster with an AI assistant</p>" +

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/CodyOnboardingGuidancePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/CodyOnboardingGuidancePanel.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.chat.ui
 
 import com.intellij.ide.ui.laf.darcula.ui.DarculaButtonUI
+import com.intellij.openapi.project.Project
 import com.intellij.ui.ColorUtil
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
@@ -22,7 +23,7 @@ import javax.swing.JEditorPane
 import javax.swing.JPanel
 import javax.swing.text.html.HTMLEditorKit
 
-class CodyOnboardingGuidancePanel : JPanel() {
+class CodyOnboardingGuidancePanel(val project: Project) : JPanel() {
 
   private val createIntroductionMessage: JEditorPane = createIntroductionMessage()
 
@@ -69,7 +70,7 @@ class CodyOnboardingGuidancePanel : JPanel() {
   }
 
   private fun createIntroductionMessage(): JEditorPane {
-    val introductionMessage = createHtmlViewer()
+    val introductionMessage = createHtmlViewer(project)
     val introductionMessageEditorKit = introductionMessage.editorKit as HTMLEditorKit
     introductionMessageEditorKit.styleSheet.addRule(paragraphColorStyle)
     introductionMessage.setMargin(JBUI.emptyInsets())
@@ -140,7 +141,7 @@ class CodyOnboardingGuidancePanel : JPanel() {
   }
 
   private fun createInfoSection(): JEditorPane {
-    val sectionInfo = createHtmlViewer()
+    val sectionInfo = createHtmlViewer(project)
     val sectionInfoHtmlEditorKit = sectionInfo.editorKit as HTMLEditorKit
     sectionInfoHtmlEditorKit.styleSheet.addRule(paragraphColorStyle)
     sectionInfoHtmlEditorKit.styleSheet.addRule("""h3 { margin-top: 0;}""")

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/SingleMessagePanel.kt
@@ -1,11 +1,8 @@
 package com.sourcegraph.cody.chat.ui
 
 import com.intellij.openapi.project.Project
-import com.intellij.ui.ColorUtil
 import com.intellij.util.ui.SwingHelper
-import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.protocol.ChatMessage
-import com.sourcegraph.cody.agent.protocol.Speaker
 import com.sourcegraph.cody.attribution.AttributionListener
 import com.sourcegraph.cody.attribution.AttributionSearchCommand
 import com.sourcegraph.cody.chat.ChatSession
@@ -16,7 +13,6 @@ import com.sourcegraph.cody.chat.findNodeAfterLastCodeBlock
 import com.sourcegraph.cody.chat.isCodeBlock
 import com.sourcegraph.cody.ui.HtmlViewer.createHtmlViewer
 import com.sourcegraph.telemetry.GraphQlLogger
-import java.awt.Color
 import javax.swing.JEditorPane
 import javax.swing.JPanel
 import org.commonmark.ext.gfm.tables.TablesExtension
@@ -90,16 +86,11 @@ class SingleMessagePanel(
   }
 
   private fun addAsNewTextComponent(renderedHtml: String) {
-    val textPane: JEditorPane = createHtmlViewer()
+    val textPane: JEditorPane = createHtmlViewer(project)
     SwingHelper.setHtml(textPane, renderedHtml, null)
     val textEditorComponent = TextPart(textPane)
     this.lastMessagePart = textEditorComponent
     add(textEditorComponent.component)
-  }
-
-  private fun getInlineCodeBackgroundColor(speaker: Speaker): Color {
-    return if (speaker == Speaker.ASSISTANT) ColorUtil.darker(UIUtil.getPanelBackground(), 3)
-    else ColorUtil.brighter(UIUtil.getPanelBackground(), 3)
   }
 
   /**

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/TrialEndedNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/TrialEndedNotification.kt
@@ -28,7 +28,7 @@ class TrialEndedNotification(val disposable: Disposable) :
             NotificationAction(CodyBundle.getString("EndOfTrialNotification.link-action-name")) {
           override fun actionPerformed(anActionEvent: AnActionEvent, notification: Notification) {
             openInBrowser(
-                anActionEvent.project, CodyBundle.getString("TrialEndedNotification.ended.link"))
+                anActionEvent.project, CodyBundle.getString("url.sourcegraph.subscription"))
             notification.expire()
           }
         })

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/RateLimitErrorWarningAction.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.statusbar
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.ui.Messages
 import com.sourcegraph.cody.Icons
+import com.sourcegraph.cody.telemetry.TelemetryV2
 import com.sourcegraph.common.BrowserOpener
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.config.ConfigUtil
@@ -31,7 +32,12 @@ class RateLimitErrorWarningAction(
             /* defaultOptionIndex= */ 1,
             Icons.CodyLogo)
 
+    val feature =
+        if (shouldShowUpgradeOption) "upsellUsageLimitStatusBar" else "abuseUsageLimitStatusBar"
+    e.project?.let { TelemetryV2.sendTelemetryEvent(it, feature, "shown") }
+
     if (result == 1) {
+      e.project?.let { TelemetryV2.sendTelemetryEvent(it, "upsellUsageLimitStatusBar", "clicked") }
       BrowserOpener.openInBrowser(e.project, "https://sourcegraph.com/cody/subscription")
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/HtmlViewer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/HtmlViewer.kt
@@ -1,16 +1,21 @@
 package com.sourcegraph.cody.ui
 
+import com.intellij.openapi.project.Project
 import com.intellij.ui.BrowserHyperlinkListener
 import com.intellij.util.ui.HTMLEditorKitBuilder
 import com.intellij.util.ui.JBInsets
 import com.intellij.util.ui.SwingHelper
 import com.sourcegraph.cody.chat.ChatUIConstants
+import com.sourcegraph.cody.telemetry.TelemetryV2
+import com.sourcegraph.common.CodyBundle
 import java.awt.Insets
+import java.net.URL
 import javax.swing.JEditorPane
+import javax.swing.event.HyperlinkEvent
 
 object HtmlViewer {
   @JvmStatic
-  fun createHtmlViewer(): JEditorPane {
+  fun createHtmlViewer(project: Project): JEditorPane {
     val jEditorPane = SwingHelper.createHtmlViewer(true, null, null, null)
     jEditorPane.editorKit = HTMLEditorKitBuilder().withWordWrapViewFactory().build()
     jEditorPane.isFocusable = true
@@ -21,7 +26,16 @@ object HtmlViewer {
                 ChatUIConstants.TEXT_MARGIN,
                 ChatUIConstants.TEXT_MARGIN,
                 ChatUIConstants.TEXT_MARGIN))
-    jEditorPane.addHyperlinkListener(BrowserHyperlinkListener.INSTANCE)
+    jEditorPane.addHyperlinkListener(MyBrowserHyperlinkListener(project))
     return jEditorPane
+  }
+
+  class MyBrowserHyperlinkListener(val project: Project) : BrowserHyperlinkListener() {
+    override fun hyperlinkActivated(e: HyperlinkEvent) {
+      if (e.url.sameFile(URL(CodyBundle.getString("url.sourcegraph.subscription")))) {
+        TelemetryV2.sendTelemetryEvent(project, "upsellUsageLimitCTA", "clicked")
+      }
+      super.hyperlinkActivated(e)
+    }
   }
 }

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -114,7 +114,6 @@ EndOfTrialNotification.do-not-show-again=Don't show again
 TrialEndedNotification.ignore=cody.ignore.notification.trial-ended
 TrialEndedNotification.ended.title=Your Cody Pro trial has ended
 TrialEndedNotification.ended.content=<html>Thank you for trying Cody Pro! Your trial period has ended. To keep enjoying all the features of Cody Pro, subscribe to our monthly plan. You can cancel anytime.</html>
-TrialEndedNotification.ended.link=https://sourcegraph.com/cody/subscription
 duration.today=Today
 duration.yesterday=Yesterday
 duration.x-days-ago={0} days ago
@@ -215,3 +214,6 @@ settings.migration.llm-upgrade-notification.body=\
     All chats have been upgraded to newer, more capable models. Some old models are no longer supported:<br>\
     <ul>{0}</ul>\
   </html>
+
+# URLs
+url.sourcegraph.subscription=https://sourcegraph.com/cody/subscription


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-2570/p1-add-telemetry-events-usage-limits

## Test plan

**Scenario 1**

1. Switch to rate limited free account
2. Try to do an autocomplete
3. Verify that upsell notification is shown
4. Verify that `cody.upsellUsageLimitCTA:shown` telemetry event was fired
5. Click 'Upgrade' button
6. Verify that `cody.upsellUsageLimitCTA:clicked` event is fired

**Scenario 2**

Do the same for the chat.

**Scenario 3**

Do the same for both auto-complete and chat, but instead of clicking on the notification dismiss it, and open it again using status bar:
![image](https://github.com/sourcegraph/jetbrains/assets/1519649/bc26a399-d4a4-4646-a0ab-6822995195be)
Verify that `cody.upsellUsageLimitStatusBar:shown` and `cody.upsellUsageLimitStatusBar:clicked` fires accordingly.

