### PR TITLE
Manual Stable Release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -29,7 +29,6 @@ jobs:
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
       - name: Publish nightly version
-        if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
         run: |
           echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
           ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,37 @@
+name: Nightly Release
+on:
+  push:
+    tags: [ "*" ]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+      # See note about QEMU and binfmt requirement here https://github.com/vercel/pkg#targets
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v3
+      - run: yarn global add pnpm@8.6.7
+      - run: |
+          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
+      - run: echo "Publishing version $RELEASE_VERSION"
+      - name: Publish nightly version
+        if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
+        run: |
+          echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
+          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,7 +1,6 @@
-name: Release to Marketplace
+name: Stable Release
 on:
-  push:
-    tags: [ "*" ]
+  workflow_dispatch
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -29,12 +28,5 @@ jobs:
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
       - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
-        env:
-          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
-      - name: Publish nightly version
-        if: "!endsWith(env.RELEASE_VERSION, '-nightly')"
-        run: |
-          echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
-          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,18 +126,18 @@ We trigger the stable channel release only after the nightly channel release pas
 
 ```mermaid
 graph TD;
-    Title["JetBrains plugin release"] --> stable;
-    Title --> nightly;
-    stable --> push_stable["push git tag"];
-    push_stable --> release_job_stable["wait for release job to complete"];
-    release_job_stable --> marketplace_approval["wait for marketplace approval"];
-    marketplace_approval -->|Automated approval, up to 48hr| unhide["unhide"];
-    unhide --> available_to_end_users_stable["available for download"];
-    marketplace_approval -->|Manual quick-approve| slack_approval["request JetBrains Marketplace team to manually approve update via Slack"];
-    slack_approval --> unhide["unhide approved release (requires admin access)"];
-    nightly --> push_nightly["push git tag\nwith '-nightly' suffix"];
-    push_nightly --> release_job_nightly["wait for release job to complete"];
-    release_job_nightly --> available_to_end_users_nightly["available for download"];
+    Title --> nightly["Nightly Release"];
+    Title["JetBrains Plugin Release"] --> stable["Stable Release"];
+    stable -->  trigger_stable["Manually trigger 'Stable Release' workflow\nin GitHub Actions"];
+    release_stable --> marketplace_approval["Wait for JetBrains approval"];
+    marketplace_approval --> |Automated approval, up to 48hr| unhide["unhide"];
+    unhide --> available_to_end_users_stable["Available for download"];
+    marketplace_approval --> |Manual quick-approve| slack_approval["Request JetBrains Marketplace team\nto manually approve it via Slack"];
+    slack_approval --> unhide["Unhide the approved release\n(requires admin access)"];
+    nightly --> push_nightly["Run `push-git-tag-for-next-release.sh`"];
+    trigger_stable --> release_stable["Wait for 'Stable Release' workflow to complete"];
+    push_nightly --> release_nightly["Wait for 'Nightly Release' workflow to complete"];
+    release_nightly --> available_to_end_users_nightly["Available for download"];
 ```
 
 We aim to cut a new Stable release every other week on Mondays.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,6 +117,13 @@ After doing that:
 
 ## Publishing a New Release
 
+### Historical context
+We used to publish both stable and nightly channel versions at once. 
+In that approach QA testing and JB approval happened in parallel. 
+However, it consumed a lot of CI time and JB time for the releases that did not pass our QA 
+(and did not go public eventually). Hence, we decided to use a sequential process.
+We trigger the stable channel release only after the nightly channel release passes QA.
+
 ```mermaid
 graph TD;
     Title["JetBrains plugin release"] --> stable;
@@ -136,9 +143,7 @@ graph TD;
 We aim to cut a new Stable release every other week on Mondays.
 The release cadence is irregular for Nightly versions.
 
-### 1. Push a Git Tag
-
-First, choose whether to publish a new version of nightly or stable.
+### 1. Push a git tag & publish a nightly release
 
 Use the following command for a **patch** release:
 
@@ -162,11 +167,14 @@ Or this one for a **major** release
 This script runs `verify-release.sh`, which takes a long time to run with a clean cache, which is why we don't run it in
 CI. When you have a local cache of IDEA installations then this script can run decently fast (~1-2min).
 
-After successfully pushing the new tag (for example: `v5.2.4819` or `v5.2.4249-nightly`), we are now able to publish.
+After successfully pushing the new tag (for example: `v6.0.15`), we are now able to publish.
 
 Wait for the `Release to Marketplace` GitHub workflow to complete.
 
-### 2. For Stable releases, wait for Marketplace approval
+### 2. Publish a stable release 
+
+Go to [Stable Release workflow](https://github.com/sourcegraph/jetbrains/actions/workflows/stable-release.yml),
+click `Run workflow` and select the tag that has been pushed before (and tested by QA team), run it.
 
 It can take up to 48hr for stable releases to get approved by the JetBrains Marketplace team.
 It's possible to expedite this process by posting a message in the `#marketplace` channel in

--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
-# This script implements the time-based version scheme from RFC 795
-# Simplified: versions should be MAJOR.MINOR.PATCH where
-# - MAJOR.MINOR: Latest Sourcegraph quarterly release
-# - PATCH: time-based number from simplified formula (MINUTES_SINCE_LAST_RELEASE / MINUTES_IN_ONE_YEAR * 65535)
-# The scheme gives generates a unique version number every 10 minutes.
-# https://docs.google.com/document/d/11cw-7dAp93JmasITNSNCtx31xrQsNB1L2OoxVE6zrTc/edit#bookmark=id.ufwe0bqp83z1
 set -eu
 
 # Check the number of arguments

--- a/scripts/publish-stable-version.sh
+++ b/scripts/publish-stable-version.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -eux
-VERSION="$1"
-./gradlew clean || ./gradlew clean
-./gradlew "-PpluginVersion=$VERSION-nightly" -PforceBuild=true publishPlugin
-./gradlew "-PpluginVersion=$VERSION" publishPlugin


### PR DESCRIPTION
Our current setup produces a lot of stable releases that often are not unhidden eventually. That makes the QA and awaiting JB approval process parallel. Based on the recent experience only 1/8 releases goes public. That is a waste of JB approval team's time and CI time.

Let's change the setup. The nightly version handling does not change but the default release script does not longer publish the stable version. Instead the separate workflow can be triggered on the specific tag that publishes the stable version.

## Test plan
1. push a tag for a nightly release
2. trigger the stable release manually

to be tested once merged 
