### PR TITLE
Add auth telemetry events

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.ui.JBPopupMenu
 import com.intellij.ui.awt.RelativePoint
 import com.sourcegraph.cody.auth.ui.AccountsListModel
 import com.sourcegraph.cody.auth.ui.AccountsListModelBase
+import com.sourcegraph.cody.telemetry.TelemetryV2
 import javax.swing.JComponent
 
 class CodyAccountListModel(private val project: Project) :
@@ -61,6 +62,8 @@ class CodyAccountListModel(private val project: Project) :
       token: String,
       id: String
   ) {
+    TelemetryV2.sendTelemetryEvent(project, "auth.signin.token", "clicked")
+
     val account = CodyAccount(login, displayName, server, id)
     if (accountsListModel.isEmpty) {
       activeAccount = account

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyPersistentAccountsHost.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.telemetry.TelemetryV2
 
 class CodyPersistentAccountsHost(private val project: Project) : CodyAccountsHost {
   override fun addAccount(
@@ -10,6 +11,8 @@ class CodyPersistentAccountsHost(private val project: Project) : CodyAccountsHos
       token: String,
       id: String
   ) {
+    TelemetryV2.sendTelemetryEvent(project, "auth.signin.token", "clicked")
+
     val codyAccount = CodyAccount(login, displayName, server, id)
     val authManager = CodyAuthenticationManager.getInstance(project)
     authManager.updateAccountToken(codyAccount, token)

--- a/src/main/kotlin/com/sourcegraph/cody/config/LogInToSourcegraphAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/LogInToSourcegraphAction.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.api.SourcegraphApiRequestExecutor
 import com.sourcegraph.cody.auth.SsoAuthMethod
+import com.sourcegraph.cody.telemetry.TelemetryV2
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import java.awt.Component
 import javax.swing.Action
@@ -18,6 +19,8 @@ class LogInToSourcegraphAction : BaseAddAccountWithTokenAction() {
     get() = SourcegraphServerPath.DEFAULT_HOST
 
   override fun actionPerformed(e: AnActionEvent) {
+    e.project?.let { TelemetryV2.sendTelemetryEvent(it, "auth.login", "clicked") }
+
     val accountsHost = getCodyAccountsHost(e) ?: return
     val authMethod: SsoAuthMethod =
         try {
@@ -42,6 +45,8 @@ class AddCodyEnterpriseAccountAction : BaseAddAccountWithTokenAction() {
     get() = ""
 
   override fun actionPerformed(e: AnActionEvent) {
+    e.project?.let { TelemetryV2.sendTelemetryEvent(it, "auth.login", "clicked") }
+
     val accountsHost = getCodyAccountsHost(e) ?: return
     val dialog = newAddAccountDialog(e.project, e.getData(PlatformCoreDataKeys.CONTEXT_COMPONENT))
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-988/p1-authorization-and-log-in-log-out

## Test plan

Repeat for dotcom and enterprise user account:

**Scenario 1** 

1. Remove all existing accounts
2. Make sure you are redirected to the login panel
3. Login using one of the available providers
4. Make sure that both  `cody.auth.login/clicked` and `cody.auth.signin.token/clicked` telemetry events were fired

**Scenario 2** 

1. Click on Cody status bar and choose `Manage Accounts`
2. Click to add new account
3. Make sure that  `cody.auth.login/clicked` was fired
4. Fill the account details (server and token) and confirm 
5.  Make sure that  `cody.auth.signin.token/clicked` was fired

