### PR TITLE
Do not list the same account twice

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -65,7 +65,9 @@ class CodyAccountListModel(private val project: Project) :
     if (accountsListModel.isEmpty) {
       activeAccount = account
     }
-    accountsListModel.add(account)
+    if (!accountsListModel.toList().contains(account)) {
+      accountsListModel.add(account)
+    }
     newCredentials[account] = token
     notifyCredentialsChanged(account)
   }


### PR DESCRIPTION
## Test plan

Add account that exists 
1. Using settings, add the account that already exists in the list 

