### PR TITLE
Show the login screen when the token is missing

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -156,6 +156,8 @@ class CodyAuthenticationManager(val project: Project) :
         isTokenInvalidFuture.complete(error.cause?.message == UNAUTHORIZED_ERROR_MESSAGE)
         null
       }
+    } else {
+      isTokenInvalidFuture.complete(true)
     }
 
     return authenticationState


### PR DESCRIPTION

## Test plan
Delete the token from the keychain externally 
You can run a separate instance of IDE and remove the account there.

1. Log in to the account
2. Open another IDE, log in to the same account, apply, then remove the account, apply
3. Switch back to the first ide
4. Close and reopen the project
5. Login panel visible