### PR TITLE
Improve action discoverability by adding Cody: prefix in Search Everywhere

### DIFF
--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -75,7 +75,6 @@ UpgradeToCodyProNotification.content.upgrade=\
     (Already upgraded to Pro? Restart your IDE for changes to take effect)\
   </html>
 UpgradeToCodyProNotification.content.explain=To ensure that Cody can stay operational for all Cody users, please come back tomorrow for more chats, commands, and autocompletes.
-context-panel.button.edit-repositories=Edit Remote Repositories
 context-panel.button.reindex=Reindex Local Project
 context-panel.button.help=Help
 context-panel.in-progress=Running Cody 'Keyword Search' indexer...
@@ -141,49 +140,6 @@ group.SourcegraphEditor.text=Sourcegraph
 group.CodyStatusBarActions.text=Cody
 group.CodyEditorActions.text=Cody
 group.InternalsStatusBarActions.text=?? Internals
-
-# Authentication Actions
-action.Cody.Accounts.LogInToSourcegraphAction.text=Log In to Sourcegraph
-action.Cody.Accounts.AddCodyEnterpriseAccount.text=Log In with Token to Sourcegraph Enterprise
-
-# Sourcegraph Actions
-action.sourcegraph.openFile.text=Open Selection in Sourcegraph Web
-action.sourcegraph.openFile.description=Open selection in Sourcegraph Web
-action.sourcegraph.searchSelection.text=Search Selection on Sourcegraph Web
-action.sourcegraph.searchSelection.description=Search selection on Sourcegraph web
-action.sourcegraph.searchRepository.text=Search Selection in Repository on Sourcegraph Web
-action.sourcegraph.searchRepository.description=Search selection in repository on Sourcegraph web
-action.sourcegraph.copy.text=Copy Sourcegraph File Link
-action.sourcegraph.copy.description=Copy Sourcegraph file link
-action.com.sourcegraph.website.OpenRevisionAction.text=Open Revision Diff in Sourcegraph Web
-action.sourcegraph.openFindPopup.text=Find with Sourcegraph...
-action.sourcegraph.openFindPopup.description=Search all your repos on Sourcegraph
-action.sourcegraph.login.text=Log in to Sourcegraph
-action.sourcegraph.login.description=Log in to Sourcegraph
-action.sourcegraph.disabled.description=Log in to Sourcegraph to enable Cody features
-
-# Chat Actions
-action.cody.openChat.text=Open Chat
-action.cody.newChat.text=New Chat
-action.cody.newChat.description=New chat
-action.cody.exportChats.text=Export All Chats As JSON
-action.cody.exportChats.description=Export all chats as JSON
-action.cody.command.Explain.text=Explain Code
-action.cody.command.Smell.text=Find Code Smells
-
-# Inline Edit Actions
-action.cody.enableInlineEditsActions.text=Enable Inline Edits
-action.cody.editCodeAction.text=Edit Code...
-action.cody.documentCodeAction.text=Document Code
-action.cody.editShowDiffAction.text=Show Diff
-action.cody.testCodeAction.text=Generate Unit Tests
-
-# Autocomplete Actions
-action.cody.acceptAutocompleteAction.text=Accept Autocomplete Suggestion
-action.cody.cycleForwardAutocompleteAction.text=Cycle Forward Autocomplete Suggestion
-action.cody.cycleBackAutocompleteAction.text=Cycle Backwards Autocomplete Suggestion
-action.cody.disposeInlays.text=Hide Completions
-action.cody.triggerAutocomplete.text=Autocomplete
 
 # GotItTooltip
 gotit.autocomplete.header=Your first Cody Autocomplete

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -113,138 +113,207 @@
     <actions>
         <action id="sourcegraph.openFile"
                 class="com.sourcegraph.website.OpenFileAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Open Selection in Sourcegraph Web"
+                description="Open selection in Sourcegraph Web">
+            <override-text place="GoToAction" text="Cody: Open Selection in Sourcegraph Web"/>
         </action>
         <action id="sourcegraph.searchSelection"
                 class="com.sourcegraph.website.SearchSelectionAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Search Selection on Sourcegraph Web"
+                description="Search selection on Sourcegraph web">
+            <override-text place="GoToAction" text="Cody: Search Selection on Sourcegraph Web"/>
         </action>
         <action id="sourcegraph.searchRepository"
                 class="com.sourcegraph.website.SearchRepositoryAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Search Selection in Repository on Sourcegraph Web"
+                description="Search selection in repository on Sourcegraph web">
+            <override-text place="GoToAction" text="Cody: Search Selection in Repository on Sourcegraph Web"/>
         </action>
         <action id="sourcegraph.copy"
                 class="com.sourcegraph.website.CopyAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Copy Sourcegraph File Link"
+                description="Copy Sourcegraph file link">
+            <override-text place="GoToAction" text="Cody: Copy Sourcegraph File Link"/>
         </action>
         <action id="com.sourcegraph.website.OpenRevisionAction"
                 class="com.sourcegraph.website.OpenRevisionAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Open Revision Diff in Sourcegraph Web"
+                description="Opens a revision">
             <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
             <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
             <add-to-group group-id="VcsHistoryActionsGroup.Toolbar"
                           anchor="last"/>
             <add-to-group group-id="VcsSelectionHistoryDialog.Popup"
                           anchor="last"/>
+            <override-text place="GoToAction" text="Cody: Open Revision Diff in Sourcegraph Web"/>
         </action>
         <action id="sourcegraph.openFindPopup"
                 class="com.sourcegraph.find.OpenFindAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Find with Sourcegraph..."
+                description="Search all your repos on Sourcegraph">
             <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="Mac OS X 10.5+"/>
             <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
+            <override-text place="GoToAction" text="Cody: Find with Sourcegraph..."/>
         </action>
         <action id="sourcegraph.login"
                 class="com.sourcegraph.config.OpenPluginSettingsAction"
-                icon="/icons/sourcegraphLogo.svg">
+                icon="/icons/sourcegraphLogo.svg"
+                text="Log in to Sourcegraph"
+                description="Log in to Sourcegraph">
+            <override-text place="GoToAction" text="Cody: Log in to Sourcegraph"/>
         </action>
 
         <!-- autocomplete -->
         <action id="cody.acceptAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction"
+                text="Accept Autocomplete Suggestion"
+                description="Accepts the autocomplete suggestion">
             <keyboard-shortcut replace-all="true" first-keystroke="TAB" keymap="$default"/>
+            <override-text place="GoToAction" text="Cody: Accept Autocomplete Suggestion"/>
         </action>
         <action id="cody.cycleForwardAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction"
+                text="Cycle Forward Autocomplete Suggestion"
+                description="Cycles forward through autocomplete suggestions">
             <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Cycle Forward Autocomplete Suggestion"/>
         </action>
         <action id="cody.cycleBackAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction"
+                text="Cycle Backwards Autocomplete Suggestion"
+                description="Cycles backwards through autocomplete suggestions">
             <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Cycle Backwards Autocomplete Suggestion"/>
         </action>
 
         <action id="cody.disposeInlays"
-                class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction">
+                class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction"
+                text="Hide Completions"
+                description="Hides the autocomplete popup">
             <keyboard-shortcut replace-all="true" first-keystroke="ESCAPE" keymap="$default"/>
+            <override-text place="GoToAction" text="Cody: Hide Completions"/>
         </action>
 
         <action id="cody.triggerAutocomplete"
-                class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction">
+                class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction"
+                text="Autocomplete"
+                description="Shows autocomplete suggestions">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Autocomplete"/>
         </action>
 
         <action id="cody.newChat" icon="/icons/chat/newChat.svg"
-                class="com.sourcegraph.cody.chat.actions.NewChatAction">
+                class="com.sourcegraph.cody.chat.actions.NewChatAction"
+                text="New Chat"
+                description="New chat">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: New Chat"/>
         </action>
 
         <action id="cody.exportChats" icon="/icons/chat/download.svg"
-                class="com.sourcegraph.cody.chat.actions.ExportChatsAction">
+                class="com.sourcegraph.cody.chat.actions.ExportChatsAction"
+                text="Export All Chats As JSON"
+                description="Export all chats as JSON">
+            <override-text place="GoToAction" text="Cody: Export All Chats As JSON"/>
         </action>
 
         <action id="cody.openChat"
-                class="com.sourcegraph.cody.chat.OpenChatAction">
+                class="com.sourcegraph.cody.chat.OpenChatAction"
+                text="Open Chat"
+                description="Opens a chat">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Open Chat"/>
         </action>
 
         <group id="CodyEditorActions" popup="true"
                icon="/icons/codyLogoSm.svg" searchable="false"
-               class="com.sourcegraph.cody.CodyActionGroup">
+               class="com.sourcegraph.cody.CodyActionGroup"
+               text="Cody"
+               description="Cody actions">
             <add-to-group anchor="last" group-id="EditorPopupMenu"/>
             <separator/>
+            <override-text place="GoToAction" text="Cody: Cody"/>
         </group>
 
         <action id="cody.command.Explain"
                 icon="/icons/chat/chat_command.svg"
-                class="com.sourcegraph.cody.chat.actions.ExplainCommand">
+                class="com.sourcegraph.cody.chat.actions.ExplainCommand"
+                text="Explain Code"
+                description="Explains the selected code">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="Mac OS X 10.5+"/>
             <add-to-group group-id="CodyEditorActions" anchor="last"/>
+            <override-text place="GoToAction" text="Cody: Explain Code"/>
         </action>
 
         <action id="cody.command.Smell"
                 icon="/icons/chat/chat_command.svg"
-                class="com.sourcegraph.cody.chat.actions.SmellCommand">
+                class="com.sourcegraph.cody.chat.actions.SmellCommand"
+                text="Find Code Smells"
+                description="Finds code smells in the selected code">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="Mac OS X 10.5+"/>
             <add-to-group group-id="CodyEditorActions" anchor="last"/>
+            <override-text place="GoToAction" text="Cody: Find Code Smells"/>
         </action>
 
         <action id="cody.restartAgent"
-                class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"/>
-        <group id="CodyChatActionsGroup">
+                class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"
+                text="Restart Cody Agent"
+                description="Restarts the Cody agent">
+            <override-text place="GoToAction" text="Cody: Restart Cody Agent"/>
+        </action>
+        <group id="CodyChatActionsGroup"
+               text="Cody Chat"
+               description="Cody chat actions">
             <reference ref="cody.newChat"/>
+            <override-text place="GoToAction" text="Cody: Cody Chat"/>
         </group>
 
         <!-- Inline editing actions -->
         <action id="cody.testCodeAction"
                 icon="/icons/edit/generate_test.svg"
-                class="com.sourcegraph.cody.edit.actions.TestCodeAction">
+                class="com.sourcegraph.cody.edit.actions.TestCodeAction"
+                text="Generate Unit Tests"
+                description="Generates unit tests for the selected code">
             <add-to-group group-id="CodyEditorActions" anchor="first"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Generate Unit Tests"/>
         </action>
 
         <action id="cody.documentCodeAction"
                 icon="/icons/edit/document_code.svg"
-                class="com.sourcegraph.cody.edit.actions.DocumentCodeAction">
+                class="com.sourcegraph.cody.edit.actions.DocumentCodeAction"
+                text="Document Code"
+                description="Documents the selected code">
             <add-to-group group-id="CodyEditorActions" anchor="first"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Document Code"/>
         </action>
 
         <action id="cody.editCodeAction"
                 icon="/icons/edit/edit_code.svg"
                 class="com.sourcegraph.cody.edit.actions.EditOpenOrRetryAction"
-                description="Opens the Edit Code dialog">
+                description="Opens the Edit Code dialog"
+                text="Edit Code...">
             <add-to-group group-id="CodyEditorActions" anchor="first"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt COMMA" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt ENTER" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Edit Code..."/>
         </action>
 
         <!-- Lens widget actions -->
@@ -255,25 +324,29 @@
             <!-- Intended as ctrl shift PLUS but that is not recognized by IntelliJ. -->
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Accept Edit"/>
         </action>
 
         <action id="cody.inlineEditCancelAction"
                 class="com.sourcegraph.cody.edit.actions.EditCancelAction"
                 text="Cancel Edit"
                 description="Cancel the fixup">
+            <override-text place="GoToAction" text="Cody: Cancel Edit"/>
         </action>
 
         <action id="cody.inlineEditRetryAction"
                 class="com.sourcegraph.cody.edit.actions.EditRetryAction"
                 text="Retry Edit"
                 description="Retry the fixup">
-          <!-- Key shortcut is handled by cody.editCodeAction, which converts to a Retry if Accept is showing. -->
+            <!-- Key shortcut is handled by cody.editCodeAction, which converts to a Retry if Accept is showing. -->
+            <override-text place="GoToAction" text="Cody: Retry Edit"/>
         </action>
 
         <action id="cody.inlineEditUndoAction"
                 class="com.sourcegraph.cody.edit.actions.EditUndoAction"
                 text="Undo Edit"
                 description="Undo the fixup">
+            <override-text place="GoToAction" text="Cody: Undo Edit"/>
         </action>
 
         <action id="cody.editShowDiffAction"
@@ -282,12 +355,14 @@
                 description="Show a diff view of the fixup">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt D" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt K" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Show Diff"/>
         </action>
 
         <action id="cody.inlineEditDismissAction"
                 class="com.sourcegraph.cody.edit.actions.EditDismissAction"
                 text="Dismiss"
                 description="Dismisses the inline error message">
+            <override-text place="GoToAction" text="Cody: Dismiss"/>
         </action>
 
         <action id="cody.openLogAction"
@@ -296,6 +371,7 @@
                 description="Opens Cody log">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Open Log"/>
         </action>
 
         <!-- also now dismisses error lens, if showing -->
@@ -305,32 +381,53 @@
                 description="Activates the cancel or undo lens, whichever is showing.">
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE" keymap="$default"/>
             <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE" keymap="Mac OS X 10.5+"/>
+            <override-text place="GoToAction" text="Cody: Cancel or Undo Current Edit"/>
         </action>
 
-        <group id="SourcegraphEditor" popup="true" searchable="false">
+        <group id="SourcegraphEditor" popup="true" searchable="false"
+               text="Sourcegraph"
+               description="Sourcegraph actions">
             <reference ref="sourcegraph.openFindPopup"/>
             <reference ref="sourcegraph.searchSelection"/>
             <reference ref="sourcegraph.searchRepository"/>
             <reference ref="sourcegraph.openFile"/>
             <reference ref="sourcegraph.copy"/>
             <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+            <override-text place="GoToAction" text="Cody: Sourcegraph"/>
         </group>
 
         <group id="CodyStatusBarActions" popup="true" searchable="false"
-               class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup">
+               class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup"
+               text="Cody"
+               description="Cody status bar actions">
+            <override-text place="GoToAction" text="Cody: Cody"/>
         </group>
 
         <group id="InternalsStatusBarActions" popup="true" searchable="false"
-               class="com.sourcegraph.cody.internals.InternalsStatusBarActionGroup">
+               class="com.sourcegraph.cody.internals.InternalsStatusBarActionGroup"
+               text="?? Internals"
+               description="?? Internals status bar actions">
+            <override-text place="GoToAction" text="Cody: ?? Internals"/>
         </group>
 
-        <group id="Cody.Accounts.AddAccount">
+        <group id="Cody.Accounts.AddAccount"
+               text="Cody Accounts"
+               description="Cody account actions">
             <action id="Cody.Accounts.LogInToSourcegraphAction"
-                    class="com.sourcegraph.cody.config.LogInToSourcegraphAction"/>
+                    class="com.sourcegraph.cody.config.LogInToSourcegraphAction"
+                    text="Log In to Sourcegraph"
+                    description="Logs in to Sourcegraph">
+                <override-text place="GoToAction" text="Cody: Log In to Sourcegraph"/>
+            </action>
             <action id="Cody.Accounts.AddCodyEnterpriseAccount"
-                    class="com.sourcegraph.cody.config.AddCodyEnterpriseAccountAction"/>
+                    class="com.sourcegraph.cody.config.AddCodyEnterpriseAccountAction"
+                    text="Log In with Token to Sourcegraph Enterprise"
+                    description="Logs in to Sourcegraph Enterprise with a token">
+                <override-text place="GoToAction" text="Cody: Log In with Token to Sourcegraph Enterprise"/>
+            </action>
 
             <separator/>
+            <override-text place="GoToAction" text="Cody: Cody Accounts"/>
         </group>
     </actions>
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-2130/improve-how-actions-appear-in-shiftshift-menu

## Changes

I moved action properties like `text` and `description` to `plugin.xml`.
It is just easier to edit and inspect this way.
To be honest, Geminit 1.5 did most of the work:

> Given the following plugin.xml file and properties file, please modify plugin.xml so each action have additional propertes `text` and `description` with values from properties file.
> Additionally for every action please add such tag: `<override-text place="GoToAction" text="Cody: $TEXT"/>` where `$TEXT` is taken from properties file as well.
> For some actions like: `<action id="Cody.Accounts.LogInToSourcegraphAction" class="com.sourcegraph.cody.config.LogInToSourcegraphAction"/>` you may have to change them to form such as:
> ```
> <action id="Cody.Accounts.LogInToSourcegraphAction" class="com.sourcegraph.cody.config.LogInToSourcegraphAction" text="Log In to Sourcegraph">
>   <override-text place="GoToAction" text="Cody: Log In to Sourcegraph"/>
> </action>
>```
>
> Please output whole content of the modified plugin.xml file.


## Test plan

1. Hit `Shift shift`
2. Type 'Cody:'

![image](https://github.com/sourcegraph/jetbrains/assets/1519649/5ffd1d07-0088-4cb6-b5c8-3894b281bbe1)
