### PR TITLE
Add proper groups for Cody actions

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
@@ -46,7 +46,7 @@ public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
   }
 
   private void createTitleActions(@NotNull List<? super AnAction> titleActions) {
-    AnAction action = ActionManager.getInstance().getAction("CodyChatActionsGroup");
+    AnAction action = ActionManager.getInstance().getAction("cody.newChat");
     if (action != null) {
       titleActions.add(action);
     }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyKeymapExtension.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyKeymapExtension.kt
@@ -1,0 +1,28 @@
+package com.sourcegraph.cody.config
+
+import com.intellij.openapi.actionSystem.ActionGroup
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.keymap.KeymapExtension
+import com.intellij.openapi.keymap.KeymapGroup
+import com.intellij.openapi.keymap.KeymapGroupFactory
+import com.intellij.openapi.keymap.impl.ui.ActionsTreeUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Condition
+import com.sourcegraph.common.CodyBundle
+
+class CodyKeymapExtension : KeymapExtension {
+  override fun createGroup(filtered: Condition<in AnAction>?, project: Project?): KeymapGroup? {
+    val result =
+        KeymapGroupFactory.getInstance().createGroup(CodyBundle.getString("cody.plugin-name"))
+    val actions = ActionsTreeUtil.getActions("Cody.AllActions").toList()
+    actions.filterIsInstance<ActionGroup>().forEach { actionGroup ->
+      val keymapGroup = KeymapGroupFactory.getInstance().createGroup(actionGroup.templateText)
+      actionGroup.getChildren(null).forEach {
+        ActionsTreeUtil.addAction(keymapGroup, it, filtered, true)
+      }
+      result.addGroup(keymapGroup)
+    }
+
+    return result
+  }
+}

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -1,3 +1,4 @@
+cody.plugin-name=Cody: AI Coding Assistant with Autocomplete & Chat
 status-widget.warning.pro.dialog-title=Thank you for using Cody so heavily today!
 status-widget.warning.pro.content=\
   <html>\
@@ -134,12 +135,6 @@ export.timed-out=Cody: Chat export timed out. Please retry...
 PromptPanel.ask-cody.message=Message (type @ to include specific files as context)
 PromptPanel.ask-cody.follow-up-message=Follow-up message (type @ to include specific files as context)
 LlmDropdown.disabled.text=Start a new chat to change the model
-
-# Actions Groups
-group.SourcegraphEditor.text=Sourcegraph
-group.CodyStatusBarActions.text=Cody
-group.CodyEditorActions.text=Cody
-group.InternalsStatusBarActions.text=?? Internals
 
 # GotItTooltip
 gotit.autocomplete.header=Your first Cody Autocomplete

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -114,64 +114,6 @@
     -->
     <actions>
         <group id="Cody.AllActions">
-            <group id="SourcegraphEditor" popup="true" searchable="false" text="Sourcegraph"
-                   description="Sourcegraph actions">
-
-                <add-to-group anchor="last" group-id="EditorPopupMenu"/>
-                <override-text place="GoToAction" text="Cody: Sourcegraph"/>
-
-                <action id="sourcegraph.openFile"
-                        class="com.sourcegraph.website.OpenFileAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Open Selection in Sourcegraph Web"
-                        description="Open selection in Sourcegraph Web">
-                    <override-text place="GoToAction" text="Cody: Open Selection in Sourcegraph Web"/>
-                </action>
-                <action id="sourcegraph.searchSelection"
-                        class="com.sourcegraph.website.SearchSelectionAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Search Selection on Sourcegraph Web"
-                        description="Search selection on Sourcegraph web">
-                    <override-text place="GoToAction" text="Cody: Search Selection on Sourcegraph Web"/>
-                </action>
-                <action id="sourcegraph.searchRepository"
-                        class="com.sourcegraph.website.SearchRepositoryAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Search Selection in Repository on Sourcegraph Web"
-                        description="Search selection in repository on Sourcegraph web">
-                    <override-text place="GoToAction" text="Cody: Search Selection in Repository on Sourcegraph Web"/>
-                </action>
-                <action id="sourcegraph.copy"
-                        class="com.sourcegraph.website.CopyAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Copy Sourcegraph File Link"
-                        description="Copy Sourcegraph file link">
-                    <override-text place="GoToAction" text="Cody: Copy Sourcegraph File Link"/>
-                </action>
-                <action id="com.sourcegraph.website.OpenRevisionAction"
-                        class="com.sourcegraph.website.OpenRevisionAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Open Revision Diff in Sourcegraph Web"
-                        description="Opens a revision">
-                    <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
-                    <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
-                    <add-to-group group-id="VcsHistoryActionsGroup.Toolbar"
-                                  anchor="last"/>
-                    <add-to-group group-id="VcsSelectionHistoryDialog.Popup"
-                                  anchor="last"/>
-                    <override-text place="GoToAction" text="Cody: Open Revision Diff in Sourcegraph Web"/>
-                </action>
-                <action id="sourcegraph.openFindPopup"
-                        class="com.sourcegraph.find.OpenFindAction"
-                        icon="/icons/sourcegraphLogo.svg"
-                        text="Find with Sourcegraph..."
-                        description="Search all your repos on Sourcegraph">
-                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="$default"/>
-                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="Mac OS X 10.5+"/>
-                    <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
-                    <override-text place="GoToAction" text="Cody: Find with Sourcegraph..."/>
-                </action>
-            </group>
 
             <group id="Cody.Autocomplete" popup="true" searchable="false" text="Autocomplete"
                    description="Cody autocomplete actions">
@@ -369,6 +311,65 @@
                         text="Log In with Token to Sourcegraph Enterprise"
                         description="Logs in to Sourcegraph Enterprise with a token">
                     <override-text place="GoToAction" text="Cody: Log In with Token to Sourcegraph Enterprise"/>
+                </action>
+            </group>
+
+            <group id="SourcegraphEditor" popup="true" searchable="false" text="Sourcegraph"
+                   description="Sourcegraph actions">
+
+                <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+                <override-text place="GoToAction" text="Cody: Sourcegraph"/>
+
+                <action id="sourcegraph.openFile"
+                        class="com.sourcegraph.website.OpenFileAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Open Selection in Sourcegraph Web"
+                        description="Open selection in Sourcegraph Web">
+                    <override-text place="GoToAction" text="Cody: Open Selection in Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.searchSelection"
+                        class="com.sourcegraph.website.SearchSelectionAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Search Selection on Sourcegraph Web"
+                        description="Search selection on Sourcegraph web">
+                    <override-text place="GoToAction" text="Cody: Search Selection on Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.searchRepository"
+                        class="com.sourcegraph.website.SearchRepositoryAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Search Selection in Repository on Sourcegraph Web"
+                        description="Search selection in repository on Sourcegraph web">
+                    <override-text place="GoToAction" text="Cody: Search Selection in Repository on Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.copy"
+                        class="com.sourcegraph.website.CopyAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Copy Sourcegraph File Link"
+                        description="Copy Sourcegraph file link">
+                    <override-text place="GoToAction" text="Cody: Copy Sourcegraph File Link"/>
+                </action>
+                <action id="com.sourcegraph.website.OpenRevisionAction"
+                        class="com.sourcegraph.website.OpenRevisionAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Open Revision Diff in Sourcegraph Web"
+                        description="Opens a revision">
+                    <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
+                    <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
+                    <add-to-group group-id="VcsHistoryActionsGroup.Toolbar"
+                                  anchor="last"/>
+                    <add-to-group group-id="VcsSelectionHistoryDialog.Popup"
+                                  anchor="last"/>
+                    <override-text place="GoToAction" text="Cody: Open Revision Diff in Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.openFindPopup"
+                        class="com.sourcegraph.find.OpenFindAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Find with Sourcegraph..."
+                        description="Search all your repos on Sourcegraph">
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="Mac OS X 10.5+"/>
+                    <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
+                    <override-text place="GoToAction" text="Cody: Find with Sourcegraph..."/>
                 </action>
             </group>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -98,6 +98,8 @@
                                 order="first, before commitCompletion"/>
         <annotator language="SourcegraphRemoteRepoList"
                    implementationClass="com.sourcegraph.cody.context.RemoteRepoAnnotator"/>
+
+        <keymapExtension implementation="com.sourcegraph.cody.config.CodyKeymapExtension"/>
     </extensions>
 
     <applicationListeners>
@@ -111,323 +113,309 @@
         result in the actual keybindings switching to command/meta and/or shift.
     -->
     <actions>
-        <action id="sourcegraph.openFile"
-                class="com.sourcegraph.website.OpenFileAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Open Selection in Sourcegraph Web"
-                description="Open selection in Sourcegraph Web">
-            <override-text place="GoToAction" text="Cody: Open Selection in Sourcegraph Web"/>
-        </action>
-        <action id="sourcegraph.searchSelection"
-                class="com.sourcegraph.website.SearchSelectionAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Search Selection on Sourcegraph Web"
-                description="Search selection on Sourcegraph web">
-            <override-text place="GoToAction" text="Cody: Search Selection on Sourcegraph Web"/>
-        </action>
-        <action id="sourcegraph.searchRepository"
-                class="com.sourcegraph.website.SearchRepositoryAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Search Selection in Repository on Sourcegraph Web"
-                description="Search selection in repository on Sourcegraph web">
-            <override-text place="GoToAction" text="Cody: Search Selection in Repository on Sourcegraph Web"/>
-        </action>
-        <action id="sourcegraph.copy"
-                class="com.sourcegraph.website.CopyAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Copy Sourcegraph File Link"
-                description="Copy Sourcegraph file link">
-            <override-text place="GoToAction" text="Cody: Copy Sourcegraph File Link"/>
-        </action>
-        <action id="com.sourcegraph.website.OpenRevisionAction"
-                class="com.sourcegraph.website.OpenRevisionAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Open Revision Diff in Sourcegraph Web"
-                description="Opens a revision">
-            <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
-            <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
-            <add-to-group group-id="VcsHistoryActionsGroup.Toolbar"
-                          anchor="last"/>
-            <add-to-group group-id="VcsSelectionHistoryDialog.Popup"
-                          anchor="last"/>
-            <override-text place="GoToAction" text="Cody: Open Revision Diff in Sourcegraph Web"/>
-        </action>
-        <action id="sourcegraph.openFindPopup"
-                class="com.sourcegraph.find.OpenFindAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Find with Sourcegraph..."
-                description="Search all your repos on Sourcegraph">
-            <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="Mac OS X 10.5+"/>
-            <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
-            <override-text place="GoToAction" text="Cody: Find with Sourcegraph..."/>
-        </action>
-        <action id="sourcegraph.login"
-                class="com.sourcegraph.config.OpenPluginSettingsAction"
-                icon="/icons/sourcegraphLogo.svg"
-                text="Log in to Sourcegraph"
-                description="Log in to Sourcegraph">
-            <override-text place="GoToAction" text="Cody: Log in to Sourcegraph"/>
-        </action>
+        <group id="Cody.AllActions">
+            <group id="SourcegraphEditor" popup="true" searchable="false" text="Sourcegraph"
+                   description="Sourcegraph actions">
 
-        <!-- autocomplete -->
-        <action id="cody.acceptAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction"
-                text="Accept Autocomplete Suggestion"
-                description="Accepts the autocomplete suggestion">
-            <keyboard-shortcut replace-all="true" first-keystroke="TAB" keymap="$default"/>
-            <override-text place="GoToAction" text="Cody: Accept Autocomplete Suggestion"/>
-        </action>
-        <action id="cody.cycleForwardAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction"
-                text="Cycle Forward Autocomplete Suggestion"
-                description="Cycles forward through autocomplete suggestions">
-            <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Cycle Forward Autocomplete Suggestion"/>
-        </action>
-        <action id="cody.cycleBackAutocompleteAction"
-                class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction"
-                text="Cycle Backwards Autocomplete Suggestion"
-                description="Cycles backwards through autocomplete suggestions">
-            <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Cycle Backwards Autocomplete Suggestion"/>
-        </action>
+                <add-to-group anchor="last" group-id="EditorPopupMenu"/>
+                <override-text place="GoToAction" text="Cody: Sourcegraph"/>
 
-        <action id="cody.disposeInlays"
-                class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction"
-                text="Hide Completions"
-                description="Hides the autocomplete popup">
-            <keyboard-shortcut replace-all="true" first-keystroke="ESCAPE" keymap="$default"/>
-            <override-text place="GoToAction" text="Cody: Hide Completions"/>
-        </action>
+                <action id="sourcegraph.openFile"
+                        class="com.sourcegraph.website.OpenFileAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Open Selection in Sourcegraph Web"
+                        description="Open selection in Sourcegraph Web">
+                    <override-text place="GoToAction" text="Cody: Open Selection in Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.searchSelection"
+                        class="com.sourcegraph.website.SearchSelectionAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Search Selection on Sourcegraph Web"
+                        description="Search selection on Sourcegraph web">
+                    <override-text place="GoToAction" text="Cody: Search Selection on Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.searchRepository"
+                        class="com.sourcegraph.website.SearchRepositoryAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Search Selection in Repository on Sourcegraph Web"
+                        description="Search selection in repository on Sourcegraph web">
+                    <override-text place="GoToAction" text="Cody: Search Selection in Repository on Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.copy"
+                        class="com.sourcegraph.website.CopyAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Copy Sourcegraph File Link"
+                        description="Copy Sourcegraph file link">
+                    <override-text place="GoToAction" text="Cody: Copy Sourcegraph File Link"/>
+                </action>
+                <action id="com.sourcegraph.website.OpenRevisionAction"
+                        class="com.sourcegraph.website.OpenRevisionAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Open Revision Diff in Sourcegraph Web"
+                        description="Opens a revision">
+                    <add-to-group group-id="VcsHistoryActionsGroup" anchor="last"/>
+                    <add-to-group group-id="Vcs.Log.ContextMenu" anchor="last"/>
+                    <add-to-group group-id="VcsHistoryActionsGroup.Toolbar"
+                                  anchor="last"/>
+                    <add-to-group group-id="VcsSelectionHistoryDialog.Popup"
+                                  anchor="last"/>
+                    <override-text place="GoToAction" text="Cody: Open Revision Diff in Sourcegraph Web"/>
+                </action>
+                <action id="sourcegraph.openFindPopup"
+                        class="com.sourcegraph.find.OpenFindAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Find with Sourcegraph..."
+                        description="Search all your repos on Sourcegraph">
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt s" keymap="Mac OS X 10.5+"/>
+                    <add-to-group group-id="FindMenuGroup" anchor="after" relative-to-action="ReplaceInPath"/>
+                    <override-text place="GoToAction" text="Cody: Find with Sourcegraph..."/>
+                </action>
+            </group>
 
-        <action id="cody.triggerAutocomplete"
-                class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction"
-                text="Autocomplete"
-                description="Shows autocomplete suggestions">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Autocomplete"/>
-        </action>
+            <group id="Cody.Autocomplete" popup="true" searchable="false" text="Autocomplete"
+                   description="Cody autocomplete actions">
+                <action id="cody.triggerAutocomplete"
+                        class="com.sourcegraph.cody.autocomplete.action.TriggerAutocompleteAction"
+                        text="Autocomplete"
+                        description="Shows autocomplete suggestions">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt P" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Autocomplete"/>
+                </action>
+                <action id="cody.acceptAutocompleteAction"
+                        class="com.sourcegraph.cody.autocomplete.action.AcceptCodyAutocompleteAction"
+                        text="Accept Autocomplete Suggestion"
+                        description="Accepts the autocomplete suggestion">
+                    <keyboard-shortcut replace-all="true" first-keystroke="TAB" keymap="$default"/>
+                    <override-text place="GoToAction" text="Cody: Accept Autocomplete Suggestion"/>
+                </action>
+                <action id="cody.cycleForwardAutocompleteAction"
+                        class="com.sourcegraph.cody.autocomplete.action.CycleForwardAutocompleteAction"
+                        text="Cycle Forward Autocomplete Suggestion"
+                        description="Cycles forward through autocomplete suggestions">
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt OPEN_BRACKET" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Cycle Forward Autocomplete Suggestion"/>
+                </action>
+                <action id="cody.cycleBackAutocompleteAction"
+                        class="com.sourcegraph.cody.autocomplete.action.CycleBackwardAutocompleteAction"
+                        text="Cycle Backwards Autocomplete Suggestion"
+                        description="Cycles backwards through autocomplete suggestions">
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="alt CLOSE_BRACKET" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Cycle Backwards Autocomplete Suggestion"/>
+                </action>
+                <action id="cody.disposeInlays"
+                        class="com.sourcegraph.cody.autocomplete.action.DisposeInlaysAction"
+                        text="Hide Completions"
+                        description="Hides the autocomplete popup">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ESCAPE" keymap="$default"/>
+                    <override-text place="GoToAction" text="Cody: Hide Completions"/>
+                </action>
+            </group>
 
-        <action id="cody.newChat" icon="/icons/chat/newChat.svg"
-                class="com.sourcegraph.cody.chat.actions.NewChatAction"
-                text="New Chat"
-                description="New chat">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: New Chat"/>
-        </action>
+            <group id="Cody.Chat" popup="true" searchable="false" text="Chat" description="Cody chat actions">
+                <action id="cody.newChat" icon="/icons/chat/newChat.svg"
+                        class="com.sourcegraph.cody.chat.actions.NewChatAction"
+                        text="New Chat"
+                        description="New chat">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 0" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: New Chat"/>
+                </action>
 
-        <action id="cody.exportChats" icon="/icons/chat/download.svg"
-                class="com.sourcegraph.cody.chat.actions.ExportChatsAction"
-                text="Export All Chats As JSON"
-                description="Export all chats as JSON">
-            <override-text place="GoToAction" text="Cody: Export All Chats As JSON"/>
-        </action>
+                <action id="cody.exportChats" icon="/icons/chat/download.svg"
+                        class="com.sourcegraph.cody.chat.actions.ExportChatsAction"
+                        text="Export All Chats As JSON"
+                        description="Export all chats as JSON">
+                    <override-text place="GoToAction" text="Cody: Export All Chats As JSON"/>
+                </action>
 
-        <action id="cody.openChat"
-                class="com.sourcegraph.cody.chat.OpenChatAction"
-                text="Open Chat"
-                description="Opens a chat">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Open Chat"/>
-        </action>
+                <action id="cody.openChat"
+                        class="com.sourcegraph.cody.chat.OpenChatAction"
+                        text="Open Chat"
+                        description="Opens a chat">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 9" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Open Chat"/>
+                </action>
 
-        <group id="CodyEditorActions" popup="true"
-               icon="/icons/codyLogoSm.svg" searchable="false"
-               class="com.sourcegraph.cody.CodyActionGroup"
-               text="Cody"
-               description="Cody actions">
-            <add-to-group anchor="last" group-id="EditorPopupMenu"/>
-            <separator/>
-            <override-text place="GoToAction" text="Cody: Cody"/>
-        </group>
+                <action id="cody.command.Explain"
+                        icon="/icons/chat/chat_command.svg"
+                        class="com.sourcegraph.cody.chat.actions.ExplainCommand"
+                        text="Explain Code"
+                        description="Explains the selected code">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Explain Code"/>
+                </action>
 
-        <action id="cody.command.Explain"
-                icon="/icons/chat/chat_command.svg"
-                class="com.sourcegraph.cody.chat.actions.ExplainCommand"
-                text="Explain Code"
-                description="Explains the selected code">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 1" keymap="Mac OS X 10.5+"/>
-            <add-to-group group-id="CodyEditorActions" anchor="last"/>
-            <override-text place="GoToAction" text="Cody: Explain Code"/>
-        </action>
+                <action id="cody.command.Smell"
+                        icon="/icons/chat/chat_command.svg"
+                        class="com.sourcegraph.cody.chat.actions.SmellCommand"
+                        text="Find Code Smells"
+                        description="Finds code smells in the selected code">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Find Code Smells"/>
+                </action>
+            </group>
 
-        <action id="cody.command.Smell"
-                icon="/icons/chat/chat_command.svg"
-                class="com.sourcegraph.cody.chat.actions.SmellCommand"
-                text="Find Code Smells"
-                description="Finds code smells in the selected code">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt 2" keymap="Mac OS X 10.5+"/>
-            <add-to-group group-id="CodyEditorActions" anchor="last"/>
-            <override-text place="GoToAction" text="Cody: Find Code Smells"/>
-        </action>
+            <group id="Cody.EditCode" popup="true" searchable="false" text="Edit Code"
+                   description="Cody inline edit actions">
+                <action id="cody.testCodeAction"
+                        icon="/icons/edit/generate_test.svg"
+                        class="com.sourcegraph.cody.edit.actions.TestCodeAction"
+                        text="Generate Unit Tests"
+                        description="Generates unit tests for the selected code">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Generate Unit Tests"/>
+                </action>
 
-        <action id="cody.restartAgent"
-                class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"
-                text="Restart Cody Agent"
-                description="Restarts the Cody agent">
-            <override-text place="GoToAction" text="Cody: Restart Cody Agent"/>
-        </action>
-        <group id="CodyChatActionsGroup"
-               text="Cody Chat"
-               description="Cody chat actions">
-            <reference ref="cody.newChat"/>
-            <override-text place="GoToAction" text="Cody: Cody Chat"/>
-        </group>
+                <action id="cody.documentCodeAction"
+                        icon="/icons/edit/document_code.svg"
+                        class="com.sourcegraph.cody.edit.actions.DocumentCodeAction"
+                        text="Document Code"
+                        description="Documents the selected code">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Document Code"/>
+                </action>
 
-        <!-- Inline editing actions -->
-        <action id="cody.testCodeAction"
-                icon="/icons/edit/generate_test.svg"
-                class="com.sourcegraph.cody.edit.actions.TestCodeAction"
-                text="Generate Unit Tests"
-                description="Generates unit tests for the selected code">
-            <add-to-group group-id="CodyEditorActions" anchor="first"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt G" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Generate Unit Tests"/>
-        </action>
+                <action id="cody.editCodeAction"
+                        icon="/icons/edit/edit_code.svg"
+                        class="com.sourcegraph.cody.edit.actions.EditOpenOrRetryAction"
+                        description="Opens the Edit Code dialog"
+                        text="Edit Code...">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt COMMA" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt ENTER" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Edit Code..."/>
+                </action>
 
-        <action id="cody.documentCodeAction"
-                icon="/icons/edit/document_code.svg"
-                class="com.sourcegraph.cody.edit.actions.DocumentCodeAction"
-                text="Document Code"
-                description="Documents the selected code">
-            <add-to-group group-id="CodyEditorActions" anchor="first"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt H" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Document Code"/>
-        </action>
+                <!-- Lens widget actions -->
+                <action id="cody.inlineEditAcceptAction"
+                        class="com.sourcegraph.cody.edit.actions.EditAcceptAction"
+                        text="Accept Edit"
+                        description="Accept the fixup">
+                    <!-- Intended as ctrl shift PLUS but that is not recognized by IntelliJ. -->
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Accept Edit"/>
+                </action>
 
-        <action id="cody.editCodeAction"
-                icon="/icons/edit/edit_code.svg"
-                class="com.sourcegraph.cody.edit.actions.EditOpenOrRetryAction"
-                description="Opens the Edit Code dialog"
-                text="Edit Code...">
-            <add-to-group group-id="CodyEditorActions" anchor="first"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt COMMA" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt ENTER" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Edit Code..."/>
-        </action>
+                <action id="cody.inlineEditCancelAction"
+                        class="com.sourcegraph.cody.edit.actions.EditCancelAction"
+                        text="Cancel Edit"
+                        description="Cancel the fixup">
+                    <override-text place="GoToAction" text="Cody: Cancel Edit"/>
+                </action>
 
-        <!-- Lens widget actions -->
-        <action id="cody.inlineEditAcceptAction"
-                class="com.sourcegraph.cody.edit.actions.EditAcceptAction"
-                text="Accept Edit"
-                description="Accept the fixup">
-            <!-- Intended as ctrl shift PLUS but that is not recognized by IntelliJ. -->
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift EQUALS" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Accept Edit"/>
-        </action>
+                <action id="cody.inlineEditRetryAction"
+                        class="com.sourcegraph.cody.edit.actions.EditRetryAction"
+                        text="Retry Edit"
+                        description="Retry the fixup">
+                    <!-- Key shortcut is handled by cody.editCodeAction, which converts to a Retry if Accept is showing. -->
+                    <override-text place="GoToAction" text="Cody: Retry Edit"/>
+                </action>
 
-        <action id="cody.inlineEditCancelAction"
-                class="com.sourcegraph.cody.edit.actions.EditCancelAction"
-                text="Cancel Edit"
-                description="Cancel the fixup">
-            <override-text place="GoToAction" text="Cody: Cancel Edit"/>
-        </action>
+                <action id="cody.inlineEditUndoAction"
+                        class="com.sourcegraph.cody.edit.actions.EditUndoAction"
+                        text="Undo Edit"
+                        description="Undo the fixup">
+                    <override-text place="GoToAction" text="Cody: Undo Edit"/>
+                </action>
 
-        <action id="cody.inlineEditRetryAction"
-                class="com.sourcegraph.cody.edit.actions.EditRetryAction"
-                text="Retry Edit"
-                description="Retry the fixup">
-            <!-- Key shortcut is handled by cody.editCodeAction, which converts to a Retry if Accept is showing. -->
-            <override-text place="GoToAction" text="Cody: Retry Edit"/>
-        </action>
+                <action id="cody.editShowDiffAction"
+                        class="com.sourcegraph.cody.edit.EditShowDiffAction"
+                        text="Show Diff"
+                        description="Show a diff view of the fixup">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt D" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt K" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Show Diff"/>
+                </action>
 
-        <action id="cody.inlineEditUndoAction"
-                class="com.sourcegraph.cody.edit.actions.EditUndoAction"
-                text="Undo Edit"
-                description="Undo the fixup">
-            <override-text place="GoToAction" text="Cody: Undo Edit"/>
-        </action>
+                <action id="cody.inlineEditDismissAction"
+                        class="com.sourcegraph.cody.edit.actions.EditDismissAction"
+                        text="Dismiss"
+                        description="Dismisses the inline error message">
+                    <override-text place="GoToAction" text="Cody: Dismiss"/>
+                </action>
 
-        <action id="cody.editShowDiffAction"
-                class="com.sourcegraph.cody.edit.EditShowDiffAction"
-                text="Show Diff"
-                description="Show a diff view of the fixup">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt D" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt K" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Show Diff"/>
-        </action>
+                <!-- also now dismisses error lens, if showing -->
+                <action id="cody.editCancelOrUndoAction"
+                        class="com.sourcegraph.cody.edit.actions.EditCancelOrUndoAction"
+                        text="Cancel or Undo Current Edit"
+                        description="Activates the cancel or undo lens, whichever is showing.">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE"
+                                       keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Cancel or Undo Current Edit"/>
+                </action>
+            </group>
 
-        <action id="cody.inlineEditDismissAction"
-                class="com.sourcegraph.cody.edit.actions.EditDismissAction"
-                text="Dismiss"
-                description="Dismisses the inline error message">
-            <override-text place="GoToAction" text="Cody: Dismiss"/>
-        </action>
+            <group id="Cody.Accounts.AddAccount"
+                   text="Cody Accounts"
+                   description="Cody account actions">
+                <action id="Cody.Accounts.LogInToSourcegraphAction"
+                        class="com.sourcegraph.cody.config.LogInToSourcegraphAction"
+                        text="Log In to Sourcegraph"
+                        description="Logs in to Sourcegraph">
+                    <override-text place="GoToAction" text="Cody: Log In to Sourcegraph"/>
+                </action>
+                <action id="Cody.Accounts.AddCodyEnterpriseAccount"
+                        class="com.sourcegraph.cody.config.AddCodyEnterpriseAccountAction"
+                        text="Log In with Token to Sourcegraph Enterprise"
+                        description="Logs in to Sourcegraph Enterprise with a token">
+                    <override-text place="GoToAction" text="Cody: Log In with Token to Sourcegraph Enterprise"/>
+                </action>
+            </group>
 
-        <action id="cody.openLogAction"
-                class="com.sourcegraph.cody.statusbar.OpenLogAction"
-                text="Open Log"
-                description="Opens Cody log">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Open Log"/>
-        </action>
-
-        <!-- also now dismisses error lens, if showing -->
-        <action id="cody.editCancelOrUndoAction"
-                class="com.sourcegraph.cody.edit.actions.EditCancelOrUndoAction"
-                text="Cancel or Undo Current Edit"
-                description="Activates the cancel or undo lens, whichever is showing.">
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE" keymap="$default"/>
-            <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt BACK_SPACE" keymap="Mac OS X 10.5+"/>
-            <override-text place="GoToAction" text="Cody: Cancel or Undo Current Edit"/>
-        </action>
-
-        <group id="SourcegraphEditor" popup="true" searchable="false"
-               text="Sourcegraph"
-               description="Sourcegraph actions">
-            <reference ref="sourcegraph.openFindPopup"/>
-            <reference ref="sourcegraph.searchSelection"/>
-            <reference ref="sourcegraph.searchRepository"/>
-            <reference ref="sourcegraph.openFile"/>
-            <reference ref="sourcegraph.copy"/>
-            <add-to-group anchor="last" group-id="EditorPopupMenu"/>
-            <override-text place="GoToAction" text="Cody: Sourcegraph"/>
+            <group id="Cody.Other" text="Other" description="Other Cody actions">
+                <action id="cody.restartAgent"
+                        class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"
+                        text="Restart Cody Agent"
+                        description="Restarts the Cody agent">
+                    <override-text place="GoToAction" text="Cody: Restart Cody Agent"/>
+                </action>
+                <action id="sourcegraph.login"
+                        class="com.sourcegraph.config.OpenPluginSettingsAction"
+                        icon="/icons/sourcegraphLogo.svg"
+                        text="Log in to Sourcegraph"
+                        description="Log in to Sourcegraph">
+                    <override-text place="GoToAction" text="Cody: Log in to Sourcegraph"/>
+                </action>
+                <action id="cody.openLogAction"
+                        class="com.sourcegraph.cody.statusbar.OpenLogAction"
+                        text="Open Log"
+                        description="Opens Cody log">
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Open Log"/>
+                </action>
+            </group>
         </group>
 
         <group id="CodyStatusBarActions" popup="true" searchable="false"
                class="com.sourcegraph.cody.statusbar.CodyStatusBarActionGroup"
                text="Cody"
                description="Cody status bar actions">
-            <override-text place="GoToAction" text="Cody: Cody"/>
         </group>
 
-        <group id="InternalsStatusBarActions" popup="true" searchable="false"
-               class="com.sourcegraph.cody.internals.InternalsStatusBarActionGroup"
-               text="?? Internals"
-               description="?? Internals status bar actions">
-            <override-text place="GoToAction" text="Cody: ?? Internals"/>
-        </group>
+        <group id="CodyEditorActions" popup="true"
+               icon="/icons/codyLogoSm.svg" searchable="true"
+               class="com.sourcegraph.cody.CodyActionGroup"
+               text="Cody"
+               description="Cody actions">
+            <add-to-group anchor="last" group-id="EditorPopupMenu"/>
 
-        <group id="Cody.Accounts.AddAccount"
-               text="Cody Accounts"
-               description="Cody account actions">
-            <action id="Cody.Accounts.LogInToSourcegraphAction"
-                    class="com.sourcegraph.cody.config.LogInToSourcegraphAction"
-                    text="Log In to Sourcegraph"
-                    description="Logs in to Sourcegraph">
-                <override-text place="GoToAction" text="Cody: Log In to Sourcegraph"/>
-            </action>
-            <action id="Cody.Accounts.AddCodyEnterpriseAccount"
-                    class="com.sourcegraph.cody.config.AddCodyEnterpriseAccountAction"
-                    text="Log In with Token to Sourcegraph Enterprise"
-                    description="Logs in to Sourcegraph Enterprise with a token">
-                <override-text place="GoToAction" text="Cody: Log In with Token to Sourcegraph Enterprise"/>
-            </action>
-
+            <reference ref="cody.editCodeAction"/>
+            <reference ref="cody.documentCodeAction"/>
+            <reference ref="cody.testCodeAction"/>
             <separator/>
-            <override-text place="GoToAction" text="Cody: Cody Accounts"/>
+            <reference ref="cody.command.Explain"/>
+            <reference ref="cody.command.Smell"/>
         </group>
     </actions>
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-2095/organize-keymap-settings

## Changes

1. Proper grouping was added for all actions in plugin.xml
2. The same grouping is used for nice visual organisation of keymap management

## Test plan

Visual verification in `Settings > Keymap` (see screenshots):

![image](https://github.com/sourcegraph/jetbrains/assets/1519649/b5292cfb-5a2f-47ae-9706-512fb2675b8a)
![image](https://github.com/sourcegraph/jetbrains/assets/1519649/5553077a-c21e-4003-b1c8-0c2f279f6467)
