### PR TITLE
Bring back missing action description

### DIFF
--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -157,6 +157,7 @@ filter.sidebar-panel-ignored-file.learn-more-cta=Learn more
 # Other Actions
 action.cody.restartAgent.text=Restart Cody Agent
 chat.enhanced_context.title=Chat Context Settings
+action.sourcegraph.disabled.description=Log in to Sourcegraph to enable Cody features
 
 # Settings Migration
 settings.migration.llm-upgrade-notification.title=Cody models upgrade


### PR DESCRIPTION
Rel: https://github.com/sourcegraph/jetbrains/pull/1872
Fixes: https://github.com/sourcegraph/jetbrains/issues/1892

## The error

```
java.util.MissingResourceException: Can't find resource for bundle java.util.PropertyResourceBundle, key action.sourcegraph.disabled.description
	at java.base/java.util.ResourceBundle.getObject(ResourceBundle.java:564)
	at java.base/java.util.ResourceBundle.getString(ResourceBundle.java:521)
	at com.sourcegraph.common.CodyBundle.getString(CodyBundle.kt:29)
	at com.sourcegraph.cody.chat.actions.BaseChatAction.update(BaseChatAction.kt:31)
```

## Test plan

I am not sure. I was testing my own branch and I encountered the error.

