### PR TITLE
feat(chore): Adding tags and usage for LLM Models

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=dc9ea0b18ef4db9141ef204e8a3ea026b21b9bb3
+cody.commit=20a7fd5368f1ecc14ec2c2e97fdd5144f8ba16d2

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=aa6e4fe6f24bede84f304705eeaf68ba2ef3546f
+cody.commit=dc9ea0b18ef4db9141ef204e8a3ea026b21b9bb3

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=dc9ea0b18ef4db9141ef204e8a3ea026b21b9bb3
+cody.commit=656e4ad22a3e1796d17bf116ecb43baff80dce04

--- a/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -5,6 +5,89 @@ log:
     name: Polly.JS
     version: 6.0.6
   entries:
+    - _id: 8ffa79cf5668b64b3fd5ad5674e1d846
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
+          - _fromType: array
+            name: content-type
+            value: application/json; charset=utf-8
+          - _fromType: array
+            name: user-agent
+            value: JetBrains / 6.0-localbuild
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 297
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/.api/client-config
+      response:
+        bodySize: 188
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 188
+          text: "[\"H4sIAAAAAAAAA2zMsQoCMRCE4T5PsVztE9hJsLjOznrPrBjI7koyQeW4d7dRBEn9z3xrI\
+            CKaLp5eR+OlSJr2hNpl9wk3xjBwh0fXexHI+NkbXKOrsqU2NoCal47s9utXLu07aMoV\
+            0Q3yxDlb8sfQUU9S2uE0/ylhC28AAAD//wMAK/Ow9eAAAAA=\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Thu, 18 Jul 2024 07:46:50 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+          - name: content-encoding
+            value: gzip
+        headersSize: 1342
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-07-18T07:46:50.809Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
     - _id: 37dce854386a858ed2c3697d18a6de44
       _order: 0
       cache: {}
@@ -22,7 +105,7 @@ log:
           - name: user-agent
             value: JetBrains / 6.0-localbuild
           - name: traceparent
-            value: 00-c19208e68c9d5b28bfcf49e5684e0cb6-6d1fe36244bf1e66-01
+            value: 00-7280ceb78266de97ad9a0ebacd9a21c4-f23eaba8dfc5c600-01
           - name: connection
             value: keep-alive
           - name: host
@@ -121,14 +204,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 2318
+        bodySize: 1465
         content:
           mimeType: text/event-stream
-          size: 2318
+          size: 1465
           text: >+
             event: completion
 
-            data: {"completion":"\n/**\n * Imports the Java standard utility classes, including the {@link java.util.List} and {@link java.util.ArrayList} classes.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Imports the necessary Java utility classes, including the `ArrayList` implementation.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -138,7 +221,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:29 GMT
+            value: Thu, 18 Jul 2024 07:46:53 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -167,112 +250,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:28.791Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: 12581f1c735a04aeb88af7a54cd007b2
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 217
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: JetBrains / 6.0-localbuild
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "217"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 340
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query CodyConfigFeaturesResponse {
-                  site {
-                      codyConfigFeatures {
-                          chat
-                          autoComplete
-                          commands
-                          attribution
-                      }
-                  }
-              }
-            variables: {}
-        queryString:
-          - name: CodyConfigFeaturesResponse
-            value: null
-        url: https://sourcegraph.com/.api/graphql?CodyConfigFeaturesResponse
-      response:
-        bodySize: 155
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 155
-          text: "[\"H4sIAAAAAAAAAzyLwQqA\",\"IBAF/2XPfYFXof/YdC0h3dDnIcR/Dws6DQwznTyDyXSq\
-            ETLp1N9Wc4j7KoxWpL72YJBBabIQN6jVdJ0yj885TYmzr38DlLg1RM1kAp9VxhjjAQA\
-            A//8DAIfOLkJuAAAA\"]"
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 03 Jul 2024 14:54:28 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1333
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-03T14:54:27.979Z
+      startedDateTime: 2024-07-18T07:46:51.715Z
       time: 0
       timings:
         blocked: -1
@@ -332,17 +310,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?ContextFilters
       response:
-        bodySize: 107
+        bodySize: 104
         content:
           encoding: base64
           mimeType: application/json
-          size: 107
-          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdHJ+SmVzvl5JakVJW6ZOSWpRcUg0aLE\
-            ciWrvNKcnNra2loAAAAA//8DADYuyGU1AAAA\"]"
+          size: 104
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVzvl5JakVJW6ZOSWpRcUg0aLEciWrv\
+            NKcnNra2loAAAAA//8DADYuyGU1AAAA\"]"
+          textDecoded:
+            data:
+              site:
+                codyContextFilters:
+                  raw: null
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -373,7 +356,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:27.784Z
+      startedDateTime: 2024-07-18T07:46:50.817Z
       time: 0
       timings:
         blocked: -1
@@ -460,7 +443,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -491,7 +474,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:26.972Z
+      startedDateTime: 2024-07-18T07:46:49.986Z
       time: 0
       timings:
         blocked: -1
@@ -551,18 +534,17 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 142
+        bodySize: 135
         content:
           encoding: base64
           mimeType: application/json
-          size: 142
+          size: 135
           text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD5\
-            3MSiEuf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8=\",\"AwDoCDSlSw\
-            AAAA==\"]"
+            3MSiEuf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8DAOgINKVLAAAA\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -593,7 +575,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:27.005Z
+      startedDateTime: 2024-07-18T07:46:50.019Z
       time: 0
       timings:
         blocked: -1
@@ -653,22 +635,17 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
-        bodySize: 128
+        bodySize: 130
         content:
           encoding: base64
           mimeType: application/json
-          size: 128
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
-            syU1CIlK6Xi/NKi5NT0osSCDKXa2tpaAAAAAP//AwAfFAXARQAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  provider: sourcegraph
+          size: 130
+          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDx\
+            gqL8ssyU1CIlK6WyxKLM/NJipdra2loAAAAA//8=\",\"AwAdobPlQQAAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -699,7 +676,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:26.989Z
+      startedDateTime: 2024-07-18T07:46:50.003Z
       time: 0
       timings:
         blocked: -1
@@ -784,7 +761,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -815,7 +792,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:27.021Z
+      startedDateTime: 2024-07-18T07:46:50.035Z
       time: 0
       timings:
         blocked: -1
@@ -884,23 +861,23 @@ log:
           encoding: base64
           mimeType: application/json
           size: 228
-          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2FoVsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
+          text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2FpRsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
             +Os0IoV5IopERnHl2joPb1ehnSPE9nA1rtXi6w4RUg0h/F4bVEgzMpBouvPKKBCmJeO\
             fK/YnOzDcoRkSqb4fHeGrNcDK+KGISFKUW/K3aaqRyFkVcmtuOFPt05/2f2vzTnnJwA\
-            AAP//AwBuKtnYwgAAAA==\"]"
+            AAP//AwB81vXLwgAAAA==\"]"
           textDecoded:
             data:
               currentUser:
                 codySubscription:
                   applyProRateLimits: true
-                  currentPeriodEndAt: 2024-07-14T22:11:32Z
-                  currentPeriodStartAt: 2024-06-14T22:11:32Z
+                  currentPeriodEndAt: 2024-08-14T22:11:32Z
+                  currentPeriodStartAt: 2024-07-14T22:11:32Z
                   plan: PRO
                   status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -931,120 +908,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:27.293Z
-      time: 0
-      timings:
-        blocked: -1
-        connect: -1
-        dns: -1
-        receive: 0
-        send: 0
-        ssl: -1
-        wait: 0
-    - _id: b584bf96a3d88ab96114e5cbea1e4bca
-      _order: 0
-      cache: {}
-      request:
-        bodySize: 164
-        cookies: []
-        headers:
-          - _fromType: array
-            name: authorization
-            value: token
-              REDACTED_d5e0f0a37c9821e856b923fe14e67a605e3f6c0a517d5a4f46a4e35943ee0f6d
-          - _fromType: array
-            name: content-type
-            value: application/json; charset=utf-8
-          - _fromType: array
-            name: user-agent
-            value: JetBrains / 6.0-localbuild
-          - _fromType: array
-            name: accept
-            value: "*/*"
-          - _fromType: array
-            name: content-length
-            value: "164"
-          - _fromType: array
-            name: accept-encoding
-            value: gzip,deflate
-          - name: host
-            value: sourcegraph.com
-        headersSize: 332
-        httpVersion: HTTP/1.1
-        method: POST
-        postData:
-          mimeType: application/json; charset=utf-8
-          params: []
-          textJSON:
-            query: |-
-              
-              query SiteIdentification {
-              	site {
-              		siteID
-              		productSubscription {
-              			license {
-              				hashedKey
-              			}
-              		}
-              	}
-              }
-            variables: {}
-        queryString:
-          - name: SiteIdentification
-            value: null
-        url: https://sourcegraph.com/.api/graphql?SiteIdentification
-      response:
-        bodySize: 212
-        content:
-          encoding: base64
-          mimeType: application/json
-          size: 212
-          text: "[\"H4sIAAAAAAAAAzTLsQ6CMBCA4Xe52YX2rgVmF+PI4HztXaWJAdKWwRDf3WDiv/zTd4BwY\
-            xgPqLnp/7crjDCte4n6LLzNDw1wga2sssc27aHGkreW1+UErxx1qT87c51V7vqGEYbo\
-            u9AZm/okmgxi70QZlZzzqNEaJOMNReocCdkgiCk4j4btwJwIPmdfAAAA//8DABj2u36\
-            gAAAA\"]"
-          textDecoded:
-            data:
-              site:
-                productSubscription:
-                  license:
-                    hashedKey: 9c71b123f8fdef24486dea4e56674ec32452725c5165d53bd44fb6742a39aaf5
-                siteID: SourcegraphWeb
-        cookies: []
-        headers:
-          - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
-          - name: content-type
-            value: application/json
-          - name: transfer-encoding
-            value: chunked
-          - name: connection
-            value: keep-alive
-          - name: access-control-allow-credentials
-            value: "true"
-          - name: access-control-allow-origin
-            value: ""
-          - name: cache-control
-            value: no-cache, max-age=0
-          - name: vary
-            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
-              X-Requested-With,Cookie
-          - name: x-content-type-options
-            value: nosniff
-          - name: x-frame-options
-            value: DENY
-          - name: x-xss-protection
-            value: 1; mode=block
-          - name: strict-transport-security
-            value: max-age=31536000; includeSubDomains; preload
-          - name: content-encoding
-            value: gzip
-        headersSize: 1333
-        httpVersion: HTTP/1.1
-        redirectURL: ""
-        status: 200
-        statusText: OK
-      startedDateTime: 2024-07-03T14:54:26.919Z
+      startedDateTime: 2024-07-18T07:46:50.261Z
       time: 0
       timings:
         blocked: -1
@@ -1102,18 +966,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 139
+        bodySize: 142
         content:
           encoding: base64
           mimeType: application/json
-          size: 139
-          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWBhaG\
-            xvFGBkYmugbmugbG8aZ6JroGlilpJkYGFpbGJgZKtbW1AAAAAP//AwDEjdT9SQAAAA==\
-            \"]"
+          size: 142
+          text: "[\"H4sIAAAAAAAAA6pWSkks\",\"SVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWRhaW\
+            5vFGBkYmugbmuoYW8aZ6prrJxhapBkmGZhbmScZKtbW1AAAAAP//\",\"AwBZ7XcTSQ\
+            AAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Wed, 03 Jul 2024 14:54:27 GMT
+            value: Thu, 18 Jul 2024 07:46:50 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1144,7 +1008,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-03T14:54:26.955Z
+      startedDateTime: 2024-07-18T07:46:49.951Z
       time: 0
       timings:
         blocked: -1

--- a/src/main/java/com/sourcegraph/cody/agent/CurrentConfigFeatures.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CurrentConfigFeatures.java
@@ -24,7 +24,7 @@ public final class CurrentConfigFeatures implements ConfigFeaturesObserver {
 
   /** Most recent {@link ConfigFeatures}. */
   private final AtomicReference<ConfigFeatures> features =
-      new AtomicReference<>(new ConfigFeatures(false));
+      new AtomicReference<>(new ConfigFeatures(false, false));
 
   /**
    * Observers that are attached (see {@link #attach}) and receive updates

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.agent
 
 import com.sourcegraph.cody.agent.protocol.ChatError
 import com.sourcegraph.cody.agent.protocol.ChatMessage
+import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.ContextItem
 import com.sourcegraph.cody.agent.protocol.Repo
 
@@ -55,6 +56,7 @@ data class WebviewPostMessageParams(val id: String, val message: ExtensionMessag
 
 data class ConfigFeatures(
     val attribution: Boolean,
+    val serverSentModels: Boolean
 )
 
 data class EnhancedContextContextT(val groups: List<ContextGroup>)

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -2,7 +2,6 @@ package com.sourcegraph.cody.agent
 
 import com.sourcegraph.cody.agent.protocol.ChatError
 import com.sourcegraph.cody.agent.protocol.ChatMessage
-import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.ContextItem
 import com.sourcegraph.cody.agent.protocol.Repo
 
@@ -54,10 +53,7 @@ data class ExtensionMessage(
 
 data class WebviewPostMessageParams(val id: String, val message: ExtensionMessage)
 
-data class ConfigFeatures(
-    val attribution: Boolean,
-    val serverSentModels: Boolean
-)
+data class ConfigFeatures(val attribution: Boolean, val serverSentModels: Boolean)
 
 data class EnhancedContextContextT(val groups: List<ContextGroup>)
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -8,8 +8,11 @@ data class ChatModelsResponse(val models: List<ChatModelProvider>) {
       val provider: String?,
       val title: String?,
       val model: String,
-      val tags: MutableList<String>,
-      val usage: MutableList<String>,
+      val tags: MutableList<String>? = mutableListOf(),
+      val usage: MutableList<String>? = mutableListOf(),
+      @Deprecated("No longer provided by agent") val default: Boolean = false,
+      @Deprecated("No longer provided by agent") val codyProOnly: Boolean = false,
+      @Deprecated("No longer provided by agent") val deprecated: Boolean = false
   ) {
     fun getIcon(): Icon? =
         when (provider) {
@@ -34,10 +37,8 @@ data class ChatModelsResponse(val models: List<ChatModelProvider>) {
       }
     }
 
-    public val codyProOnly: Boolean
-      get() = tags.contains("pro")
+    public fun isCodyProOnly(): Boolean = tags?.contains("pro") ?: codyProOnly
 
-    public val deprecated: Boolean
-      get() = tags.contains("deprecated")
+    public fun isDeprecated(): Boolean = tags?.contains("deprecated") ?: deprecated
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -5,12 +5,11 @@ import javax.swing.Icon
 
 data class ChatModelsResponse(val models: List<ChatModelProvider>) {
   data class ChatModelProvider(
-      val default: Boolean,
-      val codyProOnly: Boolean,
       val provider: String?,
       val title: String?,
       val model: String,
-      val deprecated: Boolean = false
+      val tags: MutableList<String>,
+      val usage: MutableList<String>,
   ) {
     fun getIcon(): Icon? =
         when (provider) {
@@ -34,5 +33,11 @@ data class ChatModelsResponse(val models: List<ChatModelProvider>) {
         provider?.let { append(" by $provider") }
       }
     }
+
+    public val codyProOnly: Boolean
+      get() = tags.contains("pro")
+
+    public val deprecated: Boolean
+      get() = tags.contains("deprecated")
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -359,8 +359,8 @@ private constructor(
                 provider = it.provider,
                 title = it.title,
                 model = it.model ?: "",
-                usage = it.usage,
-                tags = it.tags)
+                usage = it.usage.toMutableList(),
+                tags = it.tags.toMutableList())
           }
 
       val connectionId = createNewPanel(project) { it.server.chatNew() }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/AgentChatSession.kt
@@ -356,11 +356,11 @@ private constructor(
       val chatModelProvider =
           state.llm?.let {
             ChatModelsResponse.ChatModelProvider(
-                default = it.model == null,
-                codyProOnly = false,
                 provider = it.provider,
                 title = it.title,
-                model = it.model ?: "")
+                model = it.model ?: "",
+                usage = it.usage,
+                tags = it.tags)
           }
 
       val connectionId = createNewPanel(project) { it.server.chatNew() }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -28,7 +28,7 @@ class LlmDropdown(
     val parentDialog: EditCommandPrompt?,
     val chatModelProviderFromState: ChatModelsResponse.ChatModelProvider?,
 ) : ComboBox<ChatModelsResponse.ChatModelProvider>(MutableCollectionComboBoxModel()) {
-  var hasServerSentModels = false 
+  var hasServerSentModels = false
 
   init {
     renderer = LlmComboBoxRenderer(this)
@@ -50,7 +50,7 @@ class LlmDropdown(
 
   private fun subscribeToFeatureUpdates() {
     val currentConfigFeatures: CurrentConfigFeatures =
-    project.getService(CurrentConfigFeatures::class.java)
+        project.getService(CurrentConfigFeatures::class.java)
     currentConfigFeatures.attach(::handleConfigUpdate)
   }
 
@@ -64,7 +64,7 @@ class LlmDropdown(
 
   @RequiresEdt
   private fun updateModelsInUI(models: List<ChatModelsResponse.ChatModelProvider>) {
-    if (project.isDisposed) return 
+    if (project.isDisposed) return
     this.removeAllItems()
 
     val availableModels = models.filterNot { it.isDeprecated() }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -49,8 +49,8 @@ class LlmDropdown(
   private fun updateModelsInUI(models: List<ChatModelsResponse.ChatModelProvider>) {
     if (project.isDisposed) return
 
-    val availableModels = models.filterNot { it.deprecated }
-    availableModels.sortedBy { it.codyProOnly }.forEach(::addItem)
+    val availableModels = models.filterNot { it.isDeprecated() }
+    availableModels.sortedBy { it.isCodyProOnly() }.forEach(::addItem)
 
     val selectedFromState = chatModelProviderFromState
     val selectedFromHistory = HistoryService.getInstance(project).getDefaultLlm()
@@ -59,7 +59,8 @@ class LlmDropdown(
             ?: availableModels.find { it.model == selectedFromHistory?.model }
 
     selectedItem =
-        if (selectedModel?.codyProOnly == true && isCurrentUserFree()) availableModels.getOrNull(0)
+        if (selectedModel?.isCodyProOnly() == true && isCurrentUserFree())
+            availableModels.getOrNull(0)
         else selectedModel
 
     val isEnterpriseAccount =
@@ -83,7 +84,7 @@ class LlmDropdown(
     if (project.isDisposed) return
     val modelProvider = anObject as? ChatModelsResponse.ChatModelProvider
     if (modelProvider != null) {
-      if (modelProvider.codyProOnly && isCurrentUserFree()) {
+      if (modelProvider.isCodyProOnly() && isCurrentUserFree()) {
         BrowserOpener.openInBrowser(project, "https://sourcegraph.com/cody/subscription")
         return
       }

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -63,13 +63,10 @@ class LlmDropdown(
             availableModels.getOrNull(0)
         else selectedModel
 
-    val isEnterpriseAccount =
-        CodyAuthenticationManager.getInstance(project).account?.isEnterpriseAccount() ?: false
-
     // If the dropdown is already disabled, don't change it. It can happen
     // in the case of the legacy commands (updateAfterFirstMessage happens before this call).
     isEnabled = isEnabled && chatModelProviderFromState == null
-    isVisible = !isEnterpriseAccount
+    isVisible = true
     setMaximumRowCount(15)
 
     revalidate()

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.MutableCollectionComboBoxModel
 import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.ConfigFeatures
+import com.sourcegraph.cody.agent.CurrentConfigFeatures
 import com.sourcegraph.cody.agent.protocol.ChatModelsParams
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 import com.sourcegraph.cody.agent.protocol.ModelUsage
@@ -26,12 +28,14 @@ class LlmDropdown(
     val parentDialog: EditCommandPrompt?,
     val chatModelProviderFromState: ChatModelsResponse.ChatModelProvider?,
 ) : ComboBox<ChatModelsResponse.ChatModelProvider>(MutableCollectionComboBoxModel()) {
+  var hasServerSentModels = false 
 
   init {
     renderer = LlmComboBoxRenderer(this)
     isVisible = false
     isOpaque = false
 
+    subscribeToFeatureUpdates()
     updateModels()
   }
 
@@ -40,14 +44,28 @@ class LlmDropdown(
       val chatModels = agent.server.chatModels(ChatModelsParams(modelUsage.value))
       val response =
           chatModels.completeOnTimeout(null, 10, TimeUnit.SECONDS).get() ?: return@withAgent
-
       invokeLater { updateModelsInUI(response.models) }
+    }
+  }
+
+  private fun subscribeToFeatureUpdates() {
+    val currentConfigFeatures: CurrentConfigFeatures =
+    project.getService(CurrentConfigFeatures::class.java)
+    currentConfigFeatures.attach(::handleConfigUpdate)
+  }
+
+  private fun handleConfigUpdate(config: ConfigFeatures) {
+    hasServerSentModels = config.serverSentModels
+    if (!isVisible && config.serverSentModels) {
+      isVisible = true
+      revalidate()
     }
   }
 
   @RequiresEdt
   private fun updateModelsInUI(models: List<ChatModelsResponse.ChatModelProvider>) {
-    if (project.isDisposed) return
+    if (project.isDisposed) return 
+    this.removeAllItems()
 
     val availableModels = models.filterNot { it.isDeprecated() }
     availableModels.sortedBy { it.isCodyProOnly() }.forEach(::addItem)
@@ -69,7 +87,8 @@ class LlmDropdown(
     // If the dropdown is already disabled, don't change it. It can happen
     // in the case of the legacy commands (updateAfterFirstMessage happens before this call).
     isEnabled = isEnabled && chatModelProviderFromState == null
-    isVisible = !isEnterpriseAccount
+
+    isVisible = !isEnterpriseAccount || hasServerSentModels
     setMaximumRowCount(15)
 
     revalidate()

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -81,6 +81,9 @@ class LlmDropdown(
             availableModels.getOrNull(0)
         else selectedModel
 
+    val isEnterpriseAccount =
+        CodyAuthenticationManager.getInstance(project).account?.isEnterpriseAccount() ?: false
+
     // If the dropdown is already disabled, don't change it. It can happen
     // in the case of the legacy commands (updateAfterFirstMessage happens before this call).
     isEnabled = isEnabled && chatModelProviderFromState == null

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -59,8 +59,7 @@ class LlmDropdown(
             ?: availableModels.find { it.model == selectedFromHistory?.model }
 
     selectedItem =
-        if (selectedModel?.codyProOnly == true && isCurrentUserFree())
-            availableModels.find { it.default }
+        if (selectedModel?.codyProOnly == true && isCurrentUserFree()) availableModels.getOrNull(0)
         else selectedModel
 
     val isEnterpriseAccount =

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatTagsLlmMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatTagsLlmMigration.kt
@@ -1,0 +1,47 @@
+package com.sourcegraph.cody.config.migration
+
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.ChatModelsParams
+import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
+import com.sourcegraph.cody.agent.protocol.ModelUsage
+import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.AccountData
+import com.sourcegraph.cody.history.state.LLMState
+import java.util.concurrent.TimeUnit
+
+object ChatTagsLlmMigration {
+
+  fun migrate(project: Project) {
+    CodyAgentService.withAgent(project) { agent ->
+      val chatModels = agent.server.chatModels(ChatModelsParams(ModelUsage.CHAT.value))
+      val models =
+          chatModels.completeOnTimeout(null, 10, TimeUnit.SECONDS).get()?.models ?: return@withAgent
+      migrateHistory(HistoryService.getInstance(project).state.accountData, models)
+    }
+  }
+
+  fun migrateHistory(
+      accountData: List<AccountData>,
+      models: List<ChatModelsResponse.ChatModelProvider>,
+  ) {
+    accountData.forEach { accData ->
+      accData.chats
+          .mapNotNull { it.llm }
+          .forEach { llm ->
+            val model = models.find { it.model == llm.model }
+            llm.usage = model?.usage ?: mutableListOf("chat", "edit")
+            llm.tags = model?.tags ?: mutableListOf()
+
+            addTagIf(llm, "deprecated", model?.deprecated)
+            addTagIf(llm, "pro", model?.codyProOnly)
+          }
+    }
+  }
+
+  fun addTagIf(llm: LLMState, tag: String, condition: Boolean?) {
+    if (condition ?: false && !llm.tags.contains(tag)) {
+      llm.tags.add(tag)
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
@@ -38,7 +38,7 @@ object DeprecatedChatLlmMigration {
       notify: (Set<String>) -> Unit
   ) {
 
-    val defaultModel = models.getOrNull(0) ?: return
+    val defaultModel = models.find { it.default } ?: return
 
     fun isDeprecated(modelState: LLMState): Boolean =
         models.firstOrNull { it.model == modelState.model }?.deprecated ?: false

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
@@ -38,7 +38,7 @@ object DeprecatedChatLlmMigration {
       notify: (Set<String>) -> Unit
   ) {
 
-    val defaultModel = models.find { it.default } ?: return
+    val defaultModel = models.getOrNull(0) ?: return
 
     fun isDeprecated(modelState: LLMState): Boolean =
         models.firstOrNull { it.model == modelState.model }?.deprecated ?: false

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -64,6 +64,7 @@ class SettingsMigration : Activity {
     }
 
     DeprecatedChatLlmMigration.migrate(project)
+    ChatTagsLlmMigration.migrate(project)
   }
 
   private fun migrateOrphanedChatsToActiveAccount(project: Project) {

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -23,8 +23,8 @@ class LLMState : BaseState() {
         it.model = chatModelProvider.model
         it.title = chatModelProvider.title
         it.provider = chatModelProvider.provider
-        it.tags = chatModelProvider.tags
-        it.usage = chatModelProvider.usage
+        it.tags = chatModelProvider.tags ?: mutableListOf()
+        it.usage = chatModelProvider.usage ?: mutableListOf()
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -13,12 +13,18 @@ class LLMState : BaseState() {
 
   @get:OptionTag(tag = "provider", nameAttribute = "") var provider: String? by string()
 
+  @get:OptionTag(tag = "tags", nameAttribute = "") var tags: MutableList<String> by list()
+
+  @get:OptionTag(tag = "usage", nameAttribute = "") var usage: MutableList<String> by list()
+
   companion object {
     fun fromChatModel(chatModelProvider: ChatModelsResponse.ChatModelProvider): LLMState {
       return LLMState().also {
         it.model = chatModelProvider.model
         it.title = chatModelProvider.title
         it.provider = chatModelProvider.provider
+        it.tags = chatModelProvider.tags
+        it.usage = chatModelProvider.usage
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
@@ -36,7 +36,7 @@ class LlmComboBoxRenderer(private val llmDropdown: LlmDropdown) : DefaultListCel
     val displayNameLabel = JLabel(chatModelProvider.displayName())
     textBadgePanel.add(displayNameLabel, BorderLayout.CENTER)
     textBadgePanel.border = BorderFactory.createEmptyBorder(0, 5, 0, 0)
-    if (chatModelProvider.codyProOnly && llmDropdown.isCurrentUserFree()) {
+    if (chatModelProvider.isCodyProOnly() && llmDropdown.isCurrentUserFree()) {
       textBadgePanel.add(JLabel(Icons.LLM.ProSticker), BorderLayout.EAST)
     }
     val isInline = llmDropdown.parentDialog != null

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CodyAgentClientTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CodyAgentClientTest.kt
@@ -36,7 +36,7 @@ class CodyAgentClientTest : BasePlatformTestCase() {
 
   @Test
   fun `notifies observer`() {
-    val expected = ConfigFeatures(attribution = true)
+    val expected = ConfigFeatures(attribution = true, serverSentModels = true)
     client()
         .webviewPostMessage(
             WebviewPostMessageParams(

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
@@ -17,7 +17,7 @@ class CurrentConfigFeaturesTest {
   fun `observer is notified`() {
     val current = CurrentConfigFeatures()
     val observer = FakeObserver()
-    val expected = ConfigFeatures(attribution = true, serverSentModels =true)
+    val expected = ConfigFeatures(attribution = true, serverSentModels = true)
     current.attach(observer)
     current.update(expected)
     assertThat(observer.features, hasItems(expected))

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
@@ -17,7 +17,7 @@ class CurrentConfigFeaturesTest {
   fun `observer is notified`() {
     val current = CurrentConfigFeatures()
     val observer = FakeObserver()
-    val expected = ConfigFeatures(attribution = true)
+    val expected = ConfigFeatures(attribution = true, serverSentModels =true)
     current.attach(observer)
     current.update(expected)
     assertThat(observer.features, hasItems(expected))
@@ -33,7 +33,7 @@ class CurrentConfigFeaturesTest {
     await until
         {
           val beforeCount = cancelledObserver.features.size
-          current.update(ConfigFeatures(attribution = true))
+          current.update(ConfigFeatures(attribution = true, serverSentModels = true))
           val afterCount = cancelledObserver.features.size
           afterCount == beforeCount
         }
@@ -50,12 +50,12 @@ class CurrentConfigFeaturesTest {
     await until
         {
           val beforeCount = cancelledObserver.features.size
-          current.update(ConfigFeatures(attribution = true))
+          current.update(ConfigFeatures(attribution = true, serverSentModels = true))
           val afterCount = cancelledObserver.features.size
           afterCount == beforeCount
         }
     val beforeCount = activeObserver.features.size
-    current.update(ConfigFeatures(attribution = true))
+    current.update(ConfigFeatures(attribution = true, serverSentModels = true))
     val afterCount = activeObserver.features.size
     assertEquals(beforeCount + 1, afterCount)
   }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.config
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.registerServiceInstance
 import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
+import com.sourcegraph.cody.config.migration.ChatTagsLlmMigration
 import com.sourcegraph.cody.config.migration.DeprecatedChatLlmMigration
 import com.sourcegraph.cody.config.migration.SettingsMigration
 import com.sourcegraph.cody.history.HistoryService
@@ -99,11 +100,11 @@ class SettingsMigrationTest : BasePlatformTestCase() {
           it.defaultLlm =
               LLMState.fromChatModel(
                   ChatModelsResponse.ChatModelProvider(
-                      "Cyberdyne",
-                      "Terminator",
-                      "T-800",
-                      mutableListOf("free"),
-                      mutableListOf("chat", "edit")))
+                      provider = "Cyberdyne",
+                      title = "Terminator",
+                      model = "T-800",
+                      default = true,
+                      codyProOnly = false))
           it.defaultEnhancedContext =
               EnhancedContextState().also {
                 it.isEnabled = true
@@ -148,11 +149,7 @@ class SettingsMigrationTest : BasePlatformTestCase() {
                     it.llm =
                         LLMState.fromChatModel(
                             ChatModelsResponse.ChatModelProvider(
-                                "Uni of IL",
-                                "HAL",
-                                "HAL 9000",
-                                mutableListOf("pro"),
-                                mutableListOf("chat", "edit")))
+                                "Uni of IL", "HAL", "HAL 9000", codyProOnly = true))
                     it.messages =
                         mutableListOf(
                             MessageState().also {
@@ -198,20 +195,21 @@ class SettingsMigrationTest : BasePlatformTestCase() {
   fun `test DeprecatedChatLlmMigration`() {
     fun createLlmModel(
         version: String,
-        tags: List<String>,
+        isDefault: Boolean = false,
+        isDeprecated: Boolean = false,
     ): ChatModelsResponse.ChatModelProvider {
       return ChatModelsResponse.ChatModelProvider(
           "Anthropic",
           "Claude $version",
           "anthropic/claude-$version",
-          tags.toMutableList(),
-          mutableListOf("chat", "edit"))
+          default = isDefault,
+          deprecated = isDeprecated)
     }
 
-    val claude20 = createLlmModel("2.0", listOf("deprecated"))
-    val claude21 = createLlmModel("2.1", listOf("deprecated"))
-    val claude30 = createLlmModel("3.0", listOf())
-    val models = listOf(claude30, claude20, claude21)
+    val claude20 = createLlmModel("2.0", isDeprecated = true)
+    val claude21 = createLlmModel("2.1", isDeprecated = true)
+    val claude30 = createLlmModel("3.0", isDefault = true)
+    val models = listOf(claude20, claude21, claude30)
 
     val accountData =
         mutableListOf(
@@ -254,6 +252,94 @@ class SettingsMigrationTest : BasePlatformTestCase() {
       ad.chats.forEach { chat ->
         assertEquals(claude30.model, chat.llm?.model)
         assertEquals(claude30.title, chat.llm?.title)
+      }
+    }
+  }
+
+  fun `test ChatTagsLlmMigration`() {
+    fun createLlmModel(
+        version: String,
+        isDeprecated: Boolean = false,
+        isCodyPro: Boolean = false,
+        usage: List<String> = listOf("chat", "edit"),
+        tags: List<String> = listOf()
+    ): ChatModelsResponse.ChatModelProvider {
+      return ChatModelsResponse.ChatModelProvider(
+          "Anthropic",
+          "Claude $version",
+          "anthropic/claude-$version",
+          usage = usage.toMutableList(),
+          tags = tags.toMutableList(),
+          deprecated = isDeprecated,
+          codyProOnly = isCodyPro)
+    }
+
+    val claude20Old = createLlmModel("2.0", isDeprecated = true)
+    val claude20New = createLlmModel("2.0", tags = listOf("deprecated", "free"))
+
+    // This will be included as an old style model in the agent response to simulate
+    // an upgrade that runs before the agent upgrades
+    val claude21Old = createLlmModel("2.1", isDeprecated = true, isCodyPro = true)
+
+    val claude30Old = createLlmModel("3.0")
+    val claude30New = createLlmModel("3.0", tags = listOf("pro", "other"), usage = listOf("edit"))
+    val models = listOf(claude20New, claude21Old, claude30New)
+
+    val accountData =
+        mutableListOf(
+            AccountData().also {
+              it.accountId = "first"
+              it.chats =
+                  mutableListOf(
+                      ChatState("chat1").also {
+                        it.messages = mutableListOf()
+                        it.llm = LLMState.fromChatModel(claude20Old)
+                      },
+                      ChatState("chat2").also {
+                        it.messages = mutableListOf()
+                        it.llm = LLMState.fromChatModel(claude21Old)
+                      })
+            },
+            AccountData().also {
+              it.accountId = "second"
+              it.chats =
+                  mutableListOf(
+                      ChatState("chat1").also {
+                        it.messages = mutableListOf()
+                        it.llm = LLMState.fromChatModel(claude20Old)
+                      },
+                      ChatState("chat2").also {
+                        it.messages = mutableListOf()
+                        it.llm = LLMState.fromChatModel(claude30Old)
+                      })
+            })
+
+    fun getTagsAndUsage(chat: ChatState): Pair<List<String>, List<String>> {
+      val llm = chat.llm ?: return Pair(listOf<String>(), listOf<String>())
+      return Pair(llm.tags.toList(), llm.usage.toList())
+    }
+
+    ChatTagsLlmMigration.migrateHistory(accountData, models)
+    assertEquals(2, accountData.size)
+    accountData.forEach { ad ->
+      ad.chats.forEach { chat ->
+        when (chat.llm?.model) {
+          claude20Old.model -> {
+            val (tags, usage) = getTagsAndUsage(chat)
+            assertEquals(listOf("deprecated", "free"), tags)
+            assertEquals(listOf("chat", "edit"), usage)
+          }
+          claude21Old.model -> {
+            val (tags, usage) = getTagsAndUsage(chat)
+            assertEquals(listOf("deprecated", "pro"), tags)
+            assertEquals(listOf("chat", "edit"), usage)
+          }
+          claude30Old.model -> {
+            val (tags, usage) = getTagsAndUsage(chat)
+            assertEquals(listOf("pro", "other"), tags)
+            assertEquals(listOf("edit"), usage)
+          }
+        }
       }
     }
   }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -99,7 +99,11 @@ class SettingsMigrationTest : BasePlatformTestCase() {
           it.defaultLlm =
               LLMState.fromChatModel(
                   ChatModelsResponse.ChatModelProvider(
-                      true, false, "Cyberdyne", "Terminator", "T-800"))
+                      "Cyberdyne",
+                      "Terminator",
+                      "T-800",
+                      mutableListOf("pro"),
+                      mutableListOf("chat", "edit")))
           it.defaultEnhancedContext =
               EnhancedContextState().also {
                 it.isEnabled = true
@@ -144,7 +148,11 @@ class SettingsMigrationTest : BasePlatformTestCase() {
                     it.llm =
                         LLMState.fromChatModel(
                             ChatModelsResponse.ChatModelProvider(
-                                false, true, "Uni of IL", "HAL", "HAL 9000"))
+                                "Uni of IL",
+                                "HAL",
+                                "HAL 9000",
+                                mutableListOf("pro"),
+                                mutableListOf("chat", "edit")))
                     it.messages =
                         mutableListOf(
                             MessageState().also {
@@ -190,22 +198,20 @@ class SettingsMigrationTest : BasePlatformTestCase() {
   fun `test DeprecatedChatLlmMigration`() {
     fun createLlmModel(
         version: String,
-        isDefault: Boolean,
-        isDeprecated: Boolean
+        tags: List<String>,
     ): ChatModelsResponse.ChatModelProvider {
       return ChatModelsResponse.ChatModelProvider(
-          isDefault,
-          false,
           "Anthropic",
           "Claude $version",
           "anthropic/claude-$version",
-          isDeprecated)
+          tags.toMutableList(),
+          mutableListOf("chat", "edit"))
     }
 
-    val claude20 = createLlmModel("2.0", isDefault = false, isDeprecated = true)
-    val claude21 = createLlmModel("2.1", isDefault = false, isDeprecated = true)
-    val claude30 = createLlmModel("3.0", isDefault = true, isDeprecated = false)
-    val models = listOf(claude20, claude21, claude30)
+    val claude20 = createLlmModel("2.0", listOf("deprecated"))
+    val claude21 = createLlmModel("2.1", listOf("deprecated"))
+    val claude30 = createLlmModel("3.0", listOf())
+    val models = listOf(claude30, claude20, claude21)
 
     val accountData =
         mutableListOf(

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -102,7 +102,7 @@ class SettingsMigrationTest : BasePlatformTestCase() {
                       "Cyberdyne",
                       "Terminator",
                       "T-800",
-                      mutableListOf("pro"),
+                      mutableListOf("free"),
                       mutableListOf("chat", "edit")))
           it.defaultEnhancedContext =
               EnhancedContextState().also {


### PR DESCRIPTION
[CODY-2746](https://linear.app/sourcegraph/issue/CODY-2746/confirm-chat-dropdown-is-available-on-jetbrains-as-well)

This update is to align with a [refactor](https://github.com/sourcegraph/cody/pull/4780) in the vscode repo around model types to remove certain hard coded fields and replace them with ModelTags.

This is very rough around the edges because I don't know how to access the generated code in that PR (nor am I aware of the context on this repo) so any feedback is welcome!

## Test plan
Green CI
