### PR TITLE
Several fixes for Hotkey Inlay Hints

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -18,6 +18,7 @@ data class CodyApplicationSettings(
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Int? = null,
     var isLookupAutocompleteEnabled: Boolean = true,
+    var isCodyUIHintsEnabled: Boolean = true,
     var blacklistedLanguageIds: List<String> = listOf(),
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
@@ -37,6 +38,7 @@ data class CodyApplicationSettings(
     this.isCustomAutocompleteColorEnabled = state.isCustomAutocompleteColorEnabled
     this.customAutocompleteColor = state.customAutocompleteColor
     this.isLookupAutocompleteEnabled = state.isLookupAutocompleteEnabled
+    this.isCodyUIHintsEnabled = state.isCodyUIHintsEnabled
     this.blacklistedLanguageIds = state.blacklistedLanguageIds
     this.isOnboardingGuidanceDismissed = state.isOnboardingGuidanceDismissed
     this.shouldAcceptNonTrustedCertificatesAutomatically =

--- a/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SettingsModel.kt
@@ -12,6 +12,7 @@ data class SettingsModel(
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Color? = null,
     var isLookupAutocompleteEnabled: Boolean = true,
+    var isCodyUIHintsEnabled: Boolean = true,
     var blacklistedLanguageIds: List<String> = listOf(),
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = false

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.sourcegraph.cody.edit.FixupService
+import com.sourcegraph.config.ConfigUtil
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Graphics2D
@@ -28,7 +29,6 @@ class CodySelectionInlayManager(val project: Project) {
 
   fun handleSelectionChanged(editor: Editor, event: SelectionEvent) {
     clearInlay()
-
     val service = FixupService.getInstance(project)
     if (!service.isEligibleForInlineEdit(editor)) {
       return
@@ -37,6 +37,7 @@ class CodySelectionInlayManager(val project: Project) {
     if (service.getActiveSession() != null) {
       return
     }
+    if (!ConfigUtil.isCodyUIHintsEnabled()) return // User-disabled.
 
     val startOffset = event.newRange.startOffset
     val endOffset = event.newRange.endOffset

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -11,7 +11,6 @@ import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
-import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.edit.FixupService
 import java.awt.Font
 import java.awt.Graphics

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -16,10 +16,10 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ServerAuthLoader
 import com.sourcegraph.cody.config.SourcegraphServerPath
 import com.sourcegraph.cody.config.SourcegraphServerPath.Companion.from
-import org.jetbrains.annotations.Contract
-import org.jetbrains.annotations.VisibleForTesting
 import java.nio.file.Path
 import java.nio.file.Paths
+import org.jetbrains.annotations.Contract
+import org.jetbrains.annotations.VisibleForTesting
 
 object ConfigUtil {
   const val DOTCOM_URL = "https://sourcegraph.com/"
@@ -131,7 +131,8 @@ object ConfigUtil {
 
   @JvmStatic fun isCodyDebugEnabled(): Boolean = CodyApplicationSettings.instance.isCodyDebugEnabled
 
-  @JvmStatic fun isCodyUIHintsEnabled(): Boolean = CodyApplicationSettings.instance.isCodyUIHintsEnabled
+  @JvmStatic
+  fun isCodyUIHintsEnabled(): Boolean = CodyApplicationSettings.instance.isCodyUIHintsEnabled
 
   @JvmStatic
   fun isCodyVerboseDebugEnabled(): Boolean =

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -16,10 +16,10 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ServerAuthLoader
 import com.sourcegraph.cody.config.SourcegraphServerPath
 import com.sourcegraph.cody.config.SourcegraphServerPath.Companion.from
-import java.nio.file.Path
-import java.nio.file.Paths
 import org.jetbrains.annotations.Contract
 import org.jetbrains.annotations.VisibleForTesting
+import java.nio.file.Path
+import java.nio.file.Paths
 
 object ConfigUtil {
   const val DOTCOM_URL = "https://sourcegraph.com/"
@@ -130,6 +130,8 @@ object ConfigUtil {
   @JvmStatic fun isCodyEnabled(): Boolean = CodyApplicationSettings.instance.isCodyEnabled
 
   @JvmStatic fun isCodyDebugEnabled(): Boolean = CodyApplicationSettings.instance.isCodyDebugEnabled
+
+  @JvmStatic fun isCodyUIHintsEnabled(): Boolean = CodyApplicationSettings.instance.isCodyUIHintsEnabled
 
   @JvmStatic
   fun isCodyVerboseDebugEnabled(): Boolean =


### PR DESCRIPTION
Based on user feedback from GTM and Product, discussions with @danielmarquespt , and my own testing, I've made the following round of fixes to the hotkey hint feature, which shows an inlay with "Ctrl + Alt + ↵ to Edit" at the end of your selections in the editor window:

1. There is a new Preferences option for disabling the feature:
<img width="653" alt="image" src="https://github.com/sourcegraph/jetbrains/assets/613744/8a78f2b1-c6d5-4a9c-902b-687d7d2e236d">

2. The hint no longer draws if the selection is only on one line.
  - this takes care of many annoying cases, such as Find/Replace lighting it up everywhere
 
3. The hint now draws below the last line of the selection.

This makes it less intrusive, IMO, as it's out of the way of the cursor.

I think it's also more intuitive. Several users claim that it "used to work that way". It never actually worked that way; it always drew at the end of the last line of the selection. But now it does work that way.

The one downside is that the hint can sometimes draw rather far from the selection, appearing to be two lines below. We will see how people respond to it.

Coincidentally and usefully, this change also fixes CODY-2541. Getting the hint inlay out of the way of the cursor removed the interference with fine-tuning the selection.

These changes also appear have to fixed CODY-2748, because I reported it and I can no longer reproduce it. It used to be 100% reproducible, so I'm going to mark it closed until it resurfaces.

fixes CODY-2541
fixes CODY-2748

## Test plan

This requires UI testing to verify with actual integration tests.
I reviewed the test plan, and these changes do not affect the plan.
