### PR TITLE
Allow clients to redefine untitled files protocol during their creation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=280a91999947fb7829d56163d3a13f9910b0ac05
+cody.commit=6443a0b6eccb4aa1442f9c5a2b09f2755a3d89da

--- a/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CodyAgentClient.java
@@ -48,7 +48,7 @@ public class CodyAgentClient {
   @Nullable Function<TextDocumentShowParams, Boolean> onTextDocumentShow;
 
   // Callback for the "textDocument/openUntitledDocument" request from the agent.
-  @Nullable Function<UntitledTextDocument, Boolean> onOpenUntitledDocument;
+  @Nullable Function<UntitledTextDocument, ProtocolTextDocument> onOpenUntitledDocument;
 
   // Callback for the "workspace/edit" request from the agent.
   @Nullable Function<WorkspaceEditParams, Boolean> onWorkspaceEdit;
@@ -108,7 +108,7 @@ public class CodyAgentClient {
   }
 
   @JsonRequest("textDocument/openUntitledDocument")
-  public CompletableFuture<Boolean> openUntitledDocument(UntitledTextDocument params) {
+  public CompletableFuture<ProtocolTextDocument> openUntitledDocument(UntitledTextDocument params) {
     if (onOpenUntitledDocument == null) {
       return CompletableFuture.failedFuture(
           new Exception("No callback registered for textDocument/openUntitledDocument"));

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -15,7 +15,7 @@ import com.sourcegraph.cody.agent.protocol_extensions.Position
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import java.awt.Point
 import java.nio.file.FileSystems
-import java.util.*
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
 


### PR DESCRIPTION
Closes https://linear.app/sourcegraph/issue/CODY-2004/bug-cody-recreates-the-file-that-was-created-by-generate-unit-tests

## Changes

Some IDEs (maybe even most IDEs except VSC) does not have notion of unsaved files.
Keeping two different models in IDE and in the agent is problematic and leads to hard to track errors.
It is easier to let client be honest and notify agent about real protocol which it is using (most likely `file://` instead of `untitled://`).

As a result that change slightly modifies behaviour of the `openTextDocument`. 
One could now call `openTextDocument` with `untitled://abc` parameter, and as a result get a `TextDocument` which uri points to `file://abc` (or any other path, really).

## Test plan

1. Build JetBrains with this PR using CODY_DIR env var and [this PR](https://github.com/sourcegraph/cody/pull/4841)
2. Ask cody to generate tests for some file which does not have tests yet
3. Accept the changes
4. Delete that newly created file
5. Perform autocomplete in some other file
6. Make sure test file was not recreated

