### PR TITLE
Stop spamming notifications when selecting code in Cody-ignored files

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -63,30 +63,43 @@ class FixupService(val project: Project) : Disposable {
     }
   }
 
+  /**
+   * Returns true if the given Editor is eligible for inline edit commands.
+   * @param editor the Editor to check
+   * @param verbose if true, log the reason and present the user with a notification.
+   */
   @RequiresEdt
-  fun isEligibleForInlineEdit(editor: Editor): Boolean {
+  fun isEligibleForInlineEdit(editor: Editor, verbose: Boolean = true): Boolean {
     if (!isCodyEnabled()) {
-      logger.warn("Edit code invoked when Cody not enabled")
+      if (verbose) {
+        logger.warn("Edit code invoked when Cody not enabled")
+      }
       return false
     }
 
     if (!CodyAgentService.isConnected(project)) {
-      runInEdt { CodyStartingNotification().notify(project) }
-      logger.warn("The agent is not connected")
+      if (verbose) {
+        runInEdt { CodyStartingNotification().notify(project) }
+        logger.warn("The agent is not connected")
+      }
       return false
     }
 
     if (!CodyEditorUtil.isEditorValidForAutocomplete(editor)) {
-      runInEdt { EditingNotAvailableNotification().notify(project) }
-      logger.warn("Edit code invoked when editing not available")
+      if (verbose) {
+        runInEdt { EditingNotAvailableNotification().notify(project) }
+        logger.warn("Edit code invoked when editing not available")
+      }
       getActiveSession()?.cancel()
       return false
     }
 
     val policy = IgnoreOracle.getInstance(project).policyForEditor(editor)
     if (policy != IgnorePolicy.USE) {
-      runInEdt { ActionInIgnoredFileNotification().notify(project) }
-      logger.warn("Ignoring file for inline edits: $editor, policy=$policy")
+      if (verbose) {
+        runInEdt { ActionInIgnoredFileNotification().notify(project) }
+        logger.warn("Ignoring file for inline edits: $editor, policy=$policy")
+      }
       return false
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -65,6 +65,7 @@ class FixupService(val project: Project) : Disposable {
 
   /**
    * Returns true if the given Editor is eligible for inline edit commands.
+   *
    * @param editor the Editor to check
    * @param verbose if true, log the reason and present the user with a notification.
    */

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -30,7 +30,8 @@ class CodySelectionInlayManager(val project: Project) {
   fun handleSelectionChanged(editor: Editor, event: SelectionEvent) {
     clearInlay()
     val service = FixupService.getInstance(project)
-    if (!service.isEligibleForInlineEdit(editor)) {
+    // Don't spam with notifications as we're selecting code.
+    if (!service.isEligibleForInlineEdit(editor, verbose = false)) {
       return
     }
     // Don't show it if we're in the middle of an edit.


### PR DESCRIPTION
fixes CODY-2863

I noticed this annoying behavior when working on debugging WSL -- all the files are considered "ignored", and selecting code in them went wild with notifications. So I've turned them off entirely for code selection. You will get a notification when you try an inline edit or other Cody action.

## Test plan

Tested locally by simulating the code paths. We don't have any Cody-ignore tests in JetBrains yet, unfortunately.
