### PR TITLE
Repeat mode for integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -508,6 +508,7 @@ tasks {
     description = "Runs the integration tests."
     sharedIntegrationTestConfig(buildCodyDir, "replay")
     dependsOn("processIntegrationTestResources")
+    project.properties["repeatTests"]?.let { systemProperty("repeatTests", it) }
   }
 
   register<Test>("passthroughIntegrationTest") {

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/AllSuites.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/AllSuites.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.edit.DocumentCodeTest
 import com.sourcegraph.cody.util.CodyIntegrationTextFixture
+import com.sourcegraph.cody.util.RepeatableSuite
 import java.util.concurrent.TimeUnit
 import org.junit.AfterClass
 import org.junit.runner.RunWith
@@ -20,7 +21,7 @@ import org.junit.runners.Suite
  * Multiple recording files can be used, but each should have its own suite with tearDown() method
  * nad define unique CODY_RECORDING_NAME.
  */
-@RunWith(Suite::class)
+@RunWith(RepeatableSuite::class)
 @Suite.SuiteClasses(DocumentCodeTest::class)
 class AllSuites {
   companion object {

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -18,9 +18,15 @@ import com.sourcegraph.cody.edit.widget.LensLabel
 import com.sourcegraph.cody.edit.widget.LensSpinner
 import com.sourcegraph.cody.util.CodyIntegrationTextFixture
 import junit.framework.TestCase
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
+@RunWith(JUnit4::class)
 class DocumentCodeTest : CodyIntegrationTextFixture() {
 
+  @Test
   fun testGetsFoldingRanges() {
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_FOLDING_RANGES)
 
@@ -39,6 +45,8 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
         selection.startOffset == caret && selection.endOffset == caret)
   }
 
+  @Ignore
+  @Test
   fun skip_testGetsWorkingGroupLens() {
     val assertsExecuted = AtomicInteger(0)
     val showWorkingGroupSessionStateListener =
@@ -87,6 +95,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     }
   }
 
+  @Test
   fun testShowsAcceptLens() {
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_ACCEPT_GROUP)
     assertInlayIsShown()
@@ -123,6 +132,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertTrue(hasJavadocComment(myFixture.editor.document.text))
   }
 
+  @Test
   fun testAccept() {
     assertNoActiveSession()
     assertNoInlayShown()
@@ -139,6 +149,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
     assertNoActiveSession()
   }
 
+  @Test
   fun skip_testUndo() {
     val originalDocument = myFixture.editor.document.text
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_ACCEPT_GROUP)

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -47,7 +47,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
 
   @Ignore
   @Test
-  fun skip_testGetsWorkingGroupLens() {
+  fun testGetsWorkingGroupLens() {
     val assertsExecuted = AtomicInteger(0)
     val showWorkingGroupSessionStateListener =
         object : FixupService.ActiveFixupSessionStateListener {
@@ -150,7 +150,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
   }
 
   @Test
-  fun skip_testUndo() {
+  fun testUndo() {
     val originalDocument = myFixture.editor.document.text
     runAndWaitForNotifications(DocumentCodeAction.ID, TOPIC_DISPLAY_ACCEPT_GROUP)
     assertNotSame(

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -17,13 +17,13 @@ import com.sourcegraph.cody.edit.widget.LensIcon
 import com.sourcegraph.cody.edit.widget.LensLabel
 import com.sourcegraph.cody.edit.widget.LensSpinner
 import com.sourcegraph.cody.util.CodyIntegrationTextFixture
+import com.sourcegraph.cody.util.CustomJunitClassRunner
 import junit.framework.TestCase
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
+@RunWith(CustomJunitClassRunner::class)
 class DocumentCodeTest : CodyIntegrationTextFixture() {
 
   @Test

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CustomJunitClassRunner.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CustomJunitClassRunner.kt
@@ -1,0 +1,13 @@
+package com.sourcegraph.cody.util
+
+import org.junit.runners.BlockJUnit4ClassRunner
+import org.junit.runners.model.FrameworkMethod
+
+class CustomJunitClassRunner(klass: Class<*>?) : BlockJUnit4ClassRunner(klass) {
+
+  private val repeatTimes: UInt? = System.getProperty("repeatTests")?.toUIntOrNull()
+
+  override fun isIgnored(child: FrameworkMethod?): Boolean {
+    return repeatTimes == null && super.isIgnored(child)
+  }
+}

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/RepeatableSuite.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/RepeatableSuite.kt
@@ -1,0 +1,34 @@
+package com.sourcegraph.cody.util
+
+import org.junit.runners.Suite
+import org.junit.runners.model.InitializationError
+import org.junit.runners.model.RunnerBuilder
+
+class RepeatableSuite(klass: Class<*>, builder: RunnerBuilder?) :
+    Suite(builder, klass, getAnnotatedClasses(klass)) {
+
+  init {
+    if (repeatTimes < 1)
+        throw IllegalStateException("Invalid value for repeatTimes (${repeatTimes} < 1)")
+  }
+
+  companion object {
+
+    private val repeatTimes: Int = System.getProperty("repeatTests")?.toIntOrNull() ?: 1
+
+    @Throws(InitializationError::class)
+    fun getAnnotatedClasses(klass: Class<*>): Array<Class<*>> {
+      val annotation = klass.getAnnotation(SuiteClasses::class.java)
+      if (annotation == null) {
+        throw InitializationError(
+            String.format("class '%s' must have a SuiteClasses annotation", klass.name))
+      } else {
+        return annotation.value
+            .map { it.java }
+            .map { l -> List(repeatTimes) { l } }
+            .flatten()
+            .toTypedArray()
+      }
+    }
+  }
+}


### PR DESCRIPTION
To use it, add the option `-PrepeatTests` to the command line. Example:
```
./gradlew integrationTest -PrepeatTests=20
```

## Test plan

1. Introduce non-deterministic failures, like this:
   ```kotlin
   val x = Random.nextInt() % 10
   if (x < 2) {
       fail()
   } else if (x < 4) {
       1 / 0
   } else if (x < 6) {
       throw IllegalStateException("$x")
   }
   ```
3. Run the tests with high enough repetition count
4. Verify that different stack traces are present in the test report

<img width="775" alt="Screenshot 2024-07-16 at 11 17 46" src="https://github.com/user-attachments/assets/fbede453-8fe6-47b5-9fe8-7a3e4f84c924">
