### PR TITLE
CI workflow to measure stability of integration tests

### DIFF
--- a/.github/workflows/integration-stability.yml
+++ b/.github/workflows/integration-stability.yml
@@ -1,0 +1,60 @@
+name: Measure stability of integration tests
+on:
+  workflow_dispatch:
+    inputs:
+      repetitions:
+        description: 'How many times to repeat each test'
+        type: number
+        default: 10
+jobs:
+  test:
+    name: Build and run tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+      - run: yarn global add pnpm@8.6.7
+      - run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        shell: bash
+        id: pnpm-cache
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-
+          restore-keys: ${{ runner.os }}-${{ matrix.node }}-pnpm-store-k
+      - name: Cache gradle and sourcegraph stores
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.sourcegraph/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Gradle Wrapper Validation
+        uses: gradle/actions/wrapper-validation@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+      # Skip Code Search build in CI because it's slow, and we don't use it anyway for testing purposes.
+      - run: echo "SKIP_CODE_SEARCH_BUILD=true" >> $GITHUB_ENV
+      - name: Build integration tests
+        run: ./gradlew integrationTestClasses
+      - name: Run integration tests
+        run: ./gradlew integrationTest -PrepeatTests=${{ github.event.inputs.repetitions }}
+      - name: Upload the test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/
+          compression-level: 9
+      - run: ./gradlew --stop


### PR DESCRIPTION
This is a follow-up to #1911.

<img width="988" alt="Screenshot 2024-07-16 at 13 49 54" src="https://github.com/user-attachments/assets/2368a8b3-d0f1-49f6-a048-c2b174462a7c">


## Test plan

Tested on a personal fork

