### PR TITLE
Show proper shortcut for every action on edit inlay

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -614,21 +614,19 @@ class EditCommandPrompt(
     /** Returns a compact symbol representation of the action's keyboard shortcut, if any. */
     @JvmStatic
     fun getShortcutDisplayString(actionId: String): String? {
+      fun getFirstShortcut(id: String): String? {
+        return KeymapManager.getInstance().activeKeymap.getShortcuts(id).firstOrNull()?.let {
+          KeymapUtil.getShortcutText(it)
+        }
+      }
+
       return when (actionId) {
         "cody.editCodeAction",
-        "cody.inlineEditRetryAction" -> {
-          KeymapUtil.getShortcutText(
-              KeymapManager.getInstance().activeKeymap.getShortcuts("cody.editCodeAction")[0])
-        }
+        "cody.inlineEditRetryAction" -> getFirstShortcut("cody.editCodeAction")
         "cody.inlineEditCancelAction",
         "cody.inlineEditUndoAction",
-        "cody.inlineEditDismissAction" -> {
-          KeymapUtil.getShortcutText(
-              KeymapManager.getInstance()
-                  .activeKeymap
-                  .getShortcuts("cody.editCancelOrUndoAction")[0])
-        }
-        else -> null
+        "cody.inlineEditDismissAction" -> getFirstShortcut("cody.editCancelOrUndoAction")
+        else -> getFirstShortcut(actionId)
       }
     }
   }


### PR DESCRIPTION
Closes CODY-2388

## Test plan

1. Run any edit action
2. Verify all actions have descriptions

![image](https://github.com/user-attachments/assets/862d826b-6798-48a0-a098-e7246cb909e9)
