### PR TITLE
Check `editor.isDisposed` within `com.sourcegraph.cody.autocomplete.CodyAutocompleteManager.displayAgentAutocomplete` (fixes #1731)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -357,6 +357,10 @@ class CodyAutocompleteManager {
       inlayModel: InlayModel,
       triggerKind: InlineCompletionTriggerKind,
   ) {
+    if (editor.isDisposed) {
+      return
+    }
+
     val project = editor.project
     val defaultItem = items.firstOrNull() ?: return
     val range = getTextRange(editor.document, defaultItem.range)


### PR DESCRIPTION
fixes #1731

## Test plan
1. specific repro steps are unknown but based on the code the error was possible 
