### PR TITLE
Do not fail the build when integration tests fail in repetition mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -508,7 +508,12 @@ tasks {
     description = "Runs the integration tests."
     sharedIntegrationTestConfig(buildCodyDir, "replay")
     dependsOn("processIntegrationTestResources")
-    project.properties["repeatTests"]?.let { systemProperty("repeatTests", it) }
+    project.properties["repeatTests"]?.let {
+      systemProperty("repeatTests", it)
+      // We expect some of the repetitions to fail,
+      // so we don't treat this situation as a build failure
+      ignoreFailures = true
+    }
   }
 
   register<Test>("passthroughIntegrationTest") {


### PR DESCRIPTION
This is a follow-up to #1912.

I believe that build failure is not particularly informative when it happens every single time. I would prefer having a way to distinguish at first glance between a build that finished normally (with the inevitable test failures) and a build that was aborted (e.g. due to an OOM error).

## Test plan

Verified on a personal fork