### PR TITLE
Improve Cody invitation to include handy shortcuts

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagesPanel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/MessagesPanel.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.chat.ui
 
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.VerticalFlowLayout
 import com.intellij.util.concurrency.annotations.RequiresEdt
@@ -16,7 +17,14 @@ class MessagesPanel(private val project: Project, private val chatSession: ChatS
     JPanel(VerticalFlowLayout(VerticalFlowLayout.TOP, 0, 0, true, true)) {
   init {
     val welcomeText = CodyBundle.getString("messages-panel.welcome-text")
-    addChatMessageAsComponent(ChatMessage(Speaker.ASSISTANT, welcomeText))
+    val regex = Regex("\\{action\\.([^}]+)}")
+    val matches = regex.findAll(welcomeText)
+    val shortcutKeys = matches.map { it.groups[1]?.value ?: "" }.toList()
+    val finalWelcomeText =
+        shortcutKeys.fold(welcomeText) { acc, shortcutKey ->
+          acc.replace("{action.$shortcutKey}", KeymapUtil.getShortcutText(shortcutKey))
+        }
+    addChatMessageAsComponent(ChatMessage(Speaker.ASSISTANT, finalWelcomeText))
   }
 
   @RequiresEdt

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -108,7 +108,37 @@ context-panel.tree.help-tooltip.title=About chat context
 context-panel.tree.help-tooltip.description=Select up to {0} repositories to use as reference context in this chat.
 context-panel.tree.help-tooltip.link.text=Context documentation
 context-panel.tree.help-tooltip.link.href=https://sourcegraph.com/docs/cody/core-concepts/context
-messages-panel.welcome-text=Hello! I'm Cody. I can write code and answer questions for you. See [Cody documentation](https://sourcegraph.com/docs/cody) for help and tips.
+messages-panel.welcome-text=<html>\
+  <p>Cody is here to help you write, fix, and maintain your code more efficiently.</p>\
+  <br>\
+  <p>Here are some handy keyboard shortcuts:</p>\
+  <table>\
+    <tr>\
+        <td></td>\
+        <td>\
+            <b>{action.cody.triggerAutocomplete}</b><br/>\
+            <b>{action.cody.editCodeAction}</b><br/>\
+            <b>{action.cody.documentCodeAction}</b><br/>\
+            <b>{action.cody.testCodeAction}</b><br/>\
+            <b>{action.cody.newChat}</b>\
+        </td>\
+        <td>\
+            : Force an Autocompletion<br/>\
+            : Edit/Write Code<br/>\
+            : Generate Documentation<br/>\
+            : Generate Tests<br/>\
+            : New chat\
+        </td>\
+    </tr>\
+</table>\
+<table>\
+<tr>\
+<td><a href="https://sourcegraph.com/docs/cody">Documentation</a>&nbsp;&nbsp;&nbsp;|&nbsp;</td>\
+<td><a href="https://discord.com/servers/sourcegraph-969688426372825169">Community</a>&nbsp;&nbsp;&nbsp;|&nbsp;</td>\
+<td><a href="https://community.sourcegraph.com/c/cody/5">Support Forum</a></td>\
+</tr>\
+</table>\
+</html>
 EndOfTrialNotification.link-action-name=Setup Payment Info
 EndOfTrialNotification.do-not-show-again=Don't show again
 TrialEndedNotification.ignore=cody.ignore.notification.trial-ended


### PR DESCRIPTION
Closes CODY-2804

## Changes

![image](https://github.com/user-attachments/assets/8a2fed47-edc6-45d7-a422-c3d005a8c55d)

## Test plan

Run IntelliJ and see if chat shows new, better intro.