### PR TITLE
Fix command-enter shortcut for Edit Code

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/CodyActionPrompter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/CodyActionPrompter.kt
@@ -1,0 +1,12 @@
+package com.sourcegraph.cody.edit
+
+import com.intellij.openapi.actionSystem.ActionPromoter
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.DataContext
+
+internal class CodyActionPromoter : ActionPromoter {
+  override fun promote(actions: List<AnAction>, context: DataContext): List<AnAction> {
+    val (promoted, unknown) = actions.partition { it is InlineEditPromptEditCodeAction }
+    return promoted + unknown
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -2,7 +2,8 @@ package com.sourcegraph.cody.edit
 
 import com.intellij.ide.ui.UISettingsListener
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.actionSystem.KeyboardShortcut
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.DataProvider
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.Logger
@@ -19,7 +20,7 @@ import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.util.SystemInfo
+import com.intellij.openapi.util.Key
 import com.intellij.openapi.vfs.VfsUtilCore
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.WindowManager
@@ -46,10 +47,8 @@ import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.Point
-import java.awt.Toolkit
 import java.awt.event.FocusAdapter
 import java.awt.event.FocusEvent
-import java.awt.event.InputEvent
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
@@ -69,7 +68,6 @@ import javax.swing.JList
 import javax.swing.JPanel
 import javax.swing.JRootPane
 import javax.swing.JScrollPane
-import javax.swing.KeyStroke
 import javax.swing.ListCellRenderer
 import javax.swing.WindowConstants
 import javax.swing.event.CaretListener
@@ -80,7 +78,8 @@ class EditCommandPrompt(
     val editor: Editor,
     dialogTitle: String,
     instruction: String? = null
-) : JFrame(), Disposable, FixupService.ActiveFixupSessionStateListener {
+) : JFrame(), Disposable, FixupService.ActiveFixupSessionStateListener, DataProvider {
+
   private val logger = Logger.getInstance(EditCommandPrompt::class.java)
 
   private val offset = editor.caretModel.primaryCaret.offset
@@ -89,26 +88,11 @@ class EditCommandPrompt(
 
   private val isDisposed: AtomicBoolean = AtomicBoolean(false)
 
-  // Key for activating the OK button. It's not a globally registered action.
-  // We use a local action and just wire it up manually.
-  private val enterKeyStroke =
-      if (SystemInfo.isMac) {
-        // Mac: Command+Enter
-        KeyStroke.getKeyStroke(
-            KeyEvent.VK_ENTER, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx())
-      } else {
-        // Others: Control+Enter
-        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK)
-      }
-
   private val okButton =
       namedButton("ok-button").apply {
         text = "Edit Code"
         foreground = boldLabelColor()
-
         addActionListener { performOKAction() }
-        registerKeyboardAction(
-            { performOKAction() }, enterKeyStroke, JComponent.WHEN_IN_FOCUSED_WINDOW)
       }
 
   private val okButtonGroup =
@@ -117,19 +101,23 @@ class EditCommandPrompt(
         isOpaque = false
         background = textFieldBackground()
         layout = BoxLayout(this, BoxLayout.X_AXIS)
+        val activeKeymapShortcuts = KeymapUtil.getActiveKeymapShortcuts("cody.inlineEditEditCode")
         val shortcutLabel =
-            namedLabel("ok-keyboard-shortcut-label").apply {
-              text = KeymapUtil.getShortcutText(KeyboardShortcut(enterKeyStroke, null))
-              // Spacing between key shortcut and button.
-              border = BorderFactory.createEmptyBorder(0, 0, 0, 12)
-            }
-        add(shortcutLabel)
+            if (activeKeymapShortcuts.shortcuts.isNotEmpty()) {
+              namedLabel("ok-keyboard-shortcut-label")
+                  .apply {
+                    text = KeymapUtil.getShortcutsText(activeKeymapShortcuts.shortcuts)
+                    // Spacing between key shortcut and button.
+                    border = BorderFactory.createEmptyBorder(0, 0, 0, 12)
+                  }
+                  .also(::add)
+            } else null
         add(okButton)
 
         this.addPropertyChangeListener { evt ->
           if (evt?.propertyName == "enabled") {
             okButton.isEnabled = evt.newValue as Boolean
-            shortcutLabel.isEnabled = evt.newValue as Boolean
+            shortcutLabel?.isEnabled = evt.newValue as Boolean
           }
         }
       }
@@ -291,6 +279,10 @@ class EditCommandPrompt(
     shape = makeCornerShape(width, height)
     updateDialogPosition()
     isVisible = true
+
+    val old = controller.project.getUserData(EDIT_COMMAND_PROMPT_KEY)
+    old?.dispose()
+    controller.project.putUserData(EDIT_COMMAND_PROMPT_KEY, this)
   }
 
   private fun updateDialogPosition() {
@@ -547,6 +539,7 @@ class EditCommandPrompt(
   }
 
   override fun dispose() {
+    controller.project.putUserData(EDIT_COMMAND_PROMPT_KEY, null)
     if (!isDisposed.get()) {
       try {
         unregisterListeners()
@@ -582,6 +575,8 @@ class EditCommandPrompt(
   }
 
   companion object {
+    val EDIT_COMMAND_PROMPT_KEY: Key<EditCommandPrompt?> = Key.create("EDIT_COMMAND_PROMPT_KEY")
+
     // This is a fallback for the rare case when the screen size computations fail.
     const val DEFAULT_TEXT_FIELD_WIDTH: Int = 700
 
@@ -633,5 +628,12 @@ class EditCommandPrompt(
 
   override fun fixupSessionStateChanged(isInProgress: Boolean) {
     runInEdt { okButtonGroup.isEnabled = !isInProgress }
+  }
+
+  override fun getData(dataId: String): Any? {
+    if (CommonDataKeys.PROJECT.`is`(dataId)) {
+      return controller.project
+    }
+    return null
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -285,6 +285,8 @@ class EditCommandPrompt(
     controller.project.putUserData(EDIT_COMMAND_PROMPT_KEY, this)
   }
 
+  fun isOkActionEnabled() = okButtonGroup.isEnabled
+
   private fun updateDialogPosition() {
     // Convert caret position to screen coordinates.
     val pointInEditor = editor.visualPositionToXY(editor.caretModel.visualPosition)

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
@@ -9,7 +9,7 @@ internal class InlineEditPromptEditCodeAction : DumbAwareAction() {
   private fun getInlineEditPrompt(event: AnActionEvent) = EDIT_COMMAND_PROMPT_KEY.get(event.project)
 
   override fun update(event: AnActionEvent) {
-    event.presentation.isEnabledAndVisible = getInlineEditPrompt(event) != null
+    event.presentation.isEnabledAndVisible = getInlineEditPrompt(event)?.isOkActionEnabled() == true
   }
 
   override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
@@ -1,0 +1,22 @@
+package com.sourcegraph.cody.edit
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import com.sourcegraph.cody.edit.EditCommandPrompt.Companion.EDIT_COMMAND_PROMPT_KEY
+
+internal class InlineEditPromptEditCodeAction : DumbAwareAction() {
+  private fun getInlineEditPrompt(event: AnActionEvent) = EDIT_COMMAND_PROMPT_KEY.get(event.project)
+
+  override fun update(event: AnActionEvent) {
+    event.presentation.isEnabledAndVisible = getInlineEditPrompt(event) != null
+  }
+
+  override fun actionPerformed(e: AnActionEvent) {
+    getInlineEditPrompt(e)?.performOKAction()
+  }
+
+  fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.EDT
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -288,8 +288,7 @@
                 <action id="cody.inlineEditEditCode"
                         text="Edit Code"
                         class="com.sourcegraph.cody.edit.InlineEditPromptEditCodeAction" >
-                    <keyboard-shortcut first-keystroke="ctrl ENTER" keymap="$default"/>
-<!--                    replace-all="true"-->
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl ENTER" keymap="$default"/>
                 </action>
 
                 <!-- also now dismisses error lens, if showing -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,6 +52,9 @@
 
         <applicationService
                 serviceImplementation="com.sourcegraph.cody.config.CodyPersistentAccounts"/>
+
+        <actionPromoter implementation="com.sourcegraph.cody.edit.CodyActionPromoter"/>
+
         <notificationGroup id="cody.auth" displayType="BALLOON"/>
         <notificationGroup id="Sourcegraph errors" displayType="BALLOON"/>
         <notificationGroup id="Sourcegraph: URL sharing" displayType="BALLOON"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -285,6 +285,13 @@
                     <override-text place="GoToAction" text="Cody: Dismiss"/>
                 </action>
 
+                <action id="cody.inlineEditEditCode"
+                        text="Edit Code"
+                        class="com.sourcegraph.cody.edit.InlineEditPromptEditCodeAction" >
+                    <keyboard-shortcut first-keystroke="ctrl ENTER" keymap="$default"/>
+<!--                    replace-all="true"-->
+                </action>
+
                 <!-- also now dismisses error lens, if showing -->
                 <action id="cody.editCancelOrUndoAction"
                         class="com.sourcegraph.cody.edit.actions.EditCancelOrUndoAction"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -292,6 +292,8 @@
                         text="Edit Code"
                         class="com.sourcegraph.cody.edit.InlineEditPromptEditCodeAction" >
                     <keyboard-shortcut replace-all="true" first-keystroke="ctrl ENTER" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="meta ENTER" keymap="Mac OS X 10.5+"/>
+                    <override-text place="GoToAction" text="Cody: Confirm Code Edition"/>
                 </action>
 
                 <!-- also now dismisses error lens, if showing -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -293,7 +293,7 @@
                         class="com.sourcegraph.cody.edit.InlineEditPromptEditCodeAction" >
                     <keyboard-shortcut replace-all="true" first-keystroke="ctrl ENTER" keymap="$default"/>
                     <keyboard-shortcut replace-all="true" first-keystroke="meta ENTER" keymap="Mac OS X 10.5+"/>
-                    <override-text place="GoToAction" text="Cody: Confirm Code Edition"/>
+                    <override-text place="GoToAction" text="Cody: Edit Code"/>
                 </action>
 
                 <!-- also now dismisses error lens, if showing -->


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-2868.
Fixes https://github.com/sourcegraph/cody-issues/issues/307

## Test plan
1. In particular: Having IC 2024.1 and com.intellij.lang.jsgraphql (241.14494.150) plugin installed
2. Edit Code...
3. Trigger the edit with the shortcut 
