### PR TITLE
Shut down agent after each test

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -49,6 +49,13 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase() {
           logger.warn("Error shutting down session", x)
         }
       }
+      CodyAgentService.getInstance(myFixture.project).apply {
+        try {
+          stopAgent(project)
+        } catch (x: Exception) {
+          logger.warn("Error shutting down agent", x)
+        }
+      }
     } finally {
       super.tearDown()
     }


### PR DESCRIPTION
Since the `CodyIntegrationTextFixture` starts a fresh agent for every test case, we need to shut down those agents during cleanup. Otherwise the leftover agent processes clog the RAM (each Node process takes 50-250 MB), and the JVM threads which listen to them keep running forever.

## Test plan

Manually run the stability check in CI
[1000 repetitions](https://github.com/sourcegraph/jetbrains/actions/runs/10073107716) (5000 individual test cases): 2 hours 40 minutes, 118 failures