### PR TITLE
Only display Context Filter banners when Context Filters are the primary cause

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=20a7fd5368f1ecc14ec2c2e97fdd5144f8ba16d2
+cody.commit=288f7f6ddfb82b014578aff47b9114212ac414a6

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -4,6 +4,7 @@ data class IgnoreTestParams(val uri: String)
 
 data class IgnoreTestResponse(
     val policy: String // "use" or "ignore"
+    val transient: Boolean // whether the result should be cached
 )
 
 data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -4,7 +4,6 @@ data class IgnoreTestParams(val uri: String)
 
 data class IgnoreTestResponse(
     val policy: String // "use" or "ignore"
-    val transient: Boolean // whether the result should be cached
 )
 
 data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -5,7 +5,6 @@ import com.github.difflib.patch.DeltaType
 import com.github.difflib.patch.Patch
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
@@ -247,7 +246,7 @@ class CodyAutocompleteManager {
       if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
           IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
               IgnorePolicy.USE) {
-        runInEdt { ActionInIgnoredFileNotification().notify(project) }
+        ActionInIgnoredFileNotification.maybeNotify(project)
         resetApplication(project)
         resultOuter.cancel(true)
       } else {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -42,7 +42,7 @@ abstract class BaseCommandAction : BaseChatAction() {
               }
               else -> {
                 // This file is ignored. Display an error and stop.
-                ActionInIgnoredFileNotification().notify(project)
+                ActionInIgnoredFileNotification.maybeNotify(project)
               }
             }
           }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/FixupService.kt
@@ -98,7 +98,7 @@ class FixupService(val project: Project) : Disposable {
     val policy = IgnoreOracle.getInstance(project).policyForEditor(editor)
     if (policy != IgnorePolicy.USE) {
       if (verbose) {
-        runInEdt { ActionInIgnoredFileNotification().notify(project) }
+        ActionInIgnoredFileNotification.maybeNotify(project)
         logger.warn("Ignoring file for inline edits: $editor, policy=$policy")
       }
       return false

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/ActionInIgnoredFileNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/ActionInIgnoredFileNotification.kt
@@ -6,7 +6,13 @@ import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.runInEdt
+import com.intellij.openapi.diagnostic.logger
+import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
+import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.statusbar.CodyStatus
+import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
 
@@ -19,6 +25,34 @@ class ActionInIgnoredFileNotification :
         CodyBundle.getString("filter.action-in-ignored-file.detail"),
         NotificationType.INFORMATION),
     NotificationFullContent {
+
+  companion object {
+    val log = logger<ActionInIgnoredFileNotification>()
+
+    fun maybeNotify(project: Project) {
+      val status = CodyStatusService.getCurrentStatus(project)
+      val account = CodyAuthenticationManager.getInstance(project).account
+      when {
+        status == CodyStatus.CodyUninit ||
+            status == CodyStatus.CodyDisabled ||
+            status == CodyStatus.CodyNotSignedIn ||
+            status == CodyStatus.CodyInvalidToken ||
+            status == CodyStatus.CodyAgentNotRunning ||
+            status == CodyStatus.AgentError ||
+            status == CodyStatus.RateLimitError -> {
+          // Do nothing. These errors are not related to context filters; displaying them is handled
+          // by the status
+          // bar widget.
+        }
+        account?.isDotcomAccount() == true -> {
+          // Show nothing. We do not use context filters on sourcegraph.com; should be unreachable.
+          log.warn(
+              "got 'action in ignored file' notification with a dotcom account, which should be unreachable")
+        }
+        else -> runInEdt { ActionInIgnoredFileNotification().notify(project) }
+      }
+    }
+  }
 
   init {
     icon = Icons.CodyLogoSlash

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -122,11 +122,7 @@ class IgnoreOracle(private val project: Project) {
             else -> throw IllegalStateException("invalid ignore policy value")
           }
       synchronized(cache) {
-        if (it.transient) {
-          cache.remove(uri)
-        } else {
-          cache.put(uri, CacheEntry(policy = newPolicy, timestampMsec = System.currentTimeMillis()))
-        }
+        cache.put(uri, CacheEntry(policy = newPolicy, timestampMsec = System.currentTimeMillis()))
       }
       newPolicy
     }

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -29,8 +29,8 @@ enum class IgnorePolicy(val value: String) {
  */
 @Service(Service.Level.PROJECT)
 class IgnoreOracle(private val project: Project) {
-
-  private val cache = SLRUMap<String, IgnorePolicy>(100, 100)
+  data class CacheEntry(val policy: IgnorePolicy, val timestampMsec: Long)
+  private val cache = SLRUMap<String, CacheEntry>(100, 100)
   @Volatile private var focusedPolicy: IgnorePolicy? = null
   @Volatile private var willFocusUri: String? = null
   private val fileListeners: MutableList<FocusedFileIgnorePolicyListener> = mutableListOf()
@@ -101,8 +101,9 @@ class IgnoreOracle(private val project: Project) {
   fun policyForUri(uri: String): CompletableFuture<IgnorePolicy> {
     val completable = CompletableFuture<IgnorePolicy>()
     val result = synchronized(cache) { cache[uri] }
-    if (result != null) {
-      completable.complete(result)
+    val cacheMaxAgeMsec = 60 * 1000
+    if (result != null && result.timestampMsec > System.currentTimeMillis() - cacheMaxAgeMsec) {
+      completable.complete(result.policy)
       return completable
     }
     CodyAgentService.withAgent(project) { agent ->
@@ -120,7 +121,13 @@ class IgnoreOracle(private val project: Project) {
             "use" -> IgnorePolicy.USE
             else -> throw IllegalStateException("invalid ignore policy value")
           }
-      synchronized(cache) { cache.put(uri, newPolicy) }
+      synchronized(cache) {
+        if (it.transient) {
+          cache.remove(uri)
+        } else {
+          cache.put(uri, CacheEntry(policy = newPolicy, timestampMsec = System.currentTimeMillis()))
+        }
+      }
       newPolicy
     }
   }
@@ -133,21 +140,6 @@ class IgnoreOracle(private val project: Project) {
       completable.get(policyAwaitTimeoutMs, TimeUnit.MILLISECONDS)
     } catch (timedOut: TimeoutException) {
       null
-    }
-  }
-
-  /**
-   * Gets whether `uri` should be ignored for autocomplete, etc. If the result is not available
-   * quickly, returns null and invokes `orElse` on a pooled thread when the result is available.
-   */
-  @Suppress("unused")
-  fun policyForUriOrElse(uri: String, orElse: (policy: IgnorePolicy) -> Unit): IgnorePolicy? {
-    val completable = policyForUri(uri)
-    try {
-      return completable.get(16, TimeUnit.MILLISECONDS)
-    } catch (timedOut: TimeoutException) {
-      ApplicationManager.getApplication().executeOnPooledThread { orElse(completable.get()) }
-      return null
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -30,6 +30,7 @@ enum class IgnorePolicy(val value: String) {
 @Service(Service.Level.PROJECT)
 class IgnoreOracle(private val project: Project) {
   data class CacheEntry(val policy: IgnorePolicy, val timestampMsec: Long)
+
   private val cache = SLRUMap<String, CacheEntry>(100, 100)
   @Volatile private var focusedPolicy: IgnorePolicy? = null
   @Volatile private var willFocusUri: String? = null

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusService.kt
@@ -51,13 +51,12 @@ class CodyStatusService(val project: Project) : Disposable {
 
       val token =
           CodyAuthenticationManager.getInstance(project).account?.let(service::findCredentials)
+      // Note, the order of these clauses is important because earlier clauses take precedence over
+      // later ones.
+      // Fundamental issues are tested first.
       status =
           if (!ConfigUtil.isCodyEnabled()) {
             CodyStatus.CodyDisabled
-          } else if (IgnoreOracle.getInstance(project).isEditingIgnoredFile) {
-            CodyStatus.InIgnoredFile
-          } else if (!ConfigUtil.isCodyAutocompleteEnabled()) {
-            CodyStatus.AutocompleteDisabled
           } else if (CodyAgentService.agentError.get() != null) {
             CodyStatus.AgentError
           } else if (!CodyAgentService.isConnected(project)) {
@@ -69,6 +68,10 @@ class CodyStatusService(val project: Project) : Disposable {
             CodyStatus.RateLimitError
           } else if (isTokenInvalid) {
             CodyStatus.CodyInvalidToken
+          } else if (IgnoreOracle.getInstance(project).isEditingIgnoredFile) {
+            CodyStatus.InIgnoredFile
+          } else if (!ConfigUtil.isCodyAutocompleteEnabled()) {
+            CodyStatus.AutocompleteDisabled
           } else {
             CodyStatus.Ready
           }


### PR DESCRIPTION
Context filters have a conservative "fail closed" policy. As a result, many failure conditions apply context filter lockdown and users are confused by the source of the error. This change instead leaves handling common failure modes to the existing status bar display.

In addition, add a maximum age to the context filter policy cache and re-consult agent. This ensures we do not cache bad context filter policies indefinitely. (In theory this should not happen given the "context filters changed" event...)

Roll the Agent commit to pick up changes for more reliable git repo identification and correct handling of unknown repositories when the connected Sourcegraph instance has a policy.

Part of CODY-2846, CODY-2809

## Test plan

1. Edit sg02 to have a Context Filters policy:

```
  "cody.contextFilters": {
    "include": [
      {
        "repoNamePattern": "^github.com/sourcegraph/cody.*"
      }
    ],
  }
```

2. Sign in to sg02
3. Open the sourcegraph/cody repository and verify commands, etc. work.
4. Open an unrelated repository and verify that Context Filters error messages are displayed.
5. Delete the token you signed in with to revoke it.
6. Open any repository and verify that error messages related to Context Filters are not displayed.