### PR TITLE
Fix context file items presentation

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ContextItem.kt
@@ -83,11 +83,11 @@ data class ContextItemFile(
         if (isLocal()) {
           "@${uri.path.removePrefix(projectPath ?: "")}"
         } else {
-          val repoCommitFile = uri.path.split("@", "/-/blob/")
-          if (repoCommitFile.size == 3) {
-            val repo = repoCommitFile[0].split("/").lastOrNull()
-            "$repo ${repoCommitFile[2]}"
-          } else uri.path
+          val repo = repoName?.split("/")?.lastOrNull()
+          val file = title
+          return if (repo != null && title != null) {
+            "$repo $file"
+          } else return uri.path
         }
 
     return buildString {

--- a/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ContextItemTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ContextItemTest.kt
@@ -21,6 +21,7 @@ class ContextItemTest : BasePlatformTestCase() {
           uri =
               URI(
                   "https://sourcegraph.sourcegraph.com//github.com/sourcegraph/jetbrains@8229d82c29fd52eda812f182741a3a0bfc1a547e/-/blob/TESTING.md?L49-56"),
+          title = "TESTING.md:49-56",
           repoName = "github.com/sourcegraph/jetbrains",
           revision = "8229d82c29fd52eda812f182741a3a0bfc1a547e",
           range = Range(Position(48, 0), Position(56, 0)),


### PR DESCRIPTION
Some time ago the URL changed ([the PR with the change](https://github.com/sourcegraph/cody/pull/3866/files#diff-1456bee1a58eb80a929388788427f609653aef419f9c9b84e53c1d904446c516R593)).

This PR fixes the presentation of the remote context file items. Preview:
<img width="688" alt="image" src="https://github.com/user-attachments/assets/4dc9eb08-be04-443e-9421-8e6cf99f4d10">


## Test plan
1. Remote context file items look like expected.
