### PR TITLE
Make UI hints disabled by default

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -18,7 +18,7 @@ data class CodyApplicationSettings(
     var isCustomAutocompleteColorEnabled: Boolean = false,
     var customAutocompleteColor: Int? = null,
     var isLookupAutocompleteEnabled: Boolean = true,
-    var isCodyUIHintsEnabled: Boolean = true,
+    var isCodyUIHintsEnabled: Boolean = false,
     var blacklistedLanguageIds: List<String> = listOf(),
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3022/remove-the-edit-hints

## Test plan

1. Select multiline text in IntelliJ
2. Make sure edit hint is not displayed