### PR TITLE
Drop post-sign-up survey which breaks in Sourcegraph experimental UI

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/auth/SourcegraphAuthService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/SourcegraphAuthService.kt
@@ -31,17 +31,17 @@ internal class SourcegraphAuthService : AuthServiceBase() {
         when (authMethod) {
           SsoAuthMethod.GITHUB -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           SsoAuthMethod.GITLAB -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           SsoAuthMethod.GOOGLE -> {
             val end =
-                ".auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=/post-sign-up?returnTo=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
+                ".auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=/user/settings/tokens/new/callback?requestFrom=JETBRAINS-$port"
             Urls.newFromEncoded(ConfigUtil.DOTCOM_URL + end)
           }
           else ->


### PR DESCRIPTION
## Test plan

Manual test:

- Log in to Sourcegraph.com, flip the "experimental" mode on (top right).
- Open JetBrains settings and sign out of all accounts.
- In the side bar, use the social buttons to sign in. You should be able to sign in.
- Repeat the above test, but with the "experimental" mode off.