### PR TITLE
Set the version of the Plugin verifier to 1.371

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           plugin-location: '*.zip'
+          verifier-version: '1.371'
           ide-versions: |
             ideaIC:2021.1
             ideaIC:2024.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ import java.util.EnumSet
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
 import org.jetbrains.changelog.markdownToHTML
-import org.jetbrains.intellij.or
 import org.jetbrains.intellij.tasks.RunPluginVerifierTask.FailureLevel
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.incremental.deleteDirectoryContents

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ val skippedFailureLevels =
 plugins {
   id("java")
   id("jvm-test-suite")
-  id("org.jetbrains.kotlin.jvm") version "1.9.24"
+  id("org.jetbrains.kotlin.jvm") version "1.9.25"
   id("org.jetbrains.intellij") version "1.17.3"
   id("org.jetbrains.changelog") version "2.2.0"
   id("com.diffplug.spotless") version "6.25.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -508,6 +508,7 @@ tasks {
   runPluginVerifier {
     ideVersions.set(versionsToValidate)
     failureLevel.set(EnumSet.complementOf(skippedFailureLevels))
+    verifierVersion.set("1.371")
   }
 
   // Configure UI tests plugin


### PR DESCRIPTION
This is a workaround for #1962, which will allow us to pass CI without errors. These errors look like an unintended consequence of [this update](https://youtrack.jetbrains.com/issue/MP-6650/).

Also made a couple small improvements to the build definition.

## Test plan

Green CI