### PR TITLE
Expose `Restart Cody` action

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -156,7 +156,7 @@ class CodyAgentService(private val project: Project) : Disposable {
     synchronized(startupActions) { startupActions.add(action) }
   }
 
-  fun startAgent(project: Project): CompletableFuture<CodyAgent> {
+  fun startAgent(project: Project, secondsTimeout: Long = 45): CompletableFuture<CodyAgent> {
     ApplicationManager.getApplication().executeOnPooledThread {
       try {
         val future =
@@ -166,7 +166,7 @@ class CodyAgentService(private val project: Project) : Disposable {
               throw (CodyAgentException(msg))
             }
 
-        val agent = future.get(45, TimeUnit.SECONDS)
+        val agent = future.get(secondsTimeout, TimeUnit.SECONDS)
         if (!agent.isConnected()) {
           val msg = "Failed to connect to agent Cody agent"
           logger.error(msg)
@@ -203,10 +203,10 @@ class CodyAgentService(private val project: Project) : Disposable {
     }
   }
 
-  fun restartAgent(project: Project): CompletableFuture<CodyAgent> {
+  fun restartAgent(project: Project, secondsTimeout: Long = 90): CompletableFuture<CodyAgent> {
     synchronized(this) {
       stopAgent(project)
-      return startAgent(project)
+      return startAgent(project, secondsTimeout)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -176,14 +176,12 @@ class CodyAgentService(private val project: Project) : Disposable {
           codyAgent.complete(agent)
           CodyStatusService.resetApplication(project)
         }
-
       } catch (e: TimeoutException) {
         val msg = "Failed to start Cody agent in timely manner, please run any Cody action to retry"
         runInEdt { CodyConnectionTimeoutExceptionNotification().notify(project) }
         setAgentError(project, msg)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))
-      }
-      catch (e: Exception) {
+      } catch (e: Exception) {
         val msg = "Failed to start Cody agent"
         setAgentError(project, msg)
         logger.error(msg, e)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -179,6 +179,7 @@ class CodyAgentService(private val project: Project) : Disposable {
 
       } catch (e: TimeoutException) {
         val msg = "Failed to start Cody agent in timely manner, please run any Cody action to retry"
+        runInEdt { CodyConnectionTimeoutExceptionNotification().notify(project) }
         setAgentError(project, msg)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))
       }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.agent
 import com.intellij.notification.NotificationsManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -19,6 +19,7 @@ import com.sourcegraph.cody.error.CodyConsole
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.listeners.CodyFileEditorListener
 import com.sourcegraph.cody.statusbar.CodyStatusService
+import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.Timer
 import java.util.TimerTask
@@ -167,7 +168,7 @@ class CodyAgentService(private val project: Project) : Disposable {
               throw (CodyAgentException(msg))
             }
 
-        val agent = future.get(1, TimeUnit.SECONDS)
+        val agent = future.get(45, TimeUnit.SECONDS)
         if (!agent.isConnected()) {
           val msg = "Failed to connect to agent Cody agent"
           logger.error(msg)
@@ -178,7 +179,7 @@ class CodyAgentService(private val project: Project) : Disposable {
           CodyStatusService.resetApplication(project)
         }
       } catch (e: TimeoutException) {
-        val msg = "Failed to start Cody agent in timely manner, please run any Cody action to retry"
+        val msg = CodyBundle.getString("error.cody-connection-timeout.message")
         runInEdt {
           val isNoBalloonDisplayed =
               NotificationsManager.getNotificationsManager()
@@ -192,7 +193,7 @@ class CodyAgentService(private val project: Project) : Disposable {
         setAgentError(project, msg)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))
       } catch (e: Exception) {
-        val msg = "Failed to start Cody agent"
+        val msg = CodyBundle.getString("error.cody-starting.message")
         setAgentError(project, msg)
         logger.error(msg, e)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
@@ -3,10 +3,8 @@ package com.sourcegraph.cody.agent
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationFullContent
-import com.intellij.openapi.actionSystem.ActionManager
-import com.intellij.openapi.actionSystem.AnAction
-import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.Icons
+import com.sourcegraph.cody.agent.action.CodyAgentRestartAction
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.NotificationGroups
 
@@ -20,14 +18,6 @@ class CodyConnectionTimeoutExceptionNotification :
 
   init {
     icon = Icons.CodyLogoSlash
-
-    val action = ActionManager.getInstance().getAction("cody.restartCody")
-    addAction(
-        object : AnAction(action.templateText) {
-          override fun actionPerformed(e: AnActionEvent) {
-            expire()
-            action.actionPerformed(e)
-          }
-        })
+    addAction(CodyAgentRestartAction())
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
@@ -1,0 +1,33 @@
+package com.sourcegraph.cody.agent
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.Icons
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+
+class CodyConnectionTimeoutExceptionNotification :
+    Notification(
+        NotificationGroups.SOURCEGRAPH_ERRORS,
+        CodyBundle.getString("notifications.cody-connection-timeout.title"),
+        CodyBundle.getString("notifications.cody-connection-timeout.detail"),
+        NotificationType.WARNING),
+    NotificationFullContent {
+
+  init {
+    icon = Icons.CodyLogoSlash
+
+    val action = ActionManager.getInstance().getAction("cody.restartCody")
+    addAction(
+        object : AnAction(action.templateText) {
+          override fun actionPerformed(e: AnActionEvent) {
+            expire()
+            action.actionPerformed(e)
+          }
+        })
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
-class CodyAgentRestartAction : DumbAwareEDTAction("Restart Cody Agent") {
+class CodyAgentRestartAction : DumbAwareEDTAction() {
   override fun actionPerformed(event: AnActionEvent) {
     event.project?.let { CodyAgentService.getInstance(it).restartAgent(it) }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
@@ -1,11 +1,18 @@
 package com.sourcegraph.cody.agent.action
 
+import com.intellij.notification.NotificationsManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.CodyConnectionTimeoutExceptionNotification
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
-class CodyAgentRestartAction : DumbAwareEDTAction() {
+class CodyAgentRestartAction : DumbAwareEDTAction("Restart Cody") {
   override fun actionPerformed(event: AnActionEvent) {
-    event.project?.let { CodyAgentService.getInstance(it).restartAgent(it) }
+    event.project?.let { project ->
+      CodyAgentService.getInstance(project).restartAgent(project)
+      NotificationsManager.getNotificationsManager()
+          .getNotificationsOfType(CodyConnectionTimeoutExceptionNotification::class.java, project)
+          .forEach { it.expire() }
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,6 +1,5 @@
 package com.sourcegraph.cody.statusbar
 
-import com.intellij.ide.actions.AboutAction
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
@@ -23,11 +22,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
     removeAll()
     val status = e.project?.let { CodyStatusService.getCurrentStatus(it) }
     if (status == CodyStatus.CodyAgentNotRunning || status == CodyStatus.AgentError) {
-      addAll(
-          CodyAgentRestartAction(),
-          OpenLogAction(),
-          AboutAction().apply { templatePresentation.text = "Open About To Troubleshoot Issue" },
-          ReportCodyBugAction())
+      addAll(CodyAgentRestartAction(), OpenLogAction(), ReportCodyBugAction())
     } else {
       addAll(listOfNotNull(deriveRateLimitErrorAction()))
       addSeparator()

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -175,6 +175,8 @@ notification.general.cody-not-running.title=Cody is starting...
 notification.general.cody-not-running.detail=Please wait a few seconds. If Cody still won't start, check the IDE logs for errors.
 notifications.edits.editing-not-available.title=Cody can't edit the file
 notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
+notifications.cody-connection-timeout.title=Cody's connection timeout
+notifications.cody-connection-timeout.detail=Failed to start Cody in timely manner, please run any Cody action or restart Cody to retry.
 
 # Context Filters
 filter.action-in-ignored-file.detail=This file has been restricted by an admin. Autocomplete, commands, and other Cody features are disabled.
@@ -186,7 +188,6 @@ filter.sidebar-panel-ignored-file.learn-more-cta=Learn more
 
 # Other Actions
 action.cody.not-working=Cody is disabled or still starting up
-action.cody.restartAgent.text=Restart Cody Agent
 chat.enhanced_context.title=Chat Context Settings
 action.sourcegraph.disabled.description=Log in to Sourcegraph to enable Cody features
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -176,8 +176,9 @@ notification.general.cody-not-running.detail=Please wait a few seconds. If Cody 
 notifications.edits.editing-not-available.title=Cody can't edit the file
 notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
 notifications.cody-connection-timeout.title=Cody's connection timeout
-notifications.cody-connection-timeout.detail=Failed to start Cody in timely manner, please run any Cody action or restart Cody to retry.
-
+notifications.cody-connection-timeout.detail=Cody took longer than expected to start. Please run any Cody action or restart Cody to retry.
+error.cody-connection-timeout.message=Failed to start Cody in timely manner, please run any Cody action to retry
+error.cody-starting.message=Failed to start Cody
 # Context Filters
 filter.action-in-ignored-file.detail=This file has been restricted by an admin. Autocomplete, commands, and other Cody features are disabled.
 filter.action-in-ignored-file.learn-more-cta=Learn about Context Filters

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -373,11 +373,11 @@
             </group>
 
             <group id="Cody.Other" text="Other" description="Other Cody actions">
-                <action id="cody.restartAgent"
+                <action id="cody.restartCody"
                         class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"
-                        text="Restart Cody Agent"
-                        description="Restarts the Cody agent">
-                    <override-text place="GoToAction" text="Cody: Restart Cody Agent"/>
+                        text="Restart Cody"
+                        description="Restarts Cody">
+                    <override-text place="GoToAction" text="Cody: Restart Cody"/>
                 </action>
                 <action id="sourcegraph.login"
                         class="com.sourcegraph.config.OpenPluginSettingsAction"


### PR DESCRIPTION
Related to https://github.com/sourcegraph/jetbrains/issues/1964.

This PR exposes `Restart Cody` action (formerly Restart Cody Agent).
- a notification with the action appears on the start up timeout
- the action is added to the widget group on the error
- starting timeout error is no longer an IDE error 
- restart cody agent has 90s (twice as the regular starting) timeout

## Test plan
1. Change `secondsTimeout` to `1` to test it.
2. Review the notification and the widget action.

#### Demo

<img width="458" alt="image" src="https://github.com/user-attachments/assets/39de3f25-83c4-45e1-b604-998193b6230e">
<img width="515" alt="image" src="https://github.com/user-attachments/assets/23a2410b-bb12-4ec4-8eac-fd2bb72d0cd8">

