### PR TITLE
Got Cody working with WSL projects on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,6 @@ run `sdk use java 11.0.15-tem`. Confirm that you have Java 11 installed with `ja
 | Reformat Java and Kotlin sources                                                                                                    | `./gradlew spotlessApply`                                                |
 | Debug agent JSON-RPC communication                                                                                                  | `tail -f build/sourcegraph/cody-agent-trace.json`                        |
 
-> 🤞 On Windows (ARM64 specific?), there's some problem with codesearch's svelte packages. Skip the code search build by setting this environment variable:
->
-> ```
-> $env:SKIP_CODE_SEARCH_BUILD="true"
-> ```
-
 ### Editor config
 
 - Install the following two IntelliJ plugins to format Java and Kotlin on file save
@@ -94,6 +88,21 @@ Few tips and tricks regarding versioning of the tooling:
   can fix it by running `./gradlew -PplatformVersion=X.Y :runIde` once - even if compilation fails it fixes your caches.
 - IF you get error 134 while building different things with jetbrains its because java process doesn't have enough
   memory to build so you might need to get into your activity monitor to close other processes.
+
+### Building on Windows
+
+You should build everything in PowerShell. Git Bash, Ubuntu and MinGW all offer unique challenges. If you get it to build and run, add instructions here.
+
+- Install JDK 11 from https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html
+  - Oracle will make you create an account in order to download it. 🙄 
+- Install the pnpm version in `./tool-versions`
+  - Set `PNPM_HOME` env var for whole system (not just for your account) to the path where `pnpm.cmd` is.
+- Install the node version in `./tool-versions`
+
+🤞 On Windows (ARM64 specific?), there's some problem with codesearch's svelte packages. Skip the code search build by setting this environment variable:
+```
+$env:SKIP_CODE_SEARCH_BUILD="true"
+```
 
 ## Using Nightly channel releases
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -508,6 +508,40 @@ all of the following should be true for each test:
 3. When the current file's policy changes back to non-ignored, inline edits, commands, and context fetching
    should start working normally again.
 
+## Windows and WSL
+
+Cody should work correctly on Microsoft Windows setups that are configured with Windows Subsystem for Linux ("WSL").
+
+The main thing to check is that a project or repo cloned onto a WSL volume should work. WSL volumes/drives have
+paths that begin with either `\\wsl.localhost\` or `\\wsl$\` for short. Both are correct.
+
+For these tests, make sure you have a WSL-enabled Windows setup, and clone a repo onto the WSL drive.
+As an example, I cloned `github.com/redisson/redisson` (a medium-sized Java project) into my WSL home
+directory: `\\wsl.localhost\Ubuntu\home\stevey\redisson`
+
+1. Open the WSL project in IDEA.
+  - The project should open correctly.
+  - You should be able to browse and navigate to source files.
+2. Check that Cody started up and has no errors.
+3. Verify that Cody can explain some code from the project.
+4. Verify that autocompletions work in the source code.
+5. Verify that Inline Edits work in the source code. (Just checking one edit should be enough.)
+6. Verify that Cody can explain open files inside jar files:
+   - From the `Navigate` IDEA menu, `Symbol...` and verify that the Navigation dialog opens
+     (with tabs for All, Class, Files, Symbols, ...)
+   - Choose "Projects and Libraries" from the menu in the upper-right corner
+   - Choose the Symbols tab
+   - Type `Project` and from the dropdown, choose `Project of com.intellij.openapi.Project`
+   - Verify that this opens the Project interface class in an editor tab
+   - Locate the method in the interface, `getBaseDir()`:
+
+```
+     @Deprecated
+     VirtualFile getBaseDir();
+```
+   - Select the whole second line (`VirtualFile getBaseDir()`)
+   - Ask Cody to explain it. Cody should give a sensible explanation involving virtual files.
+
 ## Multi-repo context
 
 ### Free/pro accounts:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -239,6 +239,14 @@ fun Test.sharedIntegrationTestConfig(buildCodyDir: File, mode: String) {
   dependsOn("buildCody")
 }
 
+val isWindows = System.getProperty("os.name").lowercase().contains("win")
+val pnpmPath =
+    if (isWindows) {
+      "pnpm.cmd"
+    } else {
+      "pnpm"
+    }
+
 tasks {
   val codeSearchCommit = "9d86a4f7d183e980acfe5d6b6468f06aaa0d8acf"
   fun downloadCodeSearch(): File {
@@ -266,15 +274,15 @@ tasks {
     val sourcegraphDir = unzipCodeSearch()
     exec {
       workingDir(sourcegraphDir.toString())
-      commandLine("pnpm", "install", "--frozen-lockfile")
+      commandLine(pnpmPath, "install", "--frozen-lockfile")
     }
     exec {
       workingDir(sourcegraphDir.toString())
-      commandLine("pnpm", "generate")
+      commandLine(pnpmPath, "generate")
     }
     val jetbrainsDir = sourcegraphDir.resolve("client").resolve("jetbrains")
     exec {
-      commandLine("pnpm", "build")
+      commandLine(pnpmPath, "build")
       workingDir(jetbrainsDir)
     }
     val buildOutput =
@@ -325,12 +333,12 @@ tasks {
     println("Using cody from codyDir=$codyDir")
     exec {
       workingDir(codyDir)
-      commandLine("pnpm", "install", "--frozen-lockfile")
+      commandLine(pnpmPath, "install", "--frozen-lockfile")
     }
     val agentDir = codyDir.resolve("agent")
     exec {
       workingDir(agentDir)
-      commandLine("pnpm", "run", "build:agent")
+      commandLine(pnpmPath, "run", "build:agent")
     }
     copy {
       from(agentDir.resolve("dist"))

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -114,7 +114,8 @@ private constructor(
                       version = ConfigUtil.getPluginVersion(),
                       ideVersion = ApplicationInfo.getInstance().build.toString(),
                       workspaceRootUri =
-                          ConfigUtil.getWorkspaceRootPath(project).toUri().toString(),
+                          ProtocolTextDocument.normalizeUriOrPath(
+                              ConfigUtil.getWorkspaceRootPath(project).toString()),
                       extensionConfiguration = ConfigUtil.getAgentConfiguration(project),
                       capabilities =
                           ClientCapabilities(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -198,29 +198,32 @@ private constructor(
       return normalizeUriOrPath(uriString)
     }
 
-    // Fix up Windows paths.
+    @JvmStatic
     fun normalizeUriOrPath(uriString: String): String {
       val hasScheme = uriString.startsWith("file://")
       val path =
           (if (hasScheme) uriString.removePrefix("file://") else uriString).replace("\\", "/")
 
-      // Normalize WSL paths.
+      // Normalize WSL paths
       val wslPrefix = "//wsl$"
       if (path.startsWith(wslPrefix)) {
         val newPath = "//wsl.localhost${path.removePrefix(wslPrefix)}"
         return if (hasScheme) "file://$newPath" else newPath
       }
 
-      // Normalize drive letters for Windows.
+      // Normalize drive letters for Windows
       val driveLetterPattern = """^(\w):/""".toRegex()
       val normalizedPath =
           driveLetterPattern.replace(path) { matchResult ->
             val driveLetter = matchResult.groupValues[1].lowercase(Locale.getDefault())
-            // Ensure the drive letter path is formatted correctly
-            if (hasScheme) "file:///${driveLetter}:/" else "${driveLetter}:/"
+            "${driveLetter}:/"
           }
 
-      return if (hasScheme) "file:///$normalizedPath" else normalizedPath
+      if (!hasScheme) return normalizedPath
+      if (path.startsWith("/") && path.length > 1 && path[1] != '/') {
+        return "file://$normalizedPath"
+      }
+      return "file:///$normalizedPath"
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.agent.protocol
 
 import com.intellij.codeInsight.codeVision.ui.popup.layouter.bottom
 import com.intellij.codeInsight.codeVision.ui.popup.layouter.right
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -15,7 +16,7 @@ import com.sourcegraph.cody.agent.protocol_extensions.Position
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import java.awt.Point
 import java.nio.file.FileSystems
-import java.util.Locale
+import java.util.*
 import kotlin.math.max
 import kotlin.math.min
 
@@ -28,6 +29,13 @@ private constructor(
     val contentChanges: List<ProtocolTextDocumentContentChangeEvent>? = null,
     val testing: TestingParams? = null,
 ) {
+
+  init {
+    if (!ApplicationManager.getApplication().isDispatchThread) {
+      throw IllegalStateException("ProtocolTextDocument must be be created on EDT")
+    }
+  }
+
   companion object {
     @RequiresEdt
     private fun getTestingParams(
@@ -186,12 +194,33 @@ private constructor(
 
     @JvmStatic
     fun uriFor(file: VirtualFile): String {
-      val uri = FileSystems.getDefault().getPath(file.path).toUri().toString()
-      return uri.replace(Regex("file:///(\\w):/")) {
-        val driveLetter =
-            it.groups[1]?.value?.lowercase(Locale.getDefault()) ?: return@replace it.value
-        "file:///$driveLetter%3A/"
+      val uriString = FileSystems.getDefault().getPath(file.path).toUri().toString()
+      return normalizeUriOrPath(uriString)
+    }
+
+    // Fix up Windows paths.
+    fun normalizeUriOrPath(uriString: String): String {
+      val hasScheme = uriString.startsWith("file://")
+      val path =
+          (if (hasScheme) uriString.removePrefix("file://") else uriString).replace("\\", "/")
+
+      // Normalize WSL paths.
+      val wslPrefix = "//wsl$"
+      if (path.startsWith(wslPrefix)) {
+        val newPath = "//wsl.localhost${path.removePrefix(wslPrefix)}"
+        return if (hasScheme) "file://$newPath" else newPath
       }
+
+      // Normalize drive letters for Windows.
+      val driveLetterPattern = """^(\w):/""".toRegex()
+      val normalizedPath =
+          driveLetterPattern.replace(path) { matchResult ->
+            val driveLetter = matchResult.groupValues[1].lowercase(Locale.getDefault())
+            // Ensure the drive letter path is formatted correctly
+            if (hasScheme) "file:///${driveLetter}:/" else "${driveLetter}:/"
+          }
+
+      return if (hasScheme) "file:///$normalizedPath" else normalizedPath
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -220,7 +220,7 @@ private constructor(
           }
 
       if (!hasScheme) return normalizedPath
-      if (path.startsWith("/") && path.length > 1 && path[1] != '/') {
+      if (path.matches(Regex("^/[^/].*"))) {
         return "file://$normalizedPath"
       }
       return "file:///$normalizedPath"


### PR DESCRIPTION
fixes: CODY-2862

Cody couldn't start up if your repo/project was on a WSL drive/path, e.g., \\wsl.localhost\Ubuntu\home\person\foo -- we didn't handle the new URI syntaxes required here.

I've updated the code to normalize the paths properly. There was also a minor build issue that's fixed in `build.gradle.kts`.

## Test plan

I've tested it manually on Mac, Windows/normal, and Windows/WSL.

I wrote new unit tests for the primary change, which is how we normalize paths.

I will talk to our folks and see if we should add a manual QA pass for WSL projects. 