### PR TITLE
Fix integration tests

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/AllSuites.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/AllSuites.kt
@@ -1,55 +1,8 @@
 package com.sourcegraph.cody
 
-import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.edit.DocumentCodeTest
-import com.sourcegraph.cody.util.CodyIntegrationTextFixture
 import com.sourcegraph.cody.util.RepeatableSuite
-import java.util.concurrent.TimeUnit
-import org.junit.AfterClass
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
-/**
- * We need a single tearDown() method running after all tests are complete, so agent can be closed
- * gracefully and recordings can be saved properly.
- *
- * Due to the limitations of JUnit 4 this can be done only using SuiteClasses and AfterClass, and we
- * are forced to use JUnit 4 because IntelliJ testing classes like `BasePlatformTestCase` are based
- * on that version. JUnit 4 jar is part of the ideaIC package. We will upgrade to JUnit 5
- * automatically after the platform version bump.
- *
- * Multiple recording files can be used, but each should have its own suite with tearDown() method
- * nad define unique CODY_RECORDING_NAME.
- */
-@RunWith(RepeatableSuite::class)
-@Suite.SuiteClasses(DocumentCodeTest::class)
-class AllSuites {
-  companion object {
-    @AfterClass
-    @JvmStatic
-    internal fun tearDown() {
-      CodyAgentService.withAgent(CodyIntegrationTextFixture.myProject!!) { agent ->
-        val errors = agent.server.testingRequestErrors().get()
-        // We extract polly.js errors to notify users about the missing recordings, if any
-        val missingRecordings = errors.filter { it.error?.contains("`recordIfMissing` is") == true }
-        missingRecordings.forEach { missing ->
-          System.err.println(
-              """Recording is missing: ${missing.error}
-                |
-                |------------------------------------------------------------------------------------------
-                |To fix this problem please run `./gradlew :recordingIntegrationTest`.
-                |You need to export access tokens first, using script from the `sourcegraph/cody` repository:
-                |`agent/scripts/export-cody-http-recording-tokens.sh`
-                |------------------------------------------------------------------------------------------
-              """
-                  .trimMargin())
-        }
-
-        agent.server
-            .shutdown()
-            .get(CodyIntegrationTextFixture.ASYNC_WAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        agent.server.exit()
-      }
-    }
-  }
-}
+@RunWith(RepeatableSuite::class) @Suite.SuiteClasses(DocumentCodeTest::class) class AllSuites

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/edit/DocumentCodeTest.kt
@@ -90,13 +90,7 @@ class DocumentCodeTest : CodyIntegrationTextFixture() {
 
     runLensAction(acceptLens!!, EditAcceptAction.ID)
     assertNoInlayShown()
-    assertThat(
-        myFixture.editor.document.text,
-        startsWith(
-            """/**
-               | * Imports the necessary Java standard library classes for the Foo class, including the ArrayList class.
-               | */"""
-                .trimMargin()))
+    assertThat(myFixture.editor.document.text, startsWith("/**"))
   }
 
   @Test

--- a/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -47,7 +47,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:46 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -55,7 +55,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "294"
+            value: "403"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -80,7 +80,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.806Z
+      startedDateTime: 2024-08-05T10:11:45.841Z
       time: 0
       timings:
         blocked: -1
@@ -107,7 +107,7 @@ log:
           - name: user-agent
             value: JetBrains / 6.0-localbuild
           - name: traceparent
-            value: 00-2ac3b3fe53a1fbbe7b3bc804b591973a-4fe5f82fd6165da4-01
+            value: 00-0ec7441b05369c730163041565b0a6c3-ec2f5176d73290f6-01
           - name: connection
             value: keep-alive
           - name: host
@@ -206,14 +206,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=1&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 2016
+        bodySize: 1837
         content:
           mimeType: text/event-stream
-          size: 2016
+          size: 1837
           text: >+
             event: completion
 
-            data: {"completion":"\n/**\n * Imports the necessary Java standard library classes for the Foo class, including the ArrayList class.\n */\n","stopReason":"stop_sequence"}
+            data: {"completion":"/**\n * Imports the necessary Java utility classes, including {@link java.util.List} and {@link java.util.ArrayList}.\n */","stopReason":"stop_sequence"}
 
 
             event: done
@@ -223,7 +223,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:49:01 GMT
+            value: Mon, 05 Aug 2024 10:11:48 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -231,7 +231,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "292"
+            value: "401"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -254,7 +254,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:49:00.467Z
+      startedDateTime: 2024-08-05T10:11:47.322Z
       time: 0
       timings:
         blocked: -1
@@ -329,7 +329,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:59 GMT
+            value: Mon, 05 Aug 2024 10:11:46 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -337,7 +337,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "294"
+            value: "403"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -362,7 +362,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:59.179Z
+      startedDateTime: 2024-08-05T10:11:46.212Z
       time: 0
       timings:
         blocked: -1
@@ -449,7 +449,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -457,7 +457,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "404"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -482,7 +482,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.034Z
+      startedDateTime: 2024-08-05T10:11:44.993Z
       time: 0
       timings:
         blocked: -1
@@ -557,7 +557,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -565,7 +565,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "404"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -590,7 +590,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.068Z
+      startedDateTime: 2024-08-05T10:11:45.025Z
       time: 0
       timings:
         blocked: -1
@@ -650,17 +650,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmProvider
       response:
-        bodySize: 127
+        bodySize: 124
         content:
           encoding: base64
           mimeType: application/json
-          size: 127
+          size: 124
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eSDxgqL8s\
-            syU1CIlK6WyxKLM/NJipdra2loAAAAA//8=\",\"AwAdobPlQQAAAA==\"]"
+            syU1CIlK6W0zKLU8vyi7GKl2traWgAAAAD//wMAf38NDUMAAAA=\"]"
+          textDecoded:
+            data:
+              site:
+                codyLLMConfiguration:
+                  provider: fireworks
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -668,7 +673,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "404"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -693,7 +698,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.051Z
+      startedDateTime: 2024-08-05T10:11:45.009Z
       time: 0
       timings:
         blocked: -1
@@ -790,7 +795,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -798,7 +803,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "404"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -823,7 +828,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.085Z
+      startedDateTime: 2024-08-05T10:11:45.041Z
       time: 0
       timings:
         blocked: -1
@@ -887,19 +892,28 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentUserCodySubscription
       response:
-        bodySize: 231
+        bodySize: 228
         content:
           encoding: base64
           mimeType: application/json
-          size: 231
+          size: 228
           text: "[\"H4sIAAAAAAAAA1zMsQrCMBSF4Xc5c4U2FpRsRToIgqWtDm6xyRCoSbi5GUrJu4uCoI7n5\
             +Os0IoV5IopERnHl2joPb1ehnSPE9nA1rtXi6w4RUg0h/F4bVEgzMpBouvPKKBCmJeO\
             fK/YnOzDcoRkSqb4fHeGrNcDK+KGISFKUW/K3aaqRyFkVcmtuOFPt05/2f2vzTnnJwA\
-            AAP//\",\"AwB81vXLwgAAAA==\"]"
+            AAP//AwB81vXLwgAAAA==\"]"
+          textDecoded:
+            data:
+              currentUser:
+                codySubscription:
+                  applyProRateLimits: true
+                  currentPeriodEndAt: 2024-08-14T22:11:32Z
+                  currentPeriodStartAt: 2024-07-14T22:11:32Z
+                  plan: PRO
+                  status: ACTIVE
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -907,7 +921,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "403"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -932,7 +946,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:58.336Z
+      startedDateTime: 2024-08-05T10:11:45.289Z
       time: 0
       timings:
         blocked: -1
@@ -990,21 +1004,18 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?SiteProductVersion
       response:
-        bodySize: 136
+        bodySize: 139
         content:
           encoding: base64
           mimeType: application/json
-          size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWJsZmRvFGB\
-            kYmugbmukam8aZ6prrJZhaplkZJyUYWScZKtbW1AAAAAP//AwBliiQpSQAAAA==\"]"
-          textDecoded:
-            data:
-              site:
-                productVersion: 284362_2024-07-25_5.5-c68e92bc28b3
+          size: 139
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkYWphamxvFGB\
+            kYmugYWugam8aZ6prqpxsZGhkYmZpYWlqlKtbW1AAAAAP//\",\"AwDZmR/0SQAAAA==\
+            \"]"
         cookies: []
         headers:
           - name: date
-            value: Mon, 29 Jul 2024 11:48:58 GMT
+            value: Mon, 05 Aug 2024 10:11:45 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -1012,7 +1023,7 @@ log:
           - name: connection
             value: keep-alive
           - name: retry-after
-            value: "295"
+            value: "404"
           - name: access-control-allow-credentials
             value: "true"
           - name: access-control-allow-origin
@@ -1037,7 +1048,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-07-29T11:48:57.998Z
+      startedDateTime: 2024-08-05T10:11:44.958Z
       time: 0
       timings:
         blocked: -1

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -40,9 +40,9 @@ private constructor(
   fun shutdown(): CompletableFuture<Unit> {
     return server.shutdown().completeOnTimeout(null, 15, TimeUnit.SECONDS).handle { _, throwable ->
       if (throwable != null) logger.warn("Graceful shutdown of Cody agent server failed", throwable)
+      server.exit()
       listeningToJsonRpc.cancel(true)
       connection.close()
-      server.exit()
       logger.info("Cody Agent shut down gracefully")
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -40,10 +40,10 @@ private constructor(
   fun shutdown(): CompletableFuture<Unit> {
     return server.shutdown().completeOnTimeout(null, 15, TimeUnit.SECONDS).handle { _, throwable ->
       if (throwable != null) logger.warn("Graceful shutdown of Cody agent server failed", throwable)
-      server.exit()
-      logger.info("Cody Agent shut down gracefully")
       listeningToJsonRpc.cancel(true)
       connection.close()
+      server.exit()
+      logger.info("Cody Agent shut down gracefully")
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -188,11 +188,12 @@ class CodyAgentService(private val project: Project) : Disposable {
     return codyAgent
   }
 
-  fun stopAgent(project: Project?) {
+  fun stopAgent(project: Project?): CompletableFuture<Unit>? {
     try {
-      codyAgent.getNow(null)?.shutdown()
+      return codyAgent.getNow(null)?.shutdown()
     } catch (e: Exception) {
       logger.warn("Failed to stop Cody agent gracefully", e)
+      return CompletableFuture.failedFuture(e)
     } finally {
       codyAgent = CompletableFuture()
       project?.let { CodyStatusService.resetApplication(it) }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentService.kt
@@ -1,7 +1,9 @@
 package com.sourcegraph.cody.agent
 
+import com.intellij.notification.NotificationsManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -18,6 +20,7 @@ import com.sourcegraph.cody.error.CodyConsole
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.cody.listeners.CodyFileEditorListener
 import com.sourcegraph.cody.statusbar.CodyStatusService
+import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.Timer
 import java.util.TimerTask
@@ -156,7 +159,7 @@ class CodyAgentService(private val project: Project) : Disposable {
     synchronized(startupActions) { startupActions.add(action) }
   }
 
-  fun startAgent(project: Project): CompletableFuture<CodyAgent> {
+  fun startAgent(project: Project, secondsTimeout: Long = 45): CompletableFuture<CodyAgent> {
     ApplicationManager.getApplication().executeOnPooledThread {
       try {
         val future =
@@ -165,6 +168,7 @@ class CodyAgentService(private val project: Project) : Disposable {
               logger.error(msg)
               throw (CodyAgentException(msg))
             }
+
         val agent = future.get(45, TimeUnit.SECONDS)
         if (!agent.isConnected()) {
           val msg = "Failed to connect to agent Cody agent"
@@ -175,13 +179,24 @@ class CodyAgentService(private val project: Project) : Disposable {
           codyAgent.complete(agent)
           CodyStatusService.resetApplication(project)
         }
-      } catch (e: Exception) {
-        val msg =
-            if (e is TimeoutException)
-                "Failed to start Cody agent in timely manner, please run any Cody action to retry"
-            else "Failed to start Cody agent"
-        logger.error(msg, e)
+      } catch (e: TimeoutException) {
+        val msg = CodyBundle.getString("error.cody-connection-timeout.message")
+        runInEdt {
+          val isNoBalloonDisplayed =
+              NotificationsManager.getNotificationsManager()
+                  .getNotificationsOfType(
+                      CodyConnectionTimeoutExceptionNotification::class.java, project)
+                  .all { it.balloon == null }
+          if (isNoBalloonDisplayed) {
+            CodyConnectionTimeoutExceptionNotification().notify(project)
+          }
+        }
         setAgentError(project, msg)
+        codyAgent.completeExceptionally(CodyAgentException(msg, e))
+      } catch (e: Exception) {
+        val msg = CodyBundle.getString("error.cody-starting.message")
+        setAgentError(project, msg)
+        logger.error(msg, e)
         codyAgent.completeExceptionally(CodyAgentException(msg, e))
       }
     }
@@ -200,10 +215,10 @@ class CodyAgentService(private val project: Project) : Disposable {
     }
   }
 
-  fun restartAgent(project: Project): CompletableFuture<CodyAgent> {
+  fun restartAgent(project: Project, secondsTimeout: Long = 90): CompletableFuture<CodyAgent> {
     synchronized(this) {
       stopAgent(project)
-      return startAgent(project)
+      return startAgent(project, secondsTimeout)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyConnectionTimeoutExceptionNotification.kt
@@ -1,0 +1,23 @@
+package com.sourcegraph.cody.agent
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.sourcegraph.Icons
+import com.sourcegraph.cody.agent.action.CodyAgentRestartAction
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+
+class CodyConnectionTimeoutExceptionNotification :
+    Notification(
+        NotificationGroups.SOURCEGRAPH_ERRORS,
+        CodyBundle.getString("notifications.cody-connection-timeout.title"),
+        CodyBundle.getString("notifications.cody-connection-timeout.detail"),
+        NotificationType.WARNING),
+    NotificationFullContent {
+
+  init {
+    icon = Icons.CodyLogoSlash
+    addAction(CodyAgentRestartAction())
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/action/CodyAgentRestartAction.kt
@@ -1,11 +1,18 @@
 package com.sourcegraph.cody.agent.action
 
+import com.intellij.notification.NotificationsManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.CodyConnectionTimeoutExceptionNotification
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
-class CodyAgentRestartAction : DumbAwareEDTAction("Restart Cody Agent") {
+class CodyAgentRestartAction : DumbAwareEDTAction("Restart Cody") {
   override fun actionPerformed(event: AnActionEvent) {
-    event.project?.let { CodyAgentService.getInstance(it).restartAgent(it) }
+    event.project?.let { project ->
+      CodyAgentService.getInstance(project).restartAgent(project)
+      NotificationsManager.getNotificationsManager()
+          .getNotificationsOfType(CodyConnectionTimeoutExceptionNotification::class.java, project)
+          .forEach { it.expire() }
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -1,9 +1,9 @@
 package com.sourcegraph.cody.statusbar
 
-import com.intellij.ide.actions.AboutAction
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup
+import com.sourcegraph.cody.agent.action.CodyAgentRestartAction
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
 import com.sourcegraph.common.UpgradeToCodyProNotification
@@ -20,14 +20,11 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
     e.presentation.isVisible = ConfigUtil.isCodyEnabled()
 
     removeAll()
-    if (e.project?.let { CodyStatusService.getCurrentStatus(it) } ==
-        CodyStatus.CodyAgentNotRunning) {
-      addAll(
-          OpenLogAction(),
-          AboutAction().apply { templatePresentation.text = "Open About To Troubleshoot Issue" },
-          ReportCodyBugAction())
+    val status = e.project?.let { CodyStatusService.getCurrentStatus(it) }
+    if (status == CodyStatus.CodyAgentNotRunning || status == CodyStatus.AgentError) {
+      addAll(CodyAgentRestartAction(), OpenLogAction(), ReportCodyBugAction())
     } else {
-      addAll(listOfNotNull(deriveWarningAction()))
+      addAll(listOfNotNull(deriveRateLimitErrorAction()))
       addSeparator()
       addAll(
           CodyManageAccountsAction(),
@@ -43,7 +40,7 @@ class CodyStatusBarActionGroup : DefaultActionGroup() {
     }
   }
 
-  private fun deriveWarningAction(): RateLimitErrorWarningAction? {
+  private fun deriveRateLimitErrorAction(): RateLimitErrorWarningAction? {
     val autocompleteRLE = UpgradeToCodyProNotification.autocompleteRateLimitError.get()
     val chatRLE = UpgradeToCodyProNotification.chatRateLimitError.get()
 

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -175,7 +175,10 @@ notification.general.cody-not-running.title=Cody is starting...
 notification.general.cody-not-running.detail=Please wait a few seconds. If Cody still won't start, check the IDE logs for errors.
 notifications.edits.editing-not-available.title=Cody can't edit the file
 notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
-
+notifications.cody-connection-timeout.title=Cody's connection timeout
+notifications.cody-connection-timeout.detail=Cody took longer than expected to start. Please run any Cody action or restart Cody to retry.
+error.cody-connection-timeout.message=Failed to start Cody in timely manner, please run any Cody action to retry
+error.cody-starting.message=Failed to start Cody
 # Context Filters
 filter.action-in-ignored-file.detail=This file has been restricted by an admin. Autocomplete, commands, and other Cody features are disabled.
 filter.action-in-ignored-file.learn-more-cta=Learn about Context Filters
@@ -186,7 +189,6 @@ filter.sidebar-panel-ignored-file.learn-more-cta=Learn more
 
 # Other Actions
 action.cody.not-working=Cody is disabled or still starting up
-action.cody.restartAgent.text=Restart Cody Agent
 chat.enhanced_context.title=Chat Context Settings
 action.sourcegraph.disabled.description=Log in to Sourcegraph to enable Cody features
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -373,11 +373,11 @@
             </group>
 
             <group id="Cody.Other" text="Other" description="Other Cody actions">
-                <action id="cody.restartAgent"
+                <action id="cody.restartCody"
                         class="com.sourcegraph.cody.agent.action.CodyAgentRestartAction"
-                        text="Restart Cody Agent"
-                        description="Restarts the Cody agent">
-                    <override-text place="GoToAction" text="Cody: Restart Cody Agent"/>
+                        text="Restart Cody"
+                        description="Restarts Cody">
+                    <override-text place="GoToAction" text="Cody: Restart Cody"/>
                 </action>
                 <action id="sourcegraph.login"
                         class="com.sourcegraph.config.OpenPluginSettingsAction"


### PR DESCRIPTION
### Changes

This PR fixes few problems:

* We were restarting agent without waiting for it to finish
* We were not properly refreshing external file changes to VFS which sometimes was leading to having old files in memory

It's also worth noting that `BasePlatformTestCase` seems to be in face reusing the same project for all tests, even if it does some minor cleanup on it. I think this is not ideal for our case, and instead we should try to either:

* reuse the same project and do not restart agent every time
* have full project isolation

Such in-the-middle solution as we have now does not seem to be beneficial to me. But we can try to change that later, especially in case this PR would not some all integration tests instabilities.

## Test plan

N/A