### PR TITLE
Bump cody commit and fix enterprise model selection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.stdlib.default.dependency=false
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=066d9c6ff48beb96a834f17021affc4e62094415
+cody.commit=35035303eacf7a5a570b40ecddeb590b56a7fb40

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -71,16 +71,15 @@ class LlmDropdown(
     val availableModels = models.filterNot { it.isDeprecated() }
     availableModels.sortedBy { it.isCodyProOnly() }.forEach(::addItem)
 
-    val selectedFromState = chatModelProviderFromState
+    val selectedFromChatState = chatModelProviderFromState
     val selectedFromHistory = HistoryService.getInstance(project).getDefaultLlm()
-    val selectedModel =
-        availableModels.find { it.model == selectedFromState?.model || it.model == model }
-            ?: availableModels.find { it.model == selectedFromHistory?.model }
 
     selectedItem =
-        if (selectedModel?.isCodyProOnly() == true && isCurrentUserFree())
-            availableModels.getOrNull(0)
-        else selectedModel
+        models.find {
+          it.model == model ||
+              it.model == selectedFromChatState?.model ||
+              it.model == selectedFromHistory?.model
+        } ?: models.firstOrNull()
 
     val isEnterpriseAccount =
         CodyAuthenticationManager.getInstance(project).account?.isEnterpriseAccount() ?: false


### PR DESCRIPTION
## Changes

1. Bump cody commit
2. Fix model selection in a dropdown - with current code if user had no state saved model for the enterprise was evaluating to `null`

## Test plan

Full QA
