### PR TITLE
Do not fix plugin verifier version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           plugin-location: '*.zip'
-          verifier-version: '1.371'
           ide-versions: |
             ideaIC:2021.1
             ideaIC:2024.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -519,7 +519,6 @@ tasks {
   runPluginVerifier {
     ideVersions.set(versionsToValidate)
     failureLevel.set(EnumSet.complementOf(skippedFailureLevels))
-    verifierVersion.set("1.371")
   }
 
   // Configure UI tests plugin


### PR DESCRIPTION
The issues fixed temporary by https://github.com/sourcegraph/jetbrains/pull/1959 are now resolved by the newest version of the verifier.

## Test plan
1. Green CI
