### PR TITLE
Check for error group in integration tests

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -218,6 +218,11 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
   ) {
     synchronized(lensSubscribers) {
       lensSubscribers.removeAll { (checkFunc, future) ->
+        if (codeLenses.find { it.command?.command == "cody.fixup.codelens.error" } != null) {
+          future.completeExceptionally(IllegalStateException("Error group shown"))
+          return@removeAll true
+        }
+
         val hasLensAppeared = checkFunc(codeLenses)
         if (hasLensAppeared) future.complete(lensWidgetGroup)
         hasLensAppeared


### PR DESCRIPTION
The integration tests are still failing sometimes. This change should help us determine the state when the error lens group appears.

## Test plan
1. Green CI
