### PR TITLE
CodeActions: Explicitly disable ExplainAction

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -54,6 +54,10 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
     return params.title.lowercase() == "ask cody to explain"
   }
 
+  private fun isKnownAction(): Boolean {
+    return isFixAction() || isExplainAction()
+  }
+
   override fun getFamilyName(): String {
     return FAMILY_NAME
   }
@@ -63,7 +67,12 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
       return false
     }
 
-    if (!(isFixAction() || isExplainAction())) {
+    if(isExplainAction()){
+      // TODO: Temporarily disable explain action since it's not implemented
+      return false
+    }
+
+    if (!isKnownAction()) {
       // TODO: We temporarily disable unknown actions until we've verified they work.
       return false
     }

--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -67,7 +67,7 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
       return false
     }
 
-    if(isExplainAction()){
+    if (isExplainAction()) {
       // TODO: Temporarily disable explain action since it's not implemented
       return false
     }


### PR DESCRIPTION
We were not checking action types correctly. This was caused by confusion during the PR review where the flag statement was supposed to both check that the action was known (so we can disable unknown actions), but then separately flag the ExplainAction (which is known) to be disabled as well.

Now by separating the flags the intent is hopefully clearer and we ensure that ExplainActions are explicitly disabled while they're pending implementation.

Fixes [CODY-3168](https://linear.app/sourcegraph/issue/CODY-3168) / [#1989](https://github.com/sourcegraph/jetbrains/issues/1989)

## Test plan
Manually verified that Explain no longer shows up.
