### PR TITLE
CodeActions: Skip UI specific paths

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -54,6 +54,10 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
     return params.title.lowercase() == "ask cody to explain"
   }
 
+  private fun isKnownAction(): Boolean {
+    return isFixAction() || isExplainAction()
+  }
+
   override fun getFamilyName(): String {
     return FAMILY_NAME
   }
@@ -63,7 +67,12 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
       return false
     }
 
-    if (!(isFixAction() || isExplainAction())) {
+    if(isExplainAction()){
+      // TODO: Temporarily disable explain action since it's not implemented
+      return false
+    }
+
+    if (!isKnownAction()) {
       // TODO: We temporarily disable unknown actions until we've verified they work.
       return false
     }

--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -67,7 +67,7 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
       return false
     }
 
-    if(isExplainAction()){
+    if (isExplainAction()) {
       // TODO: Temporarily disable explain action since it's not implemented
       return false
     }


### PR DESCRIPTION
Before the Cody CodeHighlight pass would apply to all editors, including those used in a "hacky" way to create UI elements such as the repo-input field used in the Cody sidebar.

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/onbAacT3LuCgMVcIIUAU/8364ca3b-a40d-4e24-87a8-149095bd0957.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/onbAacT3LuCgMVcIIUAU/8364ca3b-a40d-4e24-87a8-149095bd0957.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/onbAacT3LuCgMVcIIUAU/8364ca3b-a40d-4e24-87a8-149095bd0957.mp4">CleanShot 2024-08-07 at 11.49.10.mp4</video>

Now we explicitly ignore these fake file editors. Note that as a follow up we might need to consider that other extensions similarly "mis-use" editors in the same way we did and that ignoring our specific paths isn't a long-term solution.

Fixes [CODY-3166](https://linear.app/sourcegraph/issue/CODY-3166/sourcegraphjetbrains1991-jetbrains-ask-cody-to-fix-and-ask-cody-to) / [#1991](https://github.com/sourcegraph/jetbrains/issues/1991)

## Test plan
Manually verified that HighlightPass no longer applies to the Repo Editor