### PR TITLE
Call `getAuthenticationState` on a pooled thread instead of EDT

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.config
 
 import com.intellij.collaboration.async.CompletableFutureUtil.submitIOTask
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
@@ -83,7 +84,7 @@ class CodyAuthenticationManager(val project: Project) :
         object : WindowAdapter() {
           override fun windowActivated(e: WindowEvent?) {
             super.windowActivated(e)
-            getAuthenticationState()
+            ApplicationManager.getApplication().executeOnPooledThread { getAuthenticationState() }
           }
         }
     frame?.addWindowListener(listener)


### PR DESCRIPTION
No need to call this method on EDT (at least not there).

## Test plan
1. `runIde`
2. verify that the error does not appear in the logs
