### PR TITLE
Disable highlight pass on mock files

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -153,7 +153,10 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
 class CodyFixHighlightPassFactory : TextEditorHighlightingPassFactoryRegistrar {
   private val factory: TextEditorHighlightingPassFactory =
       TextEditorHighlightingPassFactory { file, editor ->
-        CodyFixHighlightPass(file, editor)
+        when (file.virtualFile.fileSystem.protocol) {
+          "mock" -> null
+          else -> CodyFixHighlightPass(file, editor)
+        }
       }
 
   override fun registerHighlightingPassFactory(


### PR DESCRIPTION
## Changes 

Replaces https://github.com/sourcegraph/jetbrains/pull/1995

Fixes Fixes [CODY-3166](https://linear.app/sourcegraph/issue/CODY-3166/sourcegraphjetbrains1991-jetbrains-ask-cody-to-fix-and-ask-cody-to) / https://github.com/sourcegraph/jetbrains/issues/1991

Mock files are used for in-memory buffers. Normally all editable code files are not mocks/in-memory files (even scratches are normal files) so we can assume if file is mock it is most likely some special component for which we do not want to add cody error highlighting.

## Test plan

Manually verified that HighlightPass no longer applies to the Repo Editor
