### PR TITLE
Ensure the rendered autocompletion is not empty (fixes #2003)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -424,27 +424,30 @@ class CodyAutocompleteManager {
 
     var inlay: Inlay<*>? = null
     if (startsInline) {
-      val renderer =
-          CodyAutocompleteSingleLineRenderer(
-              completionText.lines().first(), items, editor, AutocompleteRendererType.INLINE)
-      inlay =
-          inlayModel.addInlineElement(cursorOffset, /* relatesToPrecedingText = */ true, renderer)
+      val text = completionText.lines().first()
+      if (text.isNotEmpty()) {
+        val renderer =
+            CodyAutocompleteSingleLineRenderer(text, items, editor, AutocompleteRendererType.INLINE)
+        inlay =
+            inlayModel.addInlineElement(cursorOffset, /* relatesToPrecedingText = */ true, renderer)
+      }
     }
     val lines = completionText.lines()
     if (lines.size > 1) {
       val text =
           (if (startsInline) lines.drop(1) else lines).dropWhile { it.isBlank() }.joinToString("\n")
-      if (text.isEmpty()) return
-      val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
-      val inlay2 =
-          inlayModel.addBlockElement(
-              /* offset = */ cursorOffset,
-              /* relatesToPrecedingText = */ true,
-              /* showAbove = */ false,
-              /* priority = */ Int.MAX_VALUE,
-              /* renderer = */ renderer)
-      if (inlay == null) {
-        inlay = inlay2
+      if (text.isNotEmpty()) {
+        val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
+        val inlay2 =
+            inlayModel.addBlockElement(
+                /* offset = */ cursorOffset,
+                /* relatesToPrecedingText = */ true,
+                /* showAbove = */ false,
+                /* priority = */ Int.MAX_VALUE,
+                /* renderer = */ renderer)
+        if (inlay == null) {
+          inlay = inlay2
+        }
       }
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -434,6 +434,7 @@ class CodyAutocompleteManager {
     if (lines.size > 1) {
       val text =
           (if (startsInline) lines.drop(1) else lines).dropWhile { it.isBlank() }.joinToString("\n")
+      if (text.isEmpty()) return
       val renderer = CodyAutocompleteBlockElementRenderer(text, items, editor)
       val inlay2 =
           inlayModel.addBlockElement(


### PR DESCRIPTION
Fixes CODY-3189

The check was originally there - we lost it at some point:
https://github.com/sourcegraph/jetbrains/commit/4f50796648d3b3ced27cd403ae8d9d31ea1610ea#diff-cb6c461805813f1dff589b6e691cded2a165241943810513c716325ad1fe25baR310

If the text to be rendered is empty let's skip the rendering. 

## Test plan
Hard to repro. Probably requires a python project. 
