### PR TITLE
Run plugin verifier for 2024.2 and add INTERNAL_API_USAGES to the skipped failure levels

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
           plugin-location: '*.zip'
           ide-versions: |
             ideaIC:2021.1
-            ideaIC:2024.1
+            ideaIC:2024.2
           failure-levels: |
             COMPATIBILITY_WARNINGS
             INTERNAL_API_USAGES

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
 // this list.
 val versionsOfInterest =
-    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1").sorted()
+    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1", "2024.2").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
@@ -47,6 +47,7 @@ val skippedFailureLevels =
     EnumSet.of(
         FailureLevel.COMPATIBILITY_PROBLEMS, // blocked by: compatibility hack for IJ 2022.1 / 2024+
         FailureLevel.DEPRECATED_API_USAGES,
+        FailureLevel.INTERNAL_API_USAGES,
         FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
         FailureLevel.EXPERIMENTAL_API_USAGES,
         FailureLevel.NOT_DYNAMIC)!!


### PR DESCRIPTION
Removing the internal api usages is nontrivial task. It seems to be better to run the verifier skipping the internal api usages complaints than not running it at all for 242. Let's run it and skip the internal api usages errors. Eventually, we should try to eliminate them and remove the skipped failure level.

The follow-up task: https://linear.app/sourcegraph/issue/CODY-3202/jetbrains-do-not-use-internal-api

## Test plan
1. Green CI
