### PR TITLE
Cody Fix: Properly Handle Edit & Retry

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -10,6 +10,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolLocation
+import com.sourcegraph.cody.edit.actions.EditCodeAction
 
 data class CodeActionQuickFixParams(
     val title: String,
@@ -102,7 +103,8 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
         throw Exception("Could not find action")
       }
       // TODO: Need to refactor agent to not return edit session for every action CODY-3125
-      agent.server.codeActions_trigger(CodeActions_TriggerParams(id = action.id))
+      val result = agent.server.codeActions_trigger(CodeActions_TriggerParams(id = action.id)).get()
+      EditCodeAction.completedEditTasks[result.id] = result
     }
   }
 }


### PR DESCRIPTION
We weren't correctly tracking the edit action resulting in that the "Edit & Retry" lens did not work the same way as in VSCode.

Now we add the Edit Action to the global EditorActions and all lenses work correctly.

This change is manly to provide feature parity between JB and VSCode, the feature will probably be disabled by https://github.com/sourcegraph/cody/pull/5143

Fixes https://github.com/sourcegraph/jetbrains/issues/2006
Fixes CODY-3192

## Test plan
CI
Manually verified the edit prompt is now shown
