### PR TITLE
Do not run INTERNAL_API_USAGES plugin validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,6 @@ jobs:
             ideaIC:2024.2
           failure-levels: |
             COMPATIBILITY_WARNINGS
-            INTERNAL_API_USAGES
             OVERRIDE_ONLY_API_USAGES
             NON_EXTENDABLE_API_USAGES
             PLUGIN_STRUCTURE_WARNINGS


### PR DESCRIPTION
## Changes

Temporarily skip validation of `INTERNAL_API_USAGES` as it is failing on `IC.2024.2`

## Test plan

N/A