### PR TITLE
Minimal version supported by verifier should be 2022.1, not 2021.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           plugin-location: '*.zip'
           ide-versions: |
-            ideaIC:2021.1
+            ideaIC:2022.1
             ideaIC:2024.2
           failure-levels: |
             COMPATIBILITY_WARNINGS


### PR DESCRIPTION
## Test plan

N/A