### PR TITLE
Fix release script to properly strip channel name from patch version

### DIFF
--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -10,7 +10,7 @@ fi
 LAST_MAJOR_MINOR_ZERO_RELEASE=$(git tag -l | grep "v\d*\\.\d*\\.\d*" | uniq | sort -V | tail -1)
 MAJOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f1)
 MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f2)
-PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f3)
+PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f3 | sed 's/-nightly//' | sed 's/-experimental//')
 
 NEXT_RELEASE_ARG="$1"
 # Check the argument and take appropriate action


### PR DESCRIPTION
## Changes

Now we have also releases with `-experimental` and `-nightly` suffixes, we need to handle those in our scripts.

## Test plan

N/A, it's internal script using for triggering releases.