### PR TITLE
Apply chore improvements; update latest ide version

### DIFF
--- a/.github/workflows/experimental-release.yml
+++ b/.github/workflows/experimental-release.yml
@@ -26,11 +26,10 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
       - run: yarn global add pnpm@8.6.7
       - run: |
-          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
-      - run: echo "Publishing version $RELEASE_VERSION"
+          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)-experimental" >> $GITHUB_ENV
       - name: Publish experimental version
         run: |
-          echo "Publishing experimental version ${RELEASE_VERSION}-experimental"
-          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-experimental" publishPlugin
+          echo "Publishing experimental version ${RELEASE_VERSION}"
+          ./gradlew "-PpluginVersion=${RELEASE_VERSION}" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -26,11 +26,10 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
       - run: yarn global add pnpm@8.6.7
       - run: |
-          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
-      - run: echo "Publishing version $RELEASE_VERSION"
+          echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)-nightly" >> $GITHUB_ENV
       - name: Publish nightly version
         run: |
-          echo "Publishing nightly version ${RELEASE_VERSION}-nightly"
-          ./gradlew "-PpluginVersion=${RELEASE_VERSION}-nightly" publishPlugin
+          echo "Publishing nightly version ${RELEASE_VERSION}"
+          ./gradlew "-PpluginVersion=${RELEASE_VERSION}" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -27,6 +27,7 @@ jobs:
       - run: |
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
+      - run: git tag -a "RELEASE_VERSION" -m "RELEASE_VERSION" && git push origin "$RELEASE_VERSION"
       - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -26,8 +26,6 @@ jobs:
       - run: yarn global add pnpm@8.6.7
       - run: |
           echo "RELEASE_VERSION=$(./scripts/version-from-git-tag.sh)" >> $GITHUB_ENV
-      - run: echo "Publishing version $RELEASE_VERSION"
-      - run: git tag -a "RELEASE_VERSION" -m "RELEASE_VERSION" && git push origin "$RELEASE_VERSION"
       - run: ./gradlew "-PpluginVersion=$RELEASE_VERSION" publishPlugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,11 +82,11 @@ jobs:
             ideaIC:2023.2
             ideaIC:2024.2.4
           failure-levels: |
-            OVERRIDE_ONLY_API_USAGES
-            NON_EXTENDABLE_API_USAGES
-            PLUGIN_STRUCTURE_WARNINGS
-            MISSING_DEPENDENCIES
             INVALID_PLUGIN
+            MISSING_DEPENDENCIES
+            NON_EXTENDABLE_API_USAGES
+            OVERRIDE_ONLY_API_USAGES
+            PLUGIN_STRUCTURE_WARNINGS
       - name: Upload the verification reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
           plugin-location: '*.zip'
           ide-versions: |
             ideaIC:2023.2
-            ideaIC:2024.2.3
+            ideaIC:2024.2.4
           failure-levels: |
             OVERRIDE_ONLY_API_USAGES
             NON_EXTENDABLE_API_USAGES

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ val isForceCodeSearchBuild = properties("forceCodeSearchBuild") == "true"
 // Remove unsupported old versions from this list.
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
 // this list.
-val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2.3").sorted()
+val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2.4").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,11 +45,12 @@ val skippedFailureLevels =
             .COMPATIBILITY_PROBLEMS, // blocked by the hacks with the completion provider for the
         // remote IDE
         FailureLevel.DEPRECATED_API_USAGES,
-        FailureLevel.INTERNAL_API_USAGES,
-        FailureLevel
-            .SCHEDULED_FOR_REMOVAL_API_USAGES, // HttpConfigurable, migration to coroutines, others
         FailureLevel.EXPERIMENTAL_API_USAGES,
-        FailureLevel.NOT_DYNAMIC)!!
+        FailureLevel.INTERNAL_API_USAGES,
+        FailureLevel.NOT_DYNAMIC,
+        FailureLevel
+            .SCHEDULED_FOR_REMOVAL_API_USAGES // HttpConfigurable, migration to coroutines, others
+        )!!
 
 plugins {
   id("java")

--- a/scripts/next-release.sh
+++ b/scripts/next-release.sh
@@ -7,10 +7,10 @@ if [ "$#" -ne 1 ]; then
   exit 1
 fi
 
-LAST_MAJOR_MINOR_ZERO_RELEASE=$(git tag -l | grep "v\d*\\.\d*\\.\d*" | uniq | sort -V | tail -1)
+LAST_MAJOR_MINOR_ZERO_RELEASE=$(git tag -l | grep "v\d*\\.\d*\\.\d*" | uniq | sort -V | tail -1 | sed 's/-nightly//' | sed 's/-experimental//')
 MAJOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f1)
 MINOR=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f2)
-PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f3 | sed 's/-nightly//' | sed 's/-experimental//')
+PATCH=$(echo $LAST_MAJOR_MINOR_ZERO_RELEASE | sed 's/v//' | cut -d. -f3)
 
 NEXT_RELEASE_ARG="$1"
 # Check the argument and take appropriate action


### PR DESCRIPTION
~We need the GitHub releases and their links to look nice. A stable release should not include `-nightly` in the link. This PR will automatically push a new tag without the suffix so we will be able to use it to generate the release notes.~

We cannot push from CI (without creating a token and setting it as a secret). Let's stick to the present process (manually push stable tag when needed).

Btw, I added a few minor improvements.

## Test plan
1. ~To test these changes we will need to do a stable release 😃~
1. N/A - these are only chore changes and improvements 
