### PR TITLE
Lower the stacktrace length limit in Report GitHub Issue 

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -69,7 +69,7 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
   private fun formatLogs(throwableText: String?, additionalInfo: String?) =
       formatAttributes(
           "Stacktrace" to
-              throwableText?.let { trimPostfix(throwableText, 6500) }, // max total length is 8192
+              throwableText?.let { trimPostfix(throwableText, 6000) }, // max total length is 8192
           "Additional info" to additionalInfo)
 
   private fun trimPostfix(text: String, maxLength: Int): String {


### PR DESCRIPTION
While testing the other feature I encountered this:
```
https://github.com/sourcegraph/jetbrains/issues/new?template=bug_report.yml&labels=bug&projects=sourcegraph/381&title=bug%3A+java.lang.RuntimeException%3A+java.util.concurrent.ExecutionException%3A+java.util.concurrent.ExecutionException%3A+org.eclipse.lsp...&about=IntelliJ+IDEA+2022.1+%28Community+Edition%29%0ABuild+%23IC-221.5080.210%2C+built+on+April+12%2C+2022%0ARuntime+version%3A+11.0.14.1%2B1-b2043.25+aarch64%0AVM%3A+OpenJDK+64-Bit+Server+VM+by+JetBrains+s.r.o.%0AmacOS+14.5%0AGC%3A+G1+Young+Generation%2C+G1+Old+Generation%0AMemory%3A+752M%0ACores%3A+10%0ANon-Bundled+Plugins%3A%0A++++com.sourcegraph.jetbrains+%286.0-localbuild%29%0A%0AKotlin%3A+221-1.6.20-release-285-IJ5080.210&logs=Stacktrace%3A%0A%60%60%60text%0Ajava.lang.RuntimeException%3A+java.util.concurrent.ExecutionException%3A+java.util.concurrent.ExecutionException%3A+org.eclipse.lsp4j.jsonrpc.ResponseErrorException%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A%0AError%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A138490%3A19%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A139426%3A18%0A++++at+async+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A137987%3A44%0A%09at+com.intellij.util.ExceptionUtil.rethrow%28ExceptionUtil.java%3A132%29%0A%09at+com.intellij.openapi.progress.util.ProgressIndicatorUtils.awaitWithCheckCanceled%28ProgressIndicatorUtils.java%3A376%29%0A%09at+com.sourcegraph.cody.inspections.CodyFixHighlightPass.doCollectInformation%28CodyFixHighlightPass.kt%3A133%29%0A%09at+com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation%28TextEditorHighlightingPass.java%3A56%29%0A%09at+com.intellij.codeInsight.daemon.impl.PassExecutorService%24ScheduledPass.lambda%24doRun%241%28PassExecutorService.java%3A419%29%0A%09at+com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction%28ApplicationImpl.java%3A1152%29%0A%09at+com.intellij.codeInsight.daemon.impl.PassExecutorService%24ScheduledPass.lambda%24doRun%242%28PassExecutorService.java%3A412%29%0A%09at+com.intellij.openapi.progress.impl.CoreProgressManager.lambda%24executeProcessUnderProgress%2412%28CoreProgressManager.java%3A608%29%0A%09at+com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun%28CoreProgressManager.java%3A683%29%0A%09at+com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress%28CoreProgressManager.java%3A639%29%0A%09at+com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress%28CoreProgressManager.java%3A607%29%0A%09at+com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress%28ProgressManagerImpl.java%3A60%29%0A%09at+com.intellij.codeInsight.daemon.impl.PassExecutorService%24ScheduledPass.doRun%28PassExecutorService.java%3A411%29%0A%09at+com.intellij.codeInsight.daemon.impl.PassExecutorService%24ScheduledPass.lambda%24run%240%28PassExecutorService.java%3A387%29%0A%09at+com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader%28ReadMostlyRWLock.java%3A174%29%0A%09at+com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader%28ApplicationImpl.java%3A213%29%0A%09at+com.intellij.codeInsight.daemon.impl.PassExecutorService%24ScheduledPass.run%28PassExecutorService.java%3A385%29%0A%09at+com.intellij.concurrency.JobLauncherImpl%24VoidForkJoinTask%241.exec%28JobLauncherImpl.java%3A184%29%0A%09at+java.base%2Fjava.util.concurrent.ForkJoinTask.doExec%28ForkJoinTask.java%3A290%29%0A%09at+java.base%2Fjava.util.concurrent.ForkJoinPool%24WorkQueue.topLevelExec%28ForkJoinPool.java%3A1020%29%0A%09at+java.base%2Fjava.util.concurrent.ForkJoinPool.scan%28ForkJoinPool.java%3A1656%29%0A%09at+java.base%2Fjava.util.concurrent.ForkJoinPool.runWorker%28ForkJoinPool.java%3A1594%29%0A%09at+java.base%2Fjava.util.concurrent.ForkJoinWorkerThread.run%28ForkJoinWorkerThread.java%3A183%29%0ACaused+by%3A+java.util.concurrent.ExecutionException%3A+java.util.concurrent.ExecutionException%3A+org.eclipse.lsp4j.jsonrpc.ResponseErrorException%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A%0AError%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A138490%3A19%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A139426%3A18%0A++++at+async+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A137987%3A44%0A%09at+java.base%2Fjava.util.concurrent.CompletableFuture.reportGet%28CompletableFuture.java%3A395%29%0A%09at+java.base%2Fjava.util.concurrent.CompletableFuture.get%28CompletableFuture.java%3A2022%29%0A%09at+com.intellij.openapi.progress.util.ProgressIndicatorUtils.awaitWithCheckCanceled%28ProgressIndicatorUtils.java%3A361%29%0A%09...+21+more%0ACaused+by%3A+java.util.concurrent.ExecutionException%3A+org.eclipse.lsp4j.jsonrpc.ResponseErrorException%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A%0AError%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A138490%3A19%0A++++at+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A139426%3A18%0A++++at+async+%2FUsers%2Fmkondratek%2FIdeaProjects%2Fjetbrains%2Fbuild%2Fsourcegraph%2Fagent%2Findex.js%3A137987%3A44%0A%09at+java.base%2Fjava.util.concurrent.CompletableFuture.reportGet%28CompletableFuture.java%3A395%29%0A%09at+java.base%2Fjava.util.concurrent.CompletableFuture.get%28CompletableFuture.java%3A1999%29%0A%09at+com.sourcegraph.cody.inspections.CodyFixHighlightPass.doCollectInformation%24lambda%245%28CodyFixHighlightPass.kt%3A122%29%0A%09at+com.sourcegraph.cody.agent.CodyAgentService%24Companion.withAgent%24lambda%242%28CodyAgentService.kt%3A266%29%0A%09at+com.intellij.openapi.application.impl.ApplicationImpl%241.run%28ApplicationImpl.java%3A295%29%0A%09at+java.base%2Fjava.util.concurrent.Executors%24RunnableAdapter.call%28Executors.java%3A515%29%0A%09at+java.base%2Fjava.util.concurrent.FutureTask.run%28FutureTask.java%3A264%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor.runWorker%28ThreadPoolExecutor.java%3A1128%29%0A%09at+java.base%2Fjava.util.concurrent.ThreadPoolExecutor%24Worker.run%28ThreadPoolExecutor.java%3A628%29%0A%09at+java.base%2Fjava.util.concurrent.Executors%24PrivilegedThreadFactory%241%241.run%28Executors.java%3A668%29%0A%09at+java.base%2Fjava.util.concurrent.Executors%24PrivilegedThreadFactory%241%241.run%28Executors.java%3A665%29%0A%09at+java.base%2Fjava.security.AccessController.doPrivileged%28Native+Method%29%0A%09at+java.base%2Fjava.util.concurrent.Executors%24PrivilegedThreadFactory%241.run%28Executors.java%3A665%29%0A%09at+java.base%2Fjava.lang.Thread.run%28Thread.java%3A829%29%0ACaused+by%3A+org.eclipse.lsp4j.jsonrpc.ResponseErrorException%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fmain%2Fjava%2Fcom%2Fsourcegraph%2Ffind%2Fbrowser%2FJavaToJSBridge.java%0A%0AError%3A+codeActions%2Fprovide%3A+document+not+found+for+file%3A%2F%2F%2FUsers%2Fmkondratek%2FrunIdeProjects%2Fjetbrains%2Fsrc%2Fm...%0A%60%60%60
```

GitHub complains: 
```
Whoa there!
Your request URL is too long.
```

Let's be more restrictive about the url length.

## Test plan
Hard to repro. Some error with a very long stacktrace is required.
