### PR TITLE
Avoid white flash when creating new panel by enabling offscreen prerendering

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -334,7 +334,7 @@ class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserB
       val browser =
           JBCefBrowserBuilder()
               .apply {
-                setOffScreenRendering(false)
+                setOffScreenRendering(true)
                 // TODO: Make this conditional on running in a debug configuration.
                 setEnableOpenDevToolsMenuItem(true)
               }


### PR DESCRIPTION
Fixes CODY-2844

## Changes

PR title really says it all

## Test plan

1. Start a new chat, ask a question
2. Open new chat window

There should be no flash of white while new chat is loading.