### PR TITLE
Fix input prompt not working after switching to offscreen rendering

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.ui
 import com.google.gson.Gson
 import com.google.gson.JsonArray
 import com.google.gson.JsonParser
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
@@ -334,7 +335,9 @@ class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserB
       val browser =
           JBCefBrowserBuilder()
               .apply {
-                setOffScreenRendering(true)
+                val isOffScreenRenderingSupported =
+                    ApplicationInfo.getInstance().build.baselineVersion >= 224
+                setOffScreenRendering(isOffScreenRenderingSupported)
                 // TODO: Make this conditional on running in a debug configuration.
                 setEnableOpenDevToolsMenuItem(true)
               }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3369/backspace-key-not-functioning

## Test plan

Scenario 1:

1. Open chat in IntelliJ older than 2024.
2. Make sure backspace works in chat input prompt.

Scenario 2:

1. Open IJ 2024. 
2. Make sure there is no flickering when switching to new chat window