### PR TITLE
Adjust IJ version used for setOffScreenRendering

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphApiRequestExecutor.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/api/SourcegraphApiRequestExecutor.kt
@@ -59,7 +59,6 @@ private constructor(
       LOG.debug("Request: ${request.url} ${request.operationName} : Connecting")
       return connect {
         val connection = it.connection as HttpURLConnection
-
         if (request is SourcegraphApiRequest.Post) {
           LOG.debug(
               "Request: ${connection.requestMethod} ${connection.url} with body:\n${request.body} : Connected")

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -284,14 +284,14 @@ class WebUIHostImpl(
     }
   }
 
-  override fun setOptions(value: WebviewOptions) {
+  override fun setOptions(options: WebviewOptions) {
     // TODO:
     // When TypeScript uses these WebView options, implement them:
     // - retainContextWhenHidden: false and dispose the browser when hidden.
     // - localResourceRoots beyond just the extension distribution path.
     // - Non-empty portMapping.
     // - enableScripts: false, enableForms: false
-    _options = value
+    _options = options
   }
 
   override fun setTitle(value: String) {
@@ -314,7 +314,7 @@ class WebUIHostImpl(
               }
             } ?: emptyList()
     if (_options.enableCommandUris == true ||
-        (_options.enableCommandUris as List<String>).contains(commandName)) {
+        (_options.enableCommandUris as List<*>).contains(commandName)) {
       CodyAgentService.withAgent(project) {
         it.server.commandExecute(CommandExecuteParams(commandName, arguments))
       }
@@ -336,7 +336,7 @@ class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserB
           JBCefBrowserBuilder()
               .apply {
                 val isOffScreenRenderingSupported =
-                    ApplicationInfo.getInstance().build.baselineVersion >= 224
+                    ApplicationInfo.getInstance().build.baselineVersion >= 232
                 setOffScreenRendering(isOffScreenRenderingSupported)
                 // TODO: Make this conditional on running in a debug configuration.
                 setEnableOpenDevToolsMenuItem(true)
@@ -835,13 +835,13 @@ class ExtensionResourceHandler() : CefResourceHandler {
     if (bytesSent >= contentLength || dataOut == null) {
       try {
         readChannel?.close()
-      } catch (e: IOException) {}
+      } catch (_: IOException) {}
       bytesRead?.set(0)
       return false
     }
 
     if (bytesWaitingSend.remaining() > 0) {
-      val willSendNumBytes = min(bytesWaitingSend.remaining() as Int, bytesToRead)
+      val willSendNumBytes = min(bytesWaitingSend.remaining(), bytesToRead)
       bytesWaitingSend.get(dataOut, 0, willSendNumBytes)
       bytesRead?.set(willSendNumBytes)
       return true
@@ -866,7 +866,7 @@ class ExtensionResourceHandler() : CefResourceHandler {
             if (result == -1) {
               try {
                 readChannel?.close()
-              } catch (e: IOException) {}
+              } catch (_: IOException) {}
               readChannel = null
             } else {
               bytesReadFromResource += result
@@ -878,7 +878,7 @@ class ExtensionResourceHandler() : CefResourceHandler {
           override fun failed(exc: Throwable?, attachment: Void?) {
             try {
               readChannel?.close()
-            } catch (e: IOException) {}
+            } catch (_: IOException) {}
             readChannel = null
             callback?.Continue()
           }
@@ -891,7 +891,7 @@ class ExtensionResourceHandler() : CefResourceHandler {
   override fun cancel() {
     try {
       readChannel?.close()
-    } catch (e: IOException) {}
+    } catch (_: IOException) {}
     readChannel = null
   }
 }


### PR DESCRIPTION
## Changes

1. Adjust IJ version used for `setOffScreenRendering`
2. Fix few minor compiler warnings

## Test plan

1. Make sure backspace works in the 2023.2 and 2023.1 chat.