### PR TITLE
Fix missing model ID for Edit commands

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -1,32 +1,33 @@
 package com.sourcegraph.cody.agent.protocol
 
+import com.sourcegraph.cody.agent.protocol_generated.Model
 import com.sourcegraph.cody.Icons
 import javax.swing.Icon
 
 data class ChatModelsResponse(val models: List<ChatModelProvider>) {
-  data class ChatModelProvider(
-      val provider: String?,
-      val title: String?,
-      val model: String,
-      val tags: MutableList<String>? = mutableListOf(),
-      val usage: MutableList<String>? = mutableListOf(),
-      @Deprecated("No longer provided by agent") val default: Boolean = false,
-      @Deprecated("No longer provided by agent") val codyProOnly: Boolean = false,
-      @Deprecated("No longer provided by agent") val deprecated: Boolean = false
-  ) {
+  data class ChatModelProvider(private val model: Model) {
+    val provider: String? = model.provider
+    val title: String? = model.title
+    val id: String = model.id
+    val tags: MutableList<String> = model.tags.map { it.toString() }.toMutableList()
+    val usage: MutableList<String> = model.usage.map { it.toString() }.toMutableList()
+    @Deprecated("No longer provided by agent") val default: Boolean = false
+    @Deprecated("No longer provided by agent") val codyProOnly: Boolean = false
+    @Deprecated("No longer provided by agent") val deprecated: Boolean = false
+
     fun getIcon(): Icon? =
-        when (provider) {
-          "Anthropic" -> Icons.LLM.Anthropic
-          "OpenAI" -> Icons.LLM.OpenAI
-          "Mistral" -> Icons.LLM.Mistral
-          "Google" -> Icons.LLM.Google
-          "Ollama" -> Icons.LLM.Ollama
-          else -> null
-        }
+      when (provider) {
+        "Anthropic" -> Icons.LLM.Anthropic
+        "OpenAI" -> Icons.LLM.OpenAI
+        "Mistral" -> Icons.LLM.Mistral
+        "Google" -> Icons.LLM.Google
+        "Ollama" -> Icons.LLM.Ollama
+        else -> null
+      }
 
     fun displayName(): String = buildString {
       if (title == null) {
-        if (model.isNotBlank()) {
+        if (id.isNotBlank()) {
           append(model)
         } else {
           append("Default")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ChatModelsResponse.kt
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody.agent.protocol
 
-import com.sourcegraph.cody.agent.protocol_generated.Model
 import com.sourcegraph.cody.Icons
+import com.sourcegraph.cody.agent.protocol_generated.Model
 import javax.swing.Icon
 
 data class ChatModelsResponse(val models: List<ChatModelProvider>) {
@@ -16,14 +16,14 @@ data class ChatModelsResponse(val models: List<ChatModelProvider>) {
     @Deprecated("No longer provided by agent") val deprecated: Boolean = false
 
     fun getIcon(): Icon? =
-      when (provider) {
-        "Anthropic" -> Icons.LLM.Anthropic
-        "OpenAI" -> Icons.LLM.OpenAI
-        "Mistral" -> Icons.LLM.Mistral
-        "Google" -> Icons.LLM.Google
-        "Ollama" -> Icons.LLM.Ollama
-        else -> null
-      }
+        when (provider) {
+          "Anthropic" -> Icons.LLM.Anthropic
+          "OpenAI" -> Icons.LLM.OpenAI
+          "Mistral" -> Icons.LLM.Mistral
+          "Google" -> Icons.LLM.Google
+          "Ollama" -> Icons.LLM.Ollama
+          else -> null
+        }
 
     fun displayName(): String = buildString {
       if (title == null) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -76,9 +76,9 @@ class LlmDropdown(
 
     selectedItem =
         models.find {
-          it.model == model ||
-              it.model == selectedFromHistory?.model ||
-              it.model == selectedFromChatState?.model
+          it.id == model ||
+              it.id == selectedFromHistory?.id ||
+              it.id == selectedFromChatState?.id
         } ?: models.firstOrNull()
 
     val isEnterpriseAccount =

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -76,7 +76,9 @@ class LlmDropdown(
 
     selectedItem =
         models.find {
-          it.id == model || it.id == selectedFromHistory?.id || it.id == selectedFromChatState?.id
+          it.id == model ||
+              it.id == selectedFromHistory?.model ||
+              it.id == selectedFromChatState?.id
         } ?: models.firstOrNull()
 
     val isEnterpriseAccount =

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -76,9 +76,7 @@ class LlmDropdown(
 
     selectedItem =
         models.find {
-          it.id == model ||
-              it.id == selectedFromHistory?.id ||
-              it.id == selectedFromChatState?.id
+          it.id == model || it.id == selectedFromHistory?.id || it.id == selectedFromChatState?.id
         } ?: models.firstOrNull()
 
     val isEnterpriseAccount =

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -7,7 +7,7 @@ import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 
 @Tag("llm")
 class LLMState : BaseState() {
-  @get:OptionTag(tag = "model", nameAttribute = "") var model: String? by string()
+  @get:OptionTag(tag = "id", nameAttribute = "") var id: String? by string()
 
   @get:OptionTag(tag = "title", nameAttribute = "") var title: String? by string()
 
@@ -20,7 +20,7 @@ class LLMState : BaseState() {
   companion object {
     fun fromChatModel(chatModelProvider: ChatModelsResponse.ChatModelProvider): LLMState {
       return LLMState().also {
-        it.model = chatModelProvider.model
+        it.id = chatModelProvider.id
         it.title = chatModelProvider.title
         it.provider = chatModelProvider.provider
         it.tags = chatModelProvider.tags ?: mutableListOf()

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -7,7 +7,7 @@ import com.sourcegraph.cody.agent.protocol.ChatModelsResponse
 
 @Tag("llm")
 class LLMState : BaseState() {
-  @get:OptionTag(tag = "id", nameAttribute = "") var id: String? by string()
+  @get:OptionTag(tag = "model", nameAttribute = "") var model: String? by string()
 
   @get:OptionTag(tag = "title", nameAttribute = "") var title: String? by string()
 
@@ -20,7 +20,7 @@ class LLMState : BaseState() {
   companion object {
     fun fromChatModel(chatModelProvider: ChatModelsResponse.ChatModelProvider): LLMState {
       return LLMState().also {
-        it.id = chatModelProvider.id
+        it.model = chatModelProvider.id
         it.title = chatModelProvider.title
         it.provider = chatModelProvider.provider
         it.tags = chatModelProvider.tags ?: mutableListOf()


### PR DESCRIPTION
- Migrated the `ChatModelsResponse` class to use the generated `Model` class internally as a follow-up to https://github.com/sourcegraph/cody/pull/5267 to fix the missing model ID for Edit commands.
- Slack thread https://sourcegraph.slack.com/archives/C06R69BC8UW/p1724228969152979
- Part of https://linear.app/sourcegraph/issue/CODY-3409/self-hosted-models-openaicompatible-autocomplete-provider-supports

## Test plan

CI