### PR TITLE
Fix focus and panel movement issues

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -34,6 +34,7 @@ import com.sourcegraph.cody.config.ui.AccountConfigurable
 import com.sourcegraph.cody.sidebar.WebTheme
 import com.sourcegraph.cody.sidebar.WebThemeController
 import com.sourcegraph.common.BrowserOpener
+import java.awt.Component
 import java.awt.datatransfer.StringSelection
 import java.io.IOException
 import java.net.URI
@@ -331,6 +332,53 @@ class WebUIHostImpl(
 
 class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserBase) {
   companion object {
+
+    /**
+     * TODO: Hopefully this can be removed when JetBrains will patch focus handler implementation
+     *   https://youtrack.jetbrains.com/issue/IJPL-158952/Focus-issue-when-using-multiple-JCEF-instances
+     *   Focus switching is caused by something higher in the call stack, so best we can do here is
+     *   to break the chain of focus stealing
+     */
+    private fun patchBrowserFocusHandler(browser: JBCefBrowserBase) {
+      val myFocusHandlerField = browser.jbCefClient.javaClass.getDeclaredField("myFocusHandler")
+      myFocusHandlerField.isAccessible = true
+      val myFocusHandler = myFocusHandlerField.get(browser.jbCefClient)
+      val clearMethod = myFocusHandler.javaClass.getDeclaredMethod("clear")
+      clearMethod.isAccessible = true
+      clearMethod.invoke(myFocusHandler)
+
+      browser.jbCefClient.addFocusHandler(
+          object : CefFocusHandlerAdapter() {
+            val previouslyFocused = mutableListOf<Pair<Component, Long>>()
+
+            // Circuit breaker to prevent focus flickering between different WebViews
+            fun isFocusAllowed(component: Component): Boolean {
+              val currentTime = System.currentTimeMillis()
+              val recentFocus = previouslyFocused.lastOrNull { it.first == component }
+              if (recentFocus != null && currentTime - recentFocus.second < 50) {
+                return false
+              }
+
+              previouslyFocused.add(Pair(component, currentTime))
+              if (previouslyFocused.size > 10) { // Keep only the last 10 entries
+                previouslyFocused.removeFirst()
+              }
+
+              return true
+            }
+
+            override fun onSetFocus(
+                browser: CefBrowser,
+                source: CefFocusHandler.FocusSource
+            ): Boolean {
+              return !browser.uiComponent.hasFocus() &&
+                  isFocusAllowed(browser.uiComponent) &&
+                  browser.uiComponent.requestFocusInWindow()
+            }
+          },
+          browser.cefBrowser)
+    }
+
     fun create(host: WebUIHost): WebUIProxy {
       val browser =
           JBCefBrowserBuilder()
@@ -343,23 +391,7 @@ class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserB
               }
               .build()
 
-      browser.jbCefClient.addFocusHandler(
-          object : CefFocusHandlerAdapter() {
-            override fun onGotFocus(browser: CefBrowser) {
-              println("onGotFocus $browser")
-            }
-
-            override fun onSetFocus(
-                browser: CefBrowser,
-                source: CefFocusHandler.FocusSource
-            ): Boolean {
-              val x = super.onSetFocus(browser, source)
-              println("onSetFocus $browser $x")
-              return x
-            }
-          },
-          browser.cefBrowser)
-
+      patchBrowserFocusHandler(browser)
       val proxy = WebUIProxy(host, browser)
 
       val viewToHost =

--- a/src/main/kotlin/com/sourcegraph/cody/ui/WebPanelProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/WebPanelProvider.kt
@@ -1,7 +1,12 @@
 package com.sourcegraph.cody.ui
 
 import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.fileEditor.*
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorLocation
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.fileEditor.FileEditorState
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -63,32 +68,31 @@ class WebPanelEditor(private val file: VirtualFile) : FileEditor {
 }
 
 class WebPanelProvider : FileEditorProvider, DumbAware {
-  private var creatingEditor = 0
+  @Volatile private var scheduledForDisposal: VirtualFile? = null
 
   override fun accept(project: Project, file: VirtualFile): Boolean =
       file.fileType == WebPanelFileType.INSTANCE
 
+  private fun runScheduledDisposal() {
+    scheduledForDisposal?.getUserData(WebPanelEditor.WEB_UI_PROXY_KEY)?.dispose()
+  }
+
   override fun createEditor(project: Project, file: VirtualFile): FileEditor {
     ApplicationManager.getApplication().assertIsDispatchThread()
-    try {
-      this.creatingEditor++
-      // If this file is already open elsewhere, close it.
-      (FileEditorManager.getInstance(project) as? FileEditorManagerEx)?.closeFile(file)
-      return WebPanelEditor(file)
-    } finally {
-      this.creatingEditor--
-    }
+    // If this file is already open elsewhere, close it.
+    (FileEditorManager.getInstance(project) as? FileEditorManagerEx)?.closeFile(file)
+
+    // If file was reopened we don't want to dispose WebView, as it means panel was just moved
+    // between editors
+    if (scheduledForDisposal != file) runScheduledDisposal()
+    scheduledForDisposal = null
+
+    return WebPanelEditor(file)
   }
 
   override fun disposeEditor(editor: FileEditor) {
-    ApplicationManager.getApplication().assertIsDispatchThread()
-    if (this.creatingEditor > 0) {
-      // We are synchronously creating an editor, which means we do not want to dispose the webview:
-      // It will be
-      // adopted by the new editor.
-      return
-    }
-    editor.file.getUserData(WebPanelEditor.WEB_UI_PROXY_KEY)?.let { it.dispose() }
+    runScheduledDisposal()
+    scheduledForDisposal = editor.file
   }
 
   // TODO: Implement readState, writeState if we need this to manage, restore.


### PR DESCRIPTION
Fixes CODY-2842
Fixes CODY-3367
Fixes CODY-3068

# Changes

1. [JetBrains JCEF has faulty focus implementation ](https://youtrack.jetbrains.com/issue/IJPL-158952/Focus-issue-when-using-multiple-JCEF-instances) sometime causing infinite cycle of components stealing focus from each other. I have not found a way to fix this elegantly, but dirty method works:
i. remove existing focus handler using reflection (:()
ii. add new focus handler with circuit breaker

2. Our implementation of panel disposal stopped working, as apparently if panel is moved old editor can be removed before new on is created (which breaks assumption in the old code). Again, I found no way to implement this in a nice way (like existing listener on "move" file between editors) and instead I had to implement a delayed, scheduled disposal if needed.

## Test plan

**Scenario for bug #1:** 

1. Open few chats in new standalone panels
2. Make sure last one have a focus
3. Close this tab

Expected result: There should be no flickering between right Cody panel and last chat open as standalone panel.

**Scenarios for bug #2:** 

_Scenario 1_
1. Open chat in new standalone panel
2. Click on the tab name and select `Split and Move Right`

Expected result: It should not crash. Window should be split and functioning panel should be moved to the right.

_Scenario 2_
1. Open few chats in new standalone panels mixed with normal files
2. Drag and drop tabs changing their order
3. Click on one of the chat panel tabs and select "Split Right"
4. Click on one of the chat panel tabs and select "Split Down"
5. Drag and drop chat tabs between split views

Expected result: It should not crash. All chat split & move operations should work as one would normally expect from other files.

