### PR TITLE
Increase minimum supported IntelliJ version to 2023.2

### DIFF
--- a/.github/workflows/scip-java.yml
+++ b/.github/workflows/scip-java.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - uses: coursier/setup-action@v1
         with:
-          jvm: 'zulu:11'
+          jvm: 'zulu:17'
           apps: scip-java
       - name: Generate SCIP File
         run: scip-java index --build-tool=gradle

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           plugin-location: '*.zip'
           ide-versions: |
-            ideaIC:2022.1
+            ideaIC:2023.2
             ideaIC:2024.2
           failure-levels: |
             COMPATIBILITY_WARNINGS

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,7 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // Remove unsupported old versions from this list.
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
 // this list.
-val versionsOfInterest =
-    listOf("2022.1", "2022.2", "2022.3", "2023.1", "2023.2", "2023.3", "2024.1", "2024.2").sorted()
+val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())
@@ -328,6 +327,7 @@ tasks {
   val protocolGeneratedDir =
       layout.projectDirectory.asFile.resolve(
           "src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated")
+
   fun buildCody(): File {
     if (!isForceAgentBuild && (buildCodyDir.listFiles()?.size ?: 0) > 0) {
       println("Cached $buildCodyDir")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ pluginName=Sourcegraph
 pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=232.*
+pluginSinceBuild=232
 pluginUntilBuild=242.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,16 +6,16 @@ pluginName=Sourcegraph
 pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild=221.1
+pluginSinceBuild=232.*
 pluginUntilBuild=242.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
-platformVersion=2022.1
+platformVersion=2023.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin,java
 # Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
-javaVersion=11
+javaVersion=17
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@ platformVersion=2023.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=Git4Idea,PerforceDirectPlugin,java
-# Java language level used to compile sources and to generate the files for - Java 11 is required for 2020.3 <= x < 2022.2
 javaVersion=17
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.

--- a/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
+++ b/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
@@ -8,7 +8,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class CodyActionGroup extends DefaultActionGroup {
 
-  ActionUpdateThread getActionUpdateThread() {
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
     return ActionUpdateThread.EDT;
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/AccountsPanelFactoryExtensions.kt
@@ -94,7 +94,7 @@ private fun <A : Account, Cred, R> create(
             addCustomUpdater { isEnabled && model.activeAccount != accountsList.selectedValue }
           }
 
-          fun getActionUpdateThread(): ActionUpdateThread {
+          override fun getActionUpdateThread(): ActionUpdateThread {
             return ActionUpdateThread.BGT
           }
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InlineEditPromptEditCodeAction.kt
@@ -16,7 +16,7 @@ internal class InlineEditPromptEditCodeAction : DumbAwareAction() {
     getInlineEditPrompt(e)?.performOKAction()
   }
 
-  fun getActionUpdateThread(): ActionUpdateThread {
+  override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/lenses/LensEditAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/lenses/LensEditAction.kt
@@ -17,7 +17,7 @@ abstract class LensEditAction(val editAction: (Project, AnActionEvent, Editor, S
     AnAction(), DumbAware {
   private val logger = Logger.getInstance(LensEditAction::class.java)
 
-  fun getActionUpdateThread(): ActionUpdateThread {
+  override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/InternalsStatusBarActionGroup.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.sourcegraph.config.ConfigUtil
 
 class InternalsStatusBarActionGroup : DefaultActionGroup() {
-  fun getActionUpdateThread(): ActionUpdateThread {
+  override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarActionGroup.kt
@@ -11,7 +11,7 @@ import com.sourcegraph.config.ConfigUtil
 
 class CodyStatusBarActionGroup : DefaultActionGroup() {
 
-  fun getActionUpdateThread(): ActionUpdateThread {
+  override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -68,6 +68,7 @@ import org.cef.network.CefCookie
 import org.cef.network.CefRequest
 import org.cef.network.CefResponse
 import org.cef.network.CefURLRequest
+import org.cef.security.CefSSLInfo
 
 /** The subset of the Agent client interface that relates to webviews. */
 interface NativeWebviewProvider {
@@ -607,30 +608,15 @@ class ExtensionRequestHandler(private val proxy: WebUIProxy, private val apiScri
     return false
   }
 
-  override fun onQuotaRequest(
-      browser: CefBrowser?,
-      originUrl: String?,
-      newSize: Long,
-      callback: CefCallback?
-  ): Boolean {
-    // TODO: Filter to the extension origin.
-    callback?.Continue()
-    return true
-  }
-
   override fun onCertificateError(
       browser: CefBrowser?,
-      certError: CefLoadHandler.ErrorCode?,
-      requestUrl: String?,
+      cert_error: CefLoadHandler.ErrorCode?,
+      request_url: String?,
+      sslInfo: CefSSLInfo?,
       callback: CefCallback?
   ): Boolean {
     // TODO: Add Telemetry here.
     return false
-  }
-
-  override fun onPluginCrashed(browser: CefBrowser?, pluginPath: String?) {
-    // TODO: Add Telemetry here.
-    // As we do not use plugins, we do not need to handle this.
   }
 
   override fun onRenderProcessTerminated(

--- a/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareEDTAction.kt
+++ b/src/main/kotlin/com/sourcegraph/common/ui/DumbAwareEDTAction.kt
@@ -21,7 +21,7 @@ abstract class DumbAwareEDTAction : DumbAwareAction {
       icon: Icon?
   ) : super(text, description, icon)
 
-  fun getActionUpdateThread(): ActionUpdateThread {
+  override fun getActionUpdateThread(): ActionUpdateThread {
     return ActionUpdateThread.EDT
   }
 }


### PR DESCRIPTION
Fixes CODY-3383

This also partially address CODY-3193.
We still need to switch to platform version 2.0 but now it will not be technically blocked.

## Test plan

Try to install plugin in IntelliJ `2023.1` or lower - it should not be allowed.