### PR TITLE
Do not run edit OK action if edit dialog is not visible

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -283,7 +283,7 @@ class EditCommandPrompt(
     project.putUserData(EDIT_COMMAND_PROMPT_KEY, this)
   }
 
-  fun isOkActionEnabled() = okButtonGroup.isEnabled && model != null
+  fun isOkActionEnabled() = isVisible && okButtonGroup.isEnabled && model != null
 
   private fun updateDialogPosition() {
     // Convert caret position to screen coordinates.

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -291,7 +291,7 @@ class WebUIHostImpl(
       // TODO: Delete this intercept when Cody edits UI is abstracted so JetBrains' native UI can be
       // invoked from the
       // extension TypeScript side through Agent.
-      isCommand && id == "cody.action.command" && decodedJson?.get("arg")?.asString == "edit" -> {
+      isCommand && id == "cody.action.command" && decodedJson.get("arg")?.asString == "edit" -> {
         runInEdt {
           // Invoke the Cody "edit" action in JetBrains directly.
           val actionManager = ActionManager.getInstance()


### PR DESCRIPTION
Fixes CODY-3264

## Test plan

Manually tested:

1. Right click on a file, edit, perform an edit such as "replace strings with a different human language"
2. Start a chat, enter a prompt such as "what does this file do?" and hit cmd-enter
3. Confirm this does not trigger a second edit