### PR TITLE
added(agent): `chat/import` to migrate historical chats to agent storage for webview

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -126,6 +126,7 @@ private constructor(
                               ignore = ClientCapabilities.IgnoreEnum.Enabled,
                               untitledDocuments = ClientCapabilities.UntitledDocumentsEnum.Enabled,
                               codeActions = ClientCapabilities.CodeActionsEnum.Enabled,
+                              globalState = ClientCapabilities.GlobalStateEnum.`Server-managed`,
                               webview = ClientCapabilities.WebviewEnum.Native,
                               webviewNativeConfig =
                                   WebviewNativeConfigParams(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -16,22 +16,7 @@ import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
-import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsParams
-import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsResult
-import com.sourcegraph.cody.agent.protocol_generated.ClientInfo
-import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
-import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
-import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
-import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
-import com.sourcegraph.cody.agent.protocol_generated.EditTask
-import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
-import com.sourcegraph.cody.agent.protocol_generated.EditTask_CancelParams
-import com.sourcegraph.cody.agent.protocol_generated.EditTask_GetTaskDetailsParams
-import com.sourcegraph.cody.agent.protocol_generated.EditTask_RetryParams
-import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
-import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
-import com.sourcegraph.cody.agent.protocol_generated.Null
-import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
+import com.sourcegraph.cody.agent.protocol_generated.*
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
@@ -165,6 +150,9 @@ interface _LegacyAgentServer {
   fun webviewResolveWebviewView(params: WebviewResolveWebviewViewParams): CompletableFuture<Any>
 
   @JsonRequest("chat/export") fun chatExport(): CompletableFuture<List<ChatHistoryResponse>>
+
+  @JsonRequest("chat/import")
+  fun chat_import(params: Chat_ImportParams): CompletableFuture<Null?>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -151,8 +151,7 @@ interface _LegacyAgentServer {
 
   @JsonRequest("chat/export") fun chatExport(): CompletableFuture<List<ChatHistoryResponse>>
 
-  @JsonRequest("chat/import")
-  fun chat_import(params: Chat_ImportParams): CompletableFuture<Null?>
+  @JsonRequest("chat/import") fun chat_import(params: Chat_ImportParams): CompletableFuture<Null?>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -32,7 +32,7 @@ object ChatHistoryMigration {
   ): Map<String, Map<String, SerializedChatTranscript>> {
     return chats
         .map { (account, chats) ->
-          val serializedChats = chats.mapNotNull(::toSerializedChatTranscript) ?: listOf()
+          val serializedChats = chats.mapNotNull(::toSerializedChatTranscript)
           val byId = serializedChats.associateBy { it.id }
 
           "${account.server.url}-${account.name}" to byId

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -1,0 +1,69 @@
+package com.sourcegraph.cody.config.migration
+
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Chat_ImportParams
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatInteraction
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatMessage
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatTranscript
+import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.history.HistoryService
+import com.sourcegraph.cody.history.state.ChatState
+import com.sourcegraph.cody.history.state.MessageState
+
+// Copies chat history from locally stored jetbrains state to the cody agent
+// so historical chats can be viewed in the cody webview
+object ChatHistoryMigration {
+    fun migrate(project: Project) {
+        CodyAgentService.withAgent(project) { agent ->
+            val chats = CodyAuthenticationManager.getInstance(project).getAccounts().fold(mutableMapOf<String, Map<String, SerializedChatTranscript>>()){ map, account ->
+                val chatHistory = HistoryService.getInstance(project).getChatHistoryFor(account.id)
+                val serializedChats = chatHistory?.mapNotNull(::toSerializedChatTranscript) ?: listOf()
+                val byDate = serializedChats.associateBy{ it.lastInteractionTimestamp }
+                val chatId = "${account.server.url}-${account.name}"
+                map[chatId] = byDate
+                map
+            }
+            agent.server.chat_import(Chat_ImportParams(
+                history = chats.toMap(),
+                merge = true
+            )).get()
+        }
+    }
+
+    private fun toSerializedChatTranscript(chat: ChatState): SerializedChatTranscript? {
+            return SerializedChatTranscript(
+                id = chat.internalId ?: return null,
+                lastInteractionTimestamp = chat.updatedAt ?: return null,
+                interactions = toSerializedInteractions(chat.messages, chat.llm?.model),
+            )
+        }
+    }
+
+    private fun toSerializedInteractions(messages: List<MessageState>, model: String?): List<SerializedChatInteraction> {
+        fun toChatMessage(message: MessageState): SerializedChatMessage? {
+            return SerializedChatMessage(
+                text = message.text ?: return null,
+                model = model,
+                speaker = when(message.speaker) {
+                    MessageState.SpeakerState.HUMAN -> SerializedChatMessage.SpeakerEnum.Human
+                    MessageState.SpeakerState.ASSISTANT -> SerializedChatMessage.SpeakerEnum.Assistant
+                    null -> return null
+                },
+            )
+        }
+
+       fun toInteraction(pair: List<SerializedChatMessage?>): SerializedChatInteraction? {
+            val (human, assistant) = pair.getOrNull(0) to pair.getOrNull(1)
+           if (human == null || human.speaker != SerializedChatMessage.SpeakerEnum.Human ||  assistant?.speaker != SerializedChatMessage.SpeakerEnum.Assistant) {
+               return null
+           }
+            return SerializedChatInteraction(
+                humanMessage = human,
+                assistantMessage = assistant
+            )
+        }
+
+        return messages.map(::toChatMessage).chunked(2).mapNotNull(::toInteraction)
+    }
+

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -15,62 +15,66 @@ import com.sourcegraph.cody.history.state.MessageState
 // Copies chat history from locally stored jetbrains state to the cody agent
 // so historical chats can be viewed in the cody webview
 object ChatHistoryMigration {
-    fun migrate(project: Project) {
-        CodyAgentService.withAgent(project) { agent ->
-            val chats = CodyAuthenticationManager.getInstance(project).getAccounts().associateWith { account ->
-                (HistoryService.getInstance(project).getChatHistoryFor(account.id) ?: listOf())
-            }
-            val history = toChatInput(chats)
+  fun migrate(project: Project) {
+    CodyAgentService.withAgent(project) { agent ->
+      val chats =
+          CodyAuthenticationManager.getInstance(project).getAccounts().associateWith { account ->
+            (HistoryService.getInstance(project).getChatHistoryFor(account.id) ?: listOf())
+          }
+      val history = toChatInput(chats)
 
-            agent.server.chat_import(Chat_ImportParams(
-                history = history,
-                merge = true
-            )).get()
-        }
+      agent.server.chat_import(Chat_ImportParams(history = history, merge = true)).get()
     }
+  }
 
-    fun toChatInput(chats: Map<CodyAccount, List<ChatState>>): Map<String, Map<String, SerializedChatTranscript>> {
-        return chats.map{ (account, chats) ->
-            val serializedChats = chats.mapNotNull(::toSerializedChatTranscript) ?: listOf()
-            val byId = serializedChats.associateBy{ it.id }
+  fun toChatInput(
+      chats: Map<CodyAccount, List<ChatState>>
+  ): Map<String, Map<String, SerializedChatTranscript>> {
+    return chats
+        .map { (account, chats) ->
+          val serializedChats = chats.mapNotNull(::toSerializedChatTranscript) ?: listOf()
+          val byId = serializedChats.associateBy { it.id }
 
-            "${account.server.url}-${account.name}" to byId
-        }.toMap()
-    }
-
-    private fun toSerializedChatTranscript(chat: ChatState): SerializedChatTranscript? {
-            return SerializedChatTranscript(
-                id = chat.internalId ?: return null,
-                lastInteractionTimestamp = chat.updatedAt ?: return null,
-                interactions = toSerializedInteractions(chat.messages, chat.llm?.model),
-            )
+          "${account.server.url}-${account.name}" to byId
         }
+        .toMap()
+  }
+
+  private fun toSerializedChatTranscript(chat: ChatState): SerializedChatTranscript? {
+    return SerializedChatTranscript(
+        id = chat.internalId ?: return null,
+        lastInteractionTimestamp = chat.updatedAt ?: return null,
+        interactions = toSerializedInteractions(chat.messages, chat.llm?.model),
+    )
+  }
+}
+
+private fun toSerializedInteractions(
+    messages: List<MessageState>,
+    model: String?
+): List<SerializedChatInteraction> {
+  fun toChatMessage(message: MessageState): SerializedChatMessage? {
+    return SerializedChatMessage(
+        text = message.text ?: return null,
+        model = model,
+        speaker =
+            when (message.speaker) {
+              MessageState.SpeakerState.HUMAN -> SerializedChatMessage.SpeakerEnum.Human
+              MessageState.SpeakerState.ASSISTANT -> SerializedChatMessage.SpeakerEnum.Assistant
+              null -> return null
+            },
+    )
+  }
+
+  fun toInteraction(pair: List<SerializedChatMessage?>): SerializedChatInteraction? {
+    val (human, assistant) = pair.getOrNull(0) to pair.getOrNull(1)
+    if (human == null ||
+        human.speaker != SerializedChatMessage.SpeakerEnum.Human ||
+        assistant?.speaker != SerializedChatMessage.SpeakerEnum.Assistant) {
+      return null
     }
+    return SerializedChatInteraction(humanMessage = human, assistantMessage = assistant)
+  }
 
-    private fun toSerializedInteractions(messages: List<MessageState>, model: String?): List<SerializedChatInteraction> {
-        fun toChatMessage(message: MessageState): SerializedChatMessage? {
-            return SerializedChatMessage(
-                text = message.text ?: return null,
-                model = model,
-                speaker = when(message.speaker) {
-                    MessageState.SpeakerState.HUMAN -> SerializedChatMessage.SpeakerEnum.Human
-                    MessageState.SpeakerState.ASSISTANT -> SerializedChatMessage.SpeakerEnum.Assistant
-                    null -> return null
-                },
-            )
-        }
-
-       fun toInteraction(pair: List<SerializedChatMessage?>): SerializedChatInteraction? {
-            val (human, assistant) = pair.getOrNull(0) to pair.getOrNull(1)
-           if (human == null || human.speaker != SerializedChatMessage.SpeakerEnum.Human ||  assistant?.speaker != SerializedChatMessage.SpeakerEnum.Assistant) {
-               return null
-           }
-            return SerializedChatInteraction(
-                humanMessage = human,
-                assistantMessage = assistant
-            )
-        }
-
-        return messages.map(::toChatMessage).chunked(2).mapNotNull(::toInteraction)
-    }
-
+  return messages.map(::toChatMessage).chunked(2).mapNotNull(::toInteraction)
+}

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -32,9 +32,9 @@ object ChatHistoryMigration {
     fun toChatInput(chats: Map<CodyAccount, List<ChatState>>): Map<String, Map<String, SerializedChatTranscript>> {
         return chats.map{ (account, chats) ->
             val serializedChats = chats.mapNotNull(::toSerializedChatTranscript) ?: listOf()
-            val byDate = serializedChats.associateBy{ it.lastInteractionTimestamp }
+            val byId = serializedChats.associateBy{ it.id }
 
-            "${account.server.url}-${account.name}" to byDate
+            "${account.server.url}-${account.name}" to byId
         }.toMap()
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -54,17 +54,17 @@ class SettingsMigration : Activity {
       organiseChatsByAccount(project)
     }
     RunOnceUtil.runOnceForApp("CodyApplicationSettingsMigration") { migrateApplicationSettings() }
-    RunOnceUtil.runOnceForApp("ToggleCodyToolWindowAfterMigration") {
+    RunOnceUtil.runOnceForProject(project, "ToggleCodyToolWindowAfterMigration") {
       toggleCodyToolbarWindow(project)
     }
-    RunOnceUtil.runOnceForApp("CodyAccountsIdsRefresh") { refreshAccountsIds(project) }
-    RunOnceUtil.runOnceForApp("CodyAssignOrphanedChatsToActiveAccount") {
+    RunOnceUtil.runOnceForProject(project, "CodyAccountsIdsRefresh") { refreshAccountsIds(project) }
+    RunOnceUtil.runOnceForProject(project, "CodyAssignOrphanedChatsToActiveAccount") {
       migrateOrphanedChatsToActiveAccount(project)
     }
 
     DeprecatedChatLlmMigration.migrate(project)
     ChatTagsLlmMigration.migrate(project)
-    RunOnceUtil.runOnceForApp("CodyMigrateChatHistory") {
+    RunOnceUtil.runOnceForProject(project, "CodyMigrateChatHistory") {
       ChatHistoryMigration.migrate(project)
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -64,6 +64,9 @@ class SettingsMigration : Activity {
 
     DeprecatedChatLlmMigration.migrate(project)
     ChatTagsLlmMigration.migrate(project)
+    RunOnceUtil.runOnceForApp("CodyMigrateChatHistory") {
+      ChatHistoryMigration.migrate(project)
+    }
   }
 
   private fun migrateOrphanedChatsToActiveAccount(project: Project) {

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -41,6 +41,10 @@ class HistoryService(private val project: Project) :
   fun findActiveAccountChat(internalId: String): ChatState? =
       getActiveAccountHistory()?.chats?.find { it.internalId == internalId }
 
+  @Synchronized
+  fun getChatHistoryFor(accountId: String): List<ChatState>? =
+      findEntry(accountId)?.chats
+
   private fun findEntry(accountId: String): AccountData? =
       state.accountData.find { it.accountId == accountId }
 

--- a/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/HistoryService.kt
@@ -42,8 +42,7 @@ class HistoryService(private val project: Project) :
       getActiveAccountHistory()?.chats?.find { it.internalId == internalId }
 
   @Synchronized
-  fun getChatHistoryFor(accountId: String): List<ChatState>? =
-      findEntry(accountId)?.chats
+  fun getChatHistoryFor(accountId: String): List<ChatState>? = findEntry(accountId)?.chats
 
   private fun findEntry(accountId: String): AccountData? =
       state.accountData.find { it.accountId == accountId }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -366,113 +366,113 @@ class SettingsMigrationTest : BasePlatformTestCase() {
     }
   }
 
+  fun `test toChatInput`() {
+    val account1 =
+        CodyAccount(name = "account1", server = SourcegraphServerPath("https://sourcegraph.com"))
+    val account2 =
+        CodyAccount(name = "account2", server = SourcegraphServerPath("https://sourcegraph.com"))
 
-    fun `test toChatInput`() {
-        val account1 = CodyAccount(name = "account1",  server= SourcegraphServerPath("https://sourcegraph.com"))
-        val account2 = CodyAccount(name = "account2", server= SourcegraphServerPath("https://sourcegraph.com"))
-
-        val chat1 = ChatState("chat1").apply {
-            updatedAt = LocalDateTime.now().toString()
-            messages = mutableListOf(
-                MessageState().apply {
+    val chat1 =
+        ChatState("chat1").apply {
+          updatedAt = LocalDateTime.now().toString()
+          messages =
+              mutableListOf(
+                  MessageState().apply {
                     text = "Hello"
                     speaker = MessageState.SpeakerState.HUMAN
-                },
-                MessageState().apply {
+                  },
+                  MessageState().apply {
                     text = "Hi there!"
                     speaker = MessageState.SpeakerState.ASSISTANT
-                }
-            )
-            llm = LLMState.fromChatModel(
-                Model(
-                    id = "model1",
-                    usage = listOf("chat"),
-                    contextWindow = ModelContextWindow(0, 0, null),
-                    clientSideConfig = null,
-                    provider = "Anthropic",
-                    title = "Claude",
-                    tags = emptyList(),
-                    modelRef = null
-                )
-            )
+                  })
+          llm =
+              LLMState.fromChatModel(
+                  Model(
+                      id = "model1",
+                      usage = listOf("chat"),
+                      contextWindow = ModelContextWindow(0, 0, null),
+                      clientSideConfig = null,
+                      provider = "Anthropic",
+                      title = "Claude",
+                      tags = emptyList(),
+                      modelRef = null))
         }
 
-        val chat2 = ChatState("chat2").apply {
-            updatedAt = LocalDateTime.now().minusDays(1).toString()
-            messages = mutableListOf(
-                MessageState().apply {
+    val chat2 =
+        ChatState("chat2").apply {
+          updatedAt = LocalDateTime.now().minusDays(1).toString()
+          messages =
+              mutableListOf(
+                  MessageState().apply {
                     text = "What's up?"
                     speaker = MessageState.SpeakerState.HUMAN
-                },
-                MessageState().apply {
+                  },
+                  MessageState().apply {
                     text = "Not much."
                     speaker = MessageState.SpeakerState.ASSISTANT
-                }
-            )
-            llm = LLMState.fromChatModel(
-                Model(
-                    id = "model2",
-                    usage = listOf("chat"),
-                    contextWindow = ModelContextWindow(0, 0, null),
-                    clientSideConfig = null,
-                    provider = "Anthropic",
-                    title = "Claude",
-                    tags = emptyList(),
-                    modelRef = null
-                )
-            )
+                  })
+          llm =
+              LLMState.fromChatModel(
+                  Model(
+                      id = "model2",
+                      usage = listOf("chat"),
+                      contextWindow = ModelContextWindow(0, 0, null),
+                      clientSideConfig = null,
+                      provider = "Anthropic",
+                      title = "Claude",
+                      tags = emptyList(),
+                      modelRef = null))
         }
 
-        val chats = mapOf(
-            account1 to listOf(chat1),
-            account2 to listOf(chat2)
-        )
+    val chats = mapOf(account1 to listOf(chat1), account2 to listOf(chat2))
 
-        val result = ChatHistoryMigration.toChatInput(chats)
+    val result = ChatHistoryMigration.toChatInput(chats)
 
-        val expectedResult = mapOf(
-            "https://sourcegraph.com-account1" to mapOf(
-                chat1.updatedAt to SerializedChatTranscript(
-                    id = chat1.internalId!!,
-                    lastInteractionTimestamp = chat1.updatedAt!!,
-                    interactions = listOf(
-                        SerializedChatInteraction(
-                            humanMessage = SerializedChatMessage(
-                                text = "Hello",
-                                model = "model1",
-                                speaker = SerializedChatMessage.SpeakerEnum.Human
-                            ),
-                            assistantMessage = SerializedChatMessage(
-                                text = "Hi there!",
-                                model = "model1",
-                                speaker = SerializedChatMessage.SpeakerEnum.Assistant
-                            )
-                        )
-                    )
-                )
-            ),
-            "https://sourcegraph.com-account2" to mapOf(
-                chat2.updatedAt to SerializedChatTranscript(
-                    id = chat2.internalId!!,
-                    lastInteractionTimestamp = chat2.updatedAt!!,
-                    interactions = listOf(
-                        SerializedChatInteraction(
-                            humanMessage = SerializedChatMessage(
-                                text = "What's up?",
-                                model = "model2",
-                                speaker = SerializedChatMessage.SpeakerEnum.Human
-                            ),
-                            assistantMessage = SerializedChatMessage(
-                                text = "Not much.",
-                                model = "model2",
-                                speaker = SerializedChatMessage.SpeakerEnum.Assistant
-                            )
-                        )
-                    )
-                )
-            )
-        )
+    val expectedResult =
+        mapOf(
+            "https://sourcegraph.com-account1" to
+                mapOf(
+                    chat1.updatedAt to
+                        SerializedChatTranscript(
+                            id = chat1.internalId!!,
+                            lastInteractionTimestamp = chat1.updatedAt!!,
+                            interactions =
+                                listOf(
+                                    SerializedChatInteraction(
+                                        humanMessage =
+                                            SerializedChatMessage(
+                                                text = "Hello",
+                                                model = "model1",
+                                                speaker = SerializedChatMessage.SpeakerEnum.Human),
+                                        assistantMessage =
+                                            SerializedChatMessage(
+                                                text = "Hi there!",
+                                                model = "model1",
+                                                speaker =
+                                                    SerializedChatMessage.SpeakerEnum
+                                                        .Assistant))))),
+            "https://sourcegraph.com-account2" to
+                mapOf(
+                    chat2.updatedAt to
+                        SerializedChatTranscript(
+                            id = chat2.internalId!!,
+                            lastInteractionTimestamp = chat2.updatedAt!!,
+                            interactions =
+                                listOf(
+                                    SerializedChatInteraction(
+                                        humanMessage =
+                                            SerializedChatMessage(
+                                                text = "What's up?",
+                                                model = "model2",
+                                                speaker = SerializedChatMessage.SpeakerEnum.Human),
+                                        assistantMessage =
+                                            SerializedChatMessage(
+                                                text = "Not much.",
+                                                model = "model2",
+                                                speaker =
+                                                    SerializedChatMessage.SpeakerEnum
+                                                        .Assistant))))))
 
-        assertEquals(expectedResult, result)
-    }
+    assertEquals(expectedResult, result)
+  }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -2,7 +2,11 @@ package com.sourcegraph.cody.config
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.registerServiceInstance
-import com.sourcegraph.cody.agent.protocol_generated.*
+import com.sourcegraph.cody.agent.protocol_generated.Model
+import com.sourcegraph.cody.agent.protocol_generated.ModelContextWindow
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatInteraction
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatMessage
+import com.sourcegraph.cody.agent.protocol_generated.SerializedChatTranscript
 import com.sourcegraph.cody.config.migration.ChatHistoryMigration
 import com.sourcegraph.cody.config.migration.ChatTagsLlmMigration
 import com.sourcegraph.cody.config.migration.DeprecatedChatLlmMigration
@@ -379,11 +383,11 @@ class SettingsMigrationTest : BasePlatformTestCase() {
               mutableListOf(
                   MessageState().apply {
                     text = "Hello"
-                    speaker = MessageState.SpeakerState.HUMAN
+                    speaker = SpeakerState.HUMAN
                   },
                   MessageState().apply {
                     text = "Hi there!"
-                    speaker = MessageState.SpeakerState.ASSISTANT
+                    speaker = SpeakerState.ASSISTANT
                   })
           llm =
               LLMState.fromChatModel(
@@ -405,11 +409,11 @@ class SettingsMigrationTest : BasePlatformTestCase() {
               mutableListOf(
                   MessageState().apply {
                     text = "What's up?"
-                    speaker = MessageState.SpeakerState.HUMAN
+                    speaker = SpeakerState.HUMAN
                   },
                   MessageState().apply {
                     text = "Not much."
-                    speaker = MessageState.SpeakerState.ASSISTANT
+                    speaker = SpeakerState.ASSISTANT
                   })
           llm =
               LLMState.fromChatModel(
@@ -432,7 +436,7 @@ class SettingsMigrationTest : BasePlatformTestCase() {
         mapOf(
             "https://sourcegraph.com-account1" to
                 mapOf(
-                    chat1.updatedAt to
+                    chat1.internalId to
                         SerializedChatTranscript(
                             id = chat1.internalId!!,
                             lastInteractionTimestamp = chat1.updatedAt!!,
@@ -453,7 +457,7 @@ class SettingsMigrationTest : BasePlatformTestCase() {
                                                         .Assistant))))),
             "https://sourcegraph.com-account2" to
                 mapOf(
-                    chat2.updatedAt to
+                    chat2.internalId to
                         SerializedChatTranscript(
                             id = chat2.internalId!!,
                             lastInteractionTimestamp = chat2.updatedAt!!,

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -2,8 +2,8 @@ package com.sourcegraph.cody.config
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.registerServiceInstance
-import com.sourcegraph.cody.agent.protocol_generated.Model
-import com.sourcegraph.cody.agent.protocol_generated.ModelContextWindow
+import com.sourcegraph.cody.agent.protocol_generated.*
+import com.sourcegraph.cody.config.migration.ChatHistoryMigration
 import com.sourcegraph.cody.config.migration.ChatTagsLlmMigration
 import com.sourcegraph.cody.config.migration.DeprecatedChatLlmMigration
 import com.sourcegraph.cody.config.migration.SettingsMigration
@@ -16,6 +16,7 @@ import com.sourcegraph.cody.history.state.LLMState
 import com.sourcegraph.cody.history.state.MessageState
 import com.sourcegraph.cody.history.state.MessageState.SpeakerState
 import com.sourcegraph.cody.history.state.RemoteRepositoryState
+import java.time.LocalDateTime
 import kotlin.test.assertContains
 
 class SettingsMigrationTest : BasePlatformTestCase() {
@@ -364,4 +365,114 @@ class SettingsMigrationTest : BasePlatformTestCase() {
       }
     }
   }
+
+
+    fun `test toChatInput`() {
+        val account1 = CodyAccount(name = "account1",  server= SourcegraphServerPath("https://sourcegraph.com"))
+        val account2 = CodyAccount(name = "account2", server= SourcegraphServerPath("https://sourcegraph.com"))
+
+        val chat1 = ChatState("chat1").apply {
+            updatedAt = LocalDateTime.now().toString()
+            messages = mutableListOf(
+                MessageState().apply {
+                    text = "Hello"
+                    speaker = MessageState.SpeakerState.HUMAN
+                },
+                MessageState().apply {
+                    text = "Hi there!"
+                    speaker = MessageState.SpeakerState.ASSISTANT
+                }
+            )
+            llm = LLMState.fromChatModel(
+                Model(
+                    id = "model1",
+                    usage = listOf("chat"),
+                    contextWindow = ModelContextWindow(0, 0, null),
+                    clientSideConfig = null,
+                    provider = "Anthropic",
+                    title = "Claude",
+                    tags = emptyList(),
+                    modelRef = null
+                )
+            )
+        }
+
+        val chat2 = ChatState("chat2").apply {
+            updatedAt = LocalDateTime.now().minusDays(1).toString()
+            messages = mutableListOf(
+                MessageState().apply {
+                    text = "What's up?"
+                    speaker = MessageState.SpeakerState.HUMAN
+                },
+                MessageState().apply {
+                    text = "Not much."
+                    speaker = MessageState.SpeakerState.ASSISTANT
+                }
+            )
+            llm = LLMState.fromChatModel(
+                Model(
+                    id = "model2",
+                    usage = listOf("chat"),
+                    contextWindow = ModelContextWindow(0, 0, null),
+                    clientSideConfig = null,
+                    provider = "Anthropic",
+                    title = "Claude",
+                    tags = emptyList(),
+                    modelRef = null
+                )
+            )
+        }
+
+        val chats = mapOf(
+            account1 to listOf(chat1),
+            account2 to listOf(chat2)
+        )
+
+        val result = ChatHistoryMigration.toChatInput(chats)
+
+        val expectedResult = mapOf(
+            "https://sourcegraph.com-account1" to mapOf(
+                chat1.updatedAt to SerializedChatTranscript(
+                    id = chat1.internalId!!,
+                    lastInteractionTimestamp = chat1.updatedAt!!,
+                    interactions = listOf(
+                        SerializedChatInteraction(
+                            humanMessage = SerializedChatMessage(
+                                text = "Hello",
+                                model = "model1",
+                                speaker = SerializedChatMessage.SpeakerEnum.Human
+                            ),
+                            assistantMessage = SerializedChatMessage(
+                                text = "Hi there!",
+                                model = "model1",
+                                speaker = SerializedChatMessage.SpeakerEnum.Assistant
+                            )
+                        )
+                    )
+                )
+            ),
+            "https://sourcegraph.com-account2" to mapOf(
+                chat2.updatedAt to SerializedChatTranscript(
+                    id = chat2.internalId!!,
+                    lastInteractionTimestamp = chat2.updatedAt!!,
+                    interactions = listOf(
+                        SerializedChatInteraction(
+                            humanMessage = SerializedChatMessage(
+                                text = "What's up?",
+                                model = "model2",
+                                speaker = SerializedChatMessage.SpeakerEnum.Human
+                            ),
+                            assistantMessage = SerializedChatMessage(
+                                text = "Not much.",
+                                model = "model2",
+                                speaker = SerializedChatMessage.SpeakerEnum.Assistant
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        assertEquals(expectedResult, result)
+    }
 }


### PR DESCRIPTION
Adds a migration to import local chat history into the agent to be used in the webview.

Tie in for https://github.com/sourcegraph/cody/pull/5304

## Test plan
Tested manually. Need to add a unit test.