### PR TITLE
Lower Cody CodeActions priority as a temporary workaround

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodeActionQuickFix.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.cody.inspections
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.codeInsight.intention.PriorityAction
+import com.intellij.codeInspection.HintAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
@@ -9,17 +10,17 @@ import com.intellij.psi.PsiFile
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
+import com.sourcegraph.cody.agent.protocol_generated.ProtocolCodeAction
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolLocation
 import com.sourcegraph.cody.edit.actions.EditCodeAction
 
 data class CodeActionQuickFixParams(
-    val title: String,
-    val kind: String?,
+    val action: ProtocolCodeAction,
     val location: ProtocolLocation,
 )
 
 class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
-    IntentionAction, PriorityAction {
+    IntentionAction, HintAction, PriorityAction {
   companion object {
     const val FAMILY_NAME = "Cody Code Action"
   }
@@ -28,11 +29,12 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
 
   override fun getPriority(): PriorityAction.Priority {
     return if (isFixAction()) {
-      PriorityAction.Priority.TOP
+      PriorityAction.Priority.NORMAL
     } else if (isExplainAction()) {
       PriorityAction.Priority.LOW
     } else {
-      PriorityAction.Priority.HIGH
+      if (params.action.isPreferred == true) PriorityAction.Priority.NORMAL
+      else PriorityAction.Priority.LOW
     }
   }
 
@@ -42,17 +44,17 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
   }
 
   override fun getText(): String {
-    return params.title
+    return params.action.title
   }
 
   private fun isFixAction(): Boolean {
     // TODO: Ideally we have some flag indicating the semantic action type
-    return params.title.lowercase() == "ask cody to fix"
+    return params.action.title.lowercase() == "ask cody to fix"
   }
 
   private fun isExplainAction(): Boolean {
     // TODO: Ideally we have some flag indicating the semantic action type
-    return params.title.lowercase() == "ask cody to explain"
+    return params.action.title.lowercase() == "ask cody to explain"
   }
 
   private fun isKnownAction(): Boolean {
@@ -97,7 +99,9 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
                   CodeActions_ProvideParams(location = params.location, triggerKind = "Invoke"))
               .get()
       val action =
-          provideResponse.codeActions.find { it.title == params.title && it.kind == params.kind }
+          provideResponse.codeActions.find {
+            it.title == params.action.title && it.kind == params.action.kind
+          }
       if (action == null) {
         // TODO: handle this with a user notification
         throw Exception("Could not find action")
@@ -106,5 +110,9 @@ class CodeActionQuickFix(private val params: CodeActionQuickFixParams) :
       val result = agent.server.codeActions_trigger(CodeActions_TriggerParams(id = action.id)).get()
       EditCodeAction.completedEditTasks[result.id] = result
     }
+  }
+
+  override fun showHint(editor: Editor): Boolean {
+    return true
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/inspections/CodyFixHighlightPass.kt
@@ -122,7 +122,7 @@ class CodyFixHighlightPass(val file: PsiFile, val editor: Editor) :
                   .get()
           myRangeActions[range] =
               provideResponse.codeActions.map {
-                CodeActionQuickFixParams(title = it.title, kind = it.kind, location = location)
+                CodeActionQuickFixParams(action = it, location = location)
               }
         }
         done.complete(Unit)


### PR DESCRIPTION
Temporarily lowers the default priority of CodeActions so that they don't interfere with common high-priority actions such as Auto Import.

## Test plan
- CI
- Manually verified that CodeActions no longer have a preferred priority for automatic imports.