### PR TITLE
Show new sidebar notification

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/initialization/CodyNewUINotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/CodyNewUINotification.kt
@@ -1,0 +1,68 @@
+package com.sourcegraph.cody.initialization
+
+import com.intellij.ide.util.PropertiesComponent
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.notification.impl.NotificationFullContent
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.ui.jcef.JBCefApp
+import com.sourcegraph.Icons
+import com.sourcegraph.common.BrowserOpener.openInBrowser
+import com.sourcegraph.common.CodyBundle
+import com.sourcegraph.common.NotificationGroups
+
+class CodyNewUINotification :
+    Notification(
+        NotificationGroups.CODY_UPDATES,
+        CodyBundle.getString("notifications.new-sidebar.title"),
+        CodyBundle.getString("notifications.new-sidebar.detail"),
+        NotificationType.IDE_UPDATE),
+    NotificationFullContent {
+
+  init {
+    icon = Icons.CodyLogo
+
+    addAction(
+        object :
+            NotificationAction(
+                CodyBundle.getString("notifications.new-sidebar.see-whats-coming.text")) {
+          override fun actionPerformed(anActionEvent: AnActionEvent, notification: Notification) {
+            openInBrowser(
+                anActionEvent.project,
+                CodyBundle.getString("notifications.new-sidebar.see-whats-coming.link"))
+            notification.expire()
+          }
+        })
+    addAction(
+        object :
+            NotificationAction(
+                CodyBundle.getString("notifications.new-sidebar.do-not-show-again")) {
+          override fun actionPerformed(anActionEvent: AnActionEvent, notification: Notification) {
+            PropertiesComponent.getInstance().setValue(ignoreFlag, true)
+            notification.expire()
+          }
+        })
+  }
+
+  companion object {
+    private val logger = Logger.getInstance(CodyNewUINotification::class.java)
+    private val ignoreFlag: String = CodyBundle.getString("notifications.new-sidebar.ignore")
+
+    fun showIfApplicable(project: Project) {
+      try {
+        val isSupportedIDEVersion = ApplicationInfo.getInstance().build.baselineVersion >= 232
+        if (isSupportedIDEVersion &&
+            JBCefApp.isSupported() &&
+            !PropertiesComponent.getInstance().getBoolean(ignoreFlag)) {
+          CodyNewUINotification().notify(project)
+        }
+      } catch (e: Exception) {
+        logger.warn("Failed to show new UI notification", e)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -49,6 +49,8 @@ class PostStartupActivity : StartupActivity.DumbAware {
 
     CodyStatusService.resetApplication(project)
 
+    CodyNewUINotification.showIfApplicable(project)
+
     val multicaster = EditorFactory.getInstance().eventMulticaster as EditorEventMulticasterEx
     val disposable = CodyAgentService.getInstance(project)
     multicaster.addFocusChangeListener(CodyFocusChangeListener(project), disposable)

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -177,6 +177,12 @@ notifications.edits.editing-not-available.title=Cody can't edit the file
 notifications.edits.editing-not-available.detail=This could be because the file is not writable or Cody has trouble communicating with the editor.
 notifications.cody-connection-timeout.title=Cody's connection timeout
 notifications.cody-connection-timeout.detail=Cody took longer than expected to start. Please run any Cody action or restart Cody to retry.
+notifications.new-sidebar.title=New Cody sidebar is coming
+notifications.new-sidebar.detail=In the next update the Cody sidebar will receive a significant UI overhaul
+notifications.new-sidebar.see-whats-coming.text=See what is coming
+notifications.new-sidebar.see-whats-coming.link=https://sourcegraph.com/blog/cody-jetbrains-6-0-26-release?utm_source=referral&utm_medium=referral&utm_campaign=jetbrains&utm_content=blog
+notifications.new-sidebar.do-not-show-again=Don't show again
+notifications.new-sidebar.ignore=notifications.new-sidebar.ignore
 error.cody-connection-timeout.message=Failed to start Cody in timely manner, please run any Cody action to retry
 error.cody-starting.message=Failed to start Cody
 # Context Filters

--- a/src/main/resources/CodyBundle.properties
+++ b/src/main/resources/CodyBundle.properties
@@ -180,7 +180,7 @@ notifications.cody-connection-timeout.detail=Cody took longer than expected to s
 notifications.new-sidebar.title=New Cody sidebar is coming
 notifications.new-sidebar.detail=In the next update the Cody sidebar will receive a significant UI overhaul
 notifications.new-sidebar.see-whats-coming.text=See what is coming
-notifications.new-sidebar.see-whats-coming.link=https://sourcegraph.com/blog/cody-jetbrains-6-0-26-release?utm_source=referral&utm_medium=referral&utm_campaign=jetbrains&utm_content=blog
+notifications.new-sidebar.see-whats-coming.link=https://sourcegraph.com/blog/cody-jetbrains-6-0-26-release?utm_source=plugins.jetbrains.com&utm_medium=referral&utm_campaign=jetbrains&utm_content=blog
 notifications.new-sidebar.do-not-show-again=Don't show again
 notifications.new-sidebar.ignore=notifications.new-sidebar.ignore
 error.cody-connection-timeout.message=Failed to start Cody in timely manner, please run any Cody action to retry


### PR DESCRIPTION
Fixes CODY-3044

## Changes

Added notification which will be informing users about upcoming UI changes.
It only shows is user IJ platform supports upcoming update.

![image](https://github.com/user-attachments/assets/af4bdce3-3209-4c71-8c69-a3f6ae2effa8)

## Test plan

1. Run with IJ < 2023.2 and make sure notification does NOT appear 
2. Run with IJ >= 2023.2 and make sure notification does appears
3. Click on [See what is coming](https://sourcegraph.com/blog/cody-jetbrains-6-0-26-release?utm_source=referral&utm_medium=referral&utm_campaign=jetbrains&utm_content=blog) and make sure proper page opens up
4. Close IDE
5. Run with IJ >= 2023.2 and make sure notification does appears again, click `Don't show again`
6. Run with IJ >= 2023.2 and make sure notification does NOT appear anymore