### PR TITLE
Drop support for IJ after 231.* on old UI branch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=221.1
-pluginUntilBuild=242.*
+pluginUntilBuild=231.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2022.1


### PR DESCRIPTION
## 

We need to limit upper version of supported IJ platform for all further bugfix releases to make sure the old UI release won't be accidentally pickup by all users.

## Test plan

N/A