### PR TITLE
Add action to toggle on/off offscreen rendering

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -23,7 +23,7 @@ data class CodyApplicationSettings(
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = true,
-    var isOffScreenRenderingEnabled: Boolean = true,
+    var isOffScreenRenderingEnabled: Boolean = false,
 ) : PersistentStateComponent<CodyApplicationSettings> {
   override fun getState(): CodyApplicationSettings = this
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -23,6 +23,7 @@ data class CodyApplicationSettings(
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = true,
+    var isOffScreenRenderingEnabled: Boolean = true,
 ) : PersistentStateComponent<CodyApplicationSettings> {
   override fun getState(): CodyApplicationSettings = this
 
@@ -44,6 +45,7 @@ data class CodyApplicationSettings(
     this.shouldAcceptNonTrustedCertificatesAutomatically =
         state.shouldAcceptNonTrustedCertificatesAutomatically
     this.shouldCheckForUpdates = state.shouldCheckForUpdates
+    this.isOffScreenRenderingEnabled = state.isOffScreenRenderingEnabled
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/config/actions/EnableOffScreenRenderingAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/actions/EnableOffScreenRenderingAction.kt
@@ -1,0 +1,20 @@
+package com.sourcegraph.cody.config.actions
+
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareToggleAction
+import com.sourcegraph.cody.config.CodyApplicationSettings
+
+class EnableOffScreenRenderingAction : DumbAwareToggleAction() {
+  override fun isSelected(e: AnActionEvent): Boolean {
+    return CodyApplicationSettings.instance.isOffScreenRenderingEnabled
+  }
+
+  override fun setSelected(e: AnActionEvent, state: Boolean) {
+    CodyApplicationSettings.instance.isOffScreenRenderingEnabled = state
+  }
+
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.BGT
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -6,7 +6,6 @@ import com.google.gson.JsonParser
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
@@ -34,6 +33,7 @@ import com.sourcegraph.cody.agent.WebviewSetTitleParams
 import com.sourcegraph.cody.agent.protocol.WebviewCreateWebviewPanelParams
 import com.sourcegraph.cody.agent.protocol.WebviewOptions
 import com.sourcegraph.cody.chat.actions.ExportChatsAction.Companion.gson
+import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ui.CodyConfigurable
 import com.sourcegraph.cody.sidebar.WebTheme
@@ -419,9 +419,7 @@ class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserB
       val browser =
           JBCefBrowserBuilder()
               .apply {
-                val isOffScreenRenderingSupported =
-                    ApplicationInfo.getInstance().build.baselineVersion >= 232
-                setOffScreenRendering(isOffScreenRenderingSupported)
+                setOffScreenRendering(CodyApplicationSettings.instance.isOffScreenRenderingEnabled)
                 // TODO: Make this conditional on running in a debug configuration.
                 setEnableOpenDevToolsMenuItem(true)
               }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -405,6 +405,12 @@
                     <keyboard-shortcut replace-all="true" first-keystroke="ctrl shift L" keymap="Mac OS X 10.5+"/>
                     <override-text place="GoToAction" text="Cody: Open Log"/>
                 </action>
+                <action id="cody.enableOffScreenRenderingAction"
+                        class="com.sourcegraph.cody.config.actions.EnableOffScreenRenderingAction"
+                        text="Enable OffScreen Rendering"
+                        description="Enable offScreen rendering in webview">
+                    <override-text place="GoToAction" text="Cody: Enable OffScreen Rendering"/>
+                </action>
             </group>
         </group>
 


### PR DESCRIPTION
## Test plan

1. Hit `shift shift`
2. Start typing "offscreen", you should see "Cody: Enable offscreen rendering"
3. Hit space to turn it on / off

![image](https://github.com/user-attachments/assets/b2566620-b280-4dfd-a120-317b59ff6fde)
