### PR TITLE
Fix issue while createting DataContext

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -6,6 +6,7 @@ import com.google.gson.JsonParser
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
@@ -298,14 +299,12 @@ class WebUIHostImpl(
         // Invoke the Cody "edit" action in JetBrains directly.
         val actionManager = ActionManager.getInstance()
         val action = actionManager.getAction("cody.editCodeAction")
-        action?.actionPerformed(
-            AnActionEvent.createFromAnAction(action, null, "") { dataId ->
-              when (dataId) {
-                CommonDataKeys.EDITOR.name ->
-                    FileEditorManager.getInstance(project).selectedTextEditor
-                else -> null
-              }
-            })
+        val dataContext =
+            FileEditorManager.getInstance(project).selectedTextEditor?.let { editor ->
+              SimpleDataContext.getSimpleContext(CommonDataKeys.EDITOR, editor)
+            } ?: SimpleDataContext.EMPTY_CONTEXT
+
+        action?.actionPerformed(AnActionEvent.createFromAnAction(action, null, "", dataContext))
       }
     } else if (isCommand && id == "cody.status-bar.interacted") {
       runInEdt {


### PR DESCRIPTION
Fixes CODY-3532

## Changes


Form the stacktrace:

> com.intellij.diagnostic.PluginException: 
> Unknown data context kind 'com.sourcegraph.cody.ui.WebUIHostImpl$$Lambda/0x0000000101d9c270'. 
> Use DataManager.getDataContext, CustomizedDataContext, or SimpleDataContext [Plugin: com.sourcegraph.jetbrains]

I couldn't reproduce the issue but I think that change should prevent it form happening.

## Test plan

As per: https://github.com/sourcegraph/jetbrains/issues/2133

1. Have Cody plugin installed in your JB IntelliJ editor
2. Login to Cody with Free/Pro user
3. Make sure there is code available in source code file
4. Relaunch the editor > Try to run Edit code command from command window

**Notice**: I was not able to reproduce