### PR TITLE
Enable JCEF in integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -302,8 +302,7 @@ fun Test.sharedIntegrationTestConfig(buildCodyDir: File, mode: String) {
       "CODY_TEMPERATURE_ZERO" to "true",
       "CODY_TELEMETRY_EXPORTER" to "testing",
       // Fastpass has custom bearer tokens that are difficult to record with Polly
-      "CODY_DISABLE_FASTPATH" to "true",
-      "ide.browser.jcef.headless.enabled" to "true")
+      "CODY_DISABLE_FASTPATH" to "true")
 
   useJUnit()
   dependsOn("buildCody")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -303,7 +303,7 @@ fun Test.sharedIntegrationTestConfig(buildCodyDir: File, mode: String) {
       "CODY_TELEMETRY_EXPORTER" to "testing",
       // Fastpass has custom bearer tokens that are difficult to record with Polly
       "CODY_DISABLE_FASTPATH" to "true",
-  )
+      "ide.browser.jcef.headless.enabled" to "true")
 
   useJUnit()
   dependsOn("buildCody")

--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.editor.ex.EditorEx
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.registry.Registry
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.testFramework.EditorTestUtil
 import com.intellij.testFramework.PlatformTestUtil
@@ -37,6 +38,7 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
 
   override fun setUp() {
     super.setUp()
+    Registry.get("ide.browser.jcef.headless.enabled").setValue(true)
 
     myProject = project
     myFixture.testDataPath = System.getProperty("test.resources.dir")


### PR DESCRIPTION

## Test plan
1. IntelliJ does not complain about the env variable being "false"
