### PR TITLE
Fix llm dropdown visibility for enterprise users (fixes #2028)

### DIFF
--- a/src/main/java/com/sourcegraph/cody/agent/CurrentConfigFeatures.java
+++ b/src/main/java/com/sourcegraph/cody/agent/CurrentConfigFeatures.java
@@ -24,7 +24,7 @@ public final class CurrentConfigFeatures implements ConfigFeaturesObserver {
 
   /** Most recent {@link ConfigFeatures}. */
   private final AtomicReference<ConfigFeatures> features =
-      new AtomicReference<>(new ConfigFeatures(false, false));
+      new AtomicReference<>(new ConfigFeatures(false));
 
   /**
    * Observers that are attached (see {@link #attach}) and receive updates

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -32,27 +32,4 @@ data class WebviewDisposeParams(val handle: String)
 // When the client initiates dispose, this is sent to the server.
 data class WebviewDidDisposeParams(val handle: String)
 
-data class ConfigFeatures(val attribution: Boolean, val serverSentModels: Boolean)
-
-data class EnhancedContextContextT(val groups: List<ContextGroup>)
-
-data class ContextGroup(
-    val dir: String? = null, // URI
-    val displayName: String,
-    val providers: List<ContextProvider>
-)
-
-// This is a subset of the ContextProvider type in lib/shared/src/codebase-context/context-status.ts
-// It covers remote search repositories.
-data class ContextProvider(
-    val kind: String, // "embeddings", "search"
-
-    // if kind is "search"
-    val type: String? = null, // "local", "remote"
-
-    // if kind is "search" and type is "remote"
-    val state: String? = null, // "ready", "no-match",
-    val id: String? = null,
-    val inclusion: String? = null, // "auto" or "manual"
-    val isIgnored: Boolean? = null,
-)
+data class ConfigFeatures(val serverSentModels: Boolean)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.chat.ui
 
 import com.intellij.openapi.application.invokeLater
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.ui.MutableCollectionComboBoxModel
@@ -30,7 +31,7 @@ class LlmDropdown(
     private val chatModelFromState: Model?,
     private val model: String? = null
 ) : ComboBox<Model>(MutableCollectionComboBoxModel()) {
-  private var hasServerSentModels = false
+  private var hasServerSentModels = project.service<CurrentConfigFeatures>().get().serverSentModels
 
   init {
     renderer = LlmComboBoxRenderer(this)

--- a/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/CurrentConfigFeaturesTest.kt
@@ -17,7 +17,7 @@ class CurrentConfigFeaturesTest {
   fun `observer is notified`() {
     val current = CurrentConfigFeatures()
     val observer = FakeObserver()
-    val expected = ConfigFeatures(attribution = true, serverSentModels = true)
+    val expected = ConfigFeatures(serverSentModels = true)
     current.attach(observer)
     current.update(expected)
     assertThat(observer.features, hasItems(expected))
@@ -33,7 +33,7 @@ class CurrentConfigFeaturesTest {
     await until
         {
           val beforeCount = cancelledObserver.features.size
-          current.update(ConfigFeatures(attribution = true, serverSentModels = true))
+          current.update(ConfigFeatures(serverSentModels = true))
           val afterCount = cancelledObserver.features.size
           afterCount == beforeCount
         }
@@ -50,12 +50,12 @@ class CurrentConfigFeaturesTest {
     await until
         {
           val beforeCount = cancelledObserver.features.size
-          current.update(ConfigFeatures(attribution = true, serverSentModels = true))
+          current.update(ConfigFeatures(serverSentModels = true))
           val afterCount = cancelledObserver.features.size
           afterCount == beforeCount
         }
     val beforeCount = activeObserver.features.size
-    current.update(ConfigFeatures(attribution = true, serverSentModels = true))
+    current.update(ConfigFeatures(serverSentModels = true))
     val afterCount = activeObserver.features.size
     assertEquals(beforeCount + 1, afterCount)
   }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2028.
Fixes https://linear.app/sourcegraph/issue/CODY-3423/jetbrains-llm-dropdown-is-missing-for-edit-code-for-enterprise-user.


## Test plan
1. Log in to an enterprise account.
2. Trigger Inline Edit.
3. Verify LLM dropdown is visible.

### The look

<img width="753" alt="image" src="https://github.com/user-attachments/assets/230b2846-6c94-459c-a51d-a77ff70fed6f">

