### PR TITLE
Fix crash in autocomplete (wrong index) (fixes #2107)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -42,14 +42,14 @@ class CodyFormatter {
         // Fix for the IJ formatting bug which removes spaces even before the given formatting
         // range.
         val existingStart = appendedString.substring(0, cursor)
-        val endIndexInPsiFile = min(cursor, psiFile.text.length)
-        val formattedStart = psiFile.text.substring(0, endIndexInPsiFile)
+        val boundedCursorPosition = min(cursor, psiFile.text.length)
+        val formattedStart = psiFile.text.substring(0, boundedCursorPosition)
         val startOfDiff = existingStart.zip(formattedStart).indexOfFirst { (e, f) -> e != f }
 
         val formattedText =
             if (startOfDiff != -1) {
               val addition = formattedStart.substring(startOfDiff)
-              existingStart + addition + psiFile.text.substring(endIndexInPsiFile)
+              existingStart + addition + psiFile.text.substring(boundedCursorPosition)
             } else psiFile.text
         return formattedText.substring(
             range.startOffset, range.endOffset + formattedText.length - document.textLength)

--- a/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyFormatter.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
+import kotlin.math.min
 
 class CodyFormatter {
   companion object {
@@ -41,13 +42,14 @@ class CodyFormatter {
         // Fix for the IJ formatting bug which removes spaces even before the given formatting
         // range.
         val existingStart = appendedString.substring(0, cursor)
-        val formattedStart = psiFile.text.substring(0, cursor)
+        val endIndexInPsiFile = min(cursor, psiFile.text.length)
+        val formattedStart = psiFile.text.substring(0, endIndexInPsiFile)
         val startOfDiff = existingStart.zip(formattedStart).indexOfFirst { (e, f) -> e != f }
 
         val formattedText =
             if (startOfDiff != -1) {
               val addition = formattedStart.substring(startOfDiff)
-              existingStart + addition + psiFile.text.substring(cursor)
+              existingStart + addition + psiFile.text.substring(endIndexInPsiFile)
             } else psiFile.text
         return formattedText.substring(
             range.startOffset, range.endOffset + formattedText.length - document.textLength)


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2107.

## Test plan
Hard to repro. See the original issue.
