### PR TITLE
Add handling for account management/switching webview action

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@ javaVersion=17
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency=false
+kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 # See https://docs.gradle.org/current/userguide/build_cache.html#sec:build_cache_configure
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=ba684ec3c3cc6d786647a296c0f13c255dd6dd28
-kotlin.daemon.jvmargs=-Xmx2g -Xms500m
+cody.commit=5e7062c2157e0e22a693b22ff0f5b4511e205286

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -251,7 +251,6 @@ class CodyAuthenticationManager(val project: Project) :
   override fun loadState(state: AccountState) {
     val initialAccount =
         state.activeAccountId?.let { id -> accountManager.accounts.find { it.id == id } }
-            ?: getAccounts().firstOrNull()
     if (initialAccount != null) {
       setActiveAccount(initialAccount)
     }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -38,6 +38,7 @@ import com.sourcegraph.cody.agent.protocol.WebviewOptions
 import com.sourcegraph.cody.chat.actions.ExportChatsAction.Companion.gson
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.config.ui.AccountConfigurable
 import com.sourcegraph.cody.config.ui.CodyConfigurable
 import com.sourcegraph.cody.sidebar.WebTheme
 import com.sourcegraph.cody.sidebar.WebThemeController
@@ -298,10 +299,16 @@ class WebUIHostImpl(
     val id = decodedJson?.get("id")?.asString
     val arg = decodedJson?.get("arg")?.asString
 
-    if (command == "auth") {
-      val authKind = decodedJson.get("authKind")?.asString
-      if (authKind == "signout") {
-        CodyAuthenticationManager.getInstance(project).setActiveAccount(null)
+    if ((command == "auth" && decodedJson.get("authKind")?.asString == "signout" ||
+        command == "cody.auth.signout")) {
+      CodyAuthenticationManager.getInstance(project).setActiveAccount(null)
+    } else if (isCommand && id == "cody.auth.switchAccount") {
+      runInEdt {
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, AccountConfigurable::class.java)
+      }
+    } else if (isCommand && id == "cody.status-bar.interacted") {
+      runInEdt {
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, CodyConfigurable::class.java)
       }
     } else if (isCommand && id == "cody.action.command" && arg == "edit") {
       // TODO: Delete this intercept when Cody edits UI is abstracted so JetBrains' native UI can be
@@ -316,10 +323,6 @@ class WebUIHostImpl(
             } ?: SimpleDataContext.EMPTY_CONTEXT
 
         action?.actionPerformed(AnActionEvent.createFromAnAction(action, null, "", dataContext))
-      }
-    } else if (isCommand && id == "cody.status-bar.interacted") {
-      runInEdt {
-        ShowSettingsUtil.getInstance().showSettingsDialog(project, CodyConfigurable::class.java)
       }
     } else {
       CodyAgentService.withAgent(project) {

--- a/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/CodyToolWindowFactory.kt
@@ -299,8 +299,8 @@ class WebUIHostImpl(
     val id = decodedJson?.get("id")?.asString
     val arg = decodedJson?.get("arg")?.asString
 
-    if ((command == "auth" && decodedJson.get("authKind")?.asString == "signout" ||
-        command == "cody.auth.signout")) {
+    if ((command == "auth" && decodedJson.get("authKind")?.asString == "signout") ||
+        (isCommand && id == "cody.auth.signout")) {
       CodyAuthenticationManager.getInstance(project).setActiveAccount(null)
     } else if (isCommand && id == "cody.auth.switchAccount") {
       runInEdt {


### PR DESCRIPTION
Fixes CODY-3346
Fixes https://github.com/sourcegraph/jetbrains/issues/2102

## Changes

Adds handling for account management/switching webview action

## Test plan

Run with this CODY PR: https://github.com/sourcegraph/cody/pull/5362

**For free/pro account:**
1. Go to the Account panel and check if both `Switch Account...` and `Manage Account` options are present
2. Make sure `Manage Account` redirects you to the account web management page
3. Make sure `Switch Account...`  opens native account management panel

**For free/pro account:**
1. Go to the Account panel and check if both `Switch Account...` and `Manage Account` options are present
2. Make sure `Manage Account` is not visible
3. Make sure `Switch Account...`  opens native account management panel

![image](https://github.com/user-attachments/assets/5fe32017-ddfe-46c0-8a66-d2ce523bf70e)