### PR TITLE
Make offscreen rendering a default

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyApplicationSettings.kt
@@ -23,7 +23,7 @@ data class CodyApplicationSettings(
     var isOnboardingGuidanceDismissed: Boolean = false,
     var shouldAcceptNonTrustedCertificatesAutomatically: Boolean = false,
     var shouldCheckForUpdates: Boolean = true,
-    var isOffScreenRenderingEnabled: Boolean = false,
+    var isOffScreenRenderingEnabled: Boolean = true,
 ) : PersistentStateComponent<CodyApplicationSettings> {
   override fun getState(): CodyApplicationSettings = this
 


### PR DESCRIPTION
## Test plan

1. Run IDE
2. Check if problems mentioned there: https://linear.app/sourcegraph/issue/CODY-3545/decide-if-we-should-go-with-offscreenrendering-enabled-or-disabled in the section **OffScreenRendering disabled** are gone