### PR TITLE
fix/Webview: Read/write providers, views consistently.

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/WebViewViewToolWindow.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/WebViewViewToolWindow.kt
@@ -105,17 +105,23 @@ class WebviewViewService(val project: Project) {
   )
 
   fun registerProvider(id: String, retainContextWhenHidden: Boolean) {
-    var provider = Provider(id, ProviderOptions(retainContextWhenHidden))
-    providers[id] = provider
-    val viewHost = views[id] ?: return
+    val viewHost: WebviewHost
+    val provider = Provider(id, ProviderOptions(retainContextWhenHidden))
+    synchronized (providers) {
+      providers[id] = provider
+      viewHost = views[id] ?: return
+    }
     runInEdt { provideView(viewHost, provider) }
   }
 
   // TODO: Implement 'dispose' for registerWebviewViewProvider.
 
   private fun provideHost(viewHost: WebviewHost) {
-    views[viewHost.id] = viewHost
-    val provider = providers[viewHost.id] ?: return
+    val provider: Provider
+    synchronized(providers) {
+      views[viewHost.id] = viewHost
+      provider = providers[viewHost.id] ?: return
+    }
     runInEdt { provideView(viewHost, provider) }
   }
 
@@ -149,12 +155,11 @@ class WebviewViewService(val project: Project) {
     }
   }
 
-  // TODO: Consider moving this to a separate class.
+  // TODO: Move this to a separate class or rename this class. WebviewPanels are not WebviewViews.
   fun createPanel(
       proxy: WebUIProxy,
       params: WebviewCreateWebviewPanelParams
   ): WebviewViewDelegate? {
-    // TODO: Give these files unique names.
     val file = LightVirtualFile("Cody")
     file.fileType = WebPanelFileType.INSTANCE
     file.putUserData(WebPanelTabTitleProvider.WEB_PANEL_TITLE_KEY, params.title)

--- a/src/main/kotlin/com/sourcegraph/cody/ui/WebViewViewToolWindow.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/WebViewViewToolWindow.kt
@@ -107,7 +107,7 @@ class WebviewViewService(val project: Project) {
   fun registerProvider(id: String, retainContextWhenHidden: Boolean) {
     val viewHost: WebviewHost
     val provider = Provider(id, ProviderOptions(retainContextWhenHidden))
-    synchronized (providers) {
+    synchronized(providers) {
       providers[id] = provider
       viewHost = views[id] ?: return
     }


### PR DESCRIPTION
Fixes a race where we collect two pieces of data from two maps with no coordination.

The race manifest by running the "commit" step when both pieces of data are available twice, hitting an assertion. However it is probably also possible to have a different outcome where nobody does the commit step.

The fix simply guards access to both maps under the monitor for the first map.

Fixes CODY-3569

## Test plan

Tested manually:

- Start the extension and open the sidebar.
- Spam the "new chat" action (Ctrl-Alt-0 on Windows for example.)