### PR TITLE
CODY-3538: Fixed chat-id bug in migration

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -1,9 +1,5 @@
 package com.sourcegraph.cody.config.migration
 
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ImportParams
@@ -15,7 +11,6 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.MessageState
-
 
 // Copies chat history from locally stored jetbrains state to the cody agent
 // so historical chats can be viewed in the cody webview
@@ -46,31 +41,12 @@ object ChatHistoryMigration {
   }
 
   private fun toSerializedChatTranscript(chat: ChatState): SerializedChatTranscript? {
-      val lastInteractionTimestamp = convertDateFormat(chat.updatedAt)
-
-      if (lastInteractionTimestamp == null) {
-          return null
-      }
     return SerializedChatTranscript(
-        id = lastInteractionTimestamp,
-        lastInteractionTimestamp = lastInteractionTimestamp,
+        id = chat.updatedAt ?: return null,
+        lastInteractionTimestamp = chat.updatedAt ?: return null,
         interactions = toSerializedInteractions(chat.messages, chat.llm?.model),
     )
   }
-}
-
-// Converts to UTC string
-fun convertDateFormat(inputDate: String?): String? {
-    if (inputDate == null) {
-        return null
-    }
-    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    val outputFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ENGLISH).withZone(ZoneOffset.UTC)
-
-    val dateTime = LocalDateTime.parse(inputDate, inputFormatter)
-    val instant = dateTime.toInstant(ZoneOffset.UTC)
-
-    return outputFormatter.format(instant)
 }
 
 private fun toSerializedInteractions(

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatHistoryMigration.kt
@@ -1,5 +1,9 @@
 package com.sourcegraph.cody.config.migration
 
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ImportParams
@@ -11,6 +15,7 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.history.HistoryService
 import com.sourcegraph.cody.history.state.ChatState
 import com.sourcegraph.cody.history.state.MessageState
+
 
 // Copies chat history from locally stored jetbrains state to the cody agent
 // so historical chats can be viewed in the cody webview
@@ -33,20 +38,39 @@ object ChatHistoryMigration {
     return chats
         .map { (account, chats) ->
           val serializedChats = chats.mapNotNull(::toSerializedChatTranscript)
-          val byId = serializedChats.associateBy { it.id }
+          val byTimestamp = serializedChats.associateBy { it.lastInteractionTimestamp }
 
-          "${account.server.url}-${account.name}" to byId
+          "${account.server.url}-${account.name}" to byTimestamp
         }
         .toMap()
   }
 
   private fun toSerializedChatTranscript(chat: ChatState): SerializedChatTranscript? {
+      val lastInteractionTimestamp = convertDateFormat(chat.updatedAt)
+
+      if (lastInteractionTimestamp == null) {
+          return null
+      }
     return SerializedChatTranscript(
-        id = chat.internalId ?: return null,
-        lastInteractionTimestamp = chat.updatedAt ?: return null,
+        id = lastInteractionTimestamp,
+        lastInteractionTimestamp = lastInteractionTimestamp,
         interactions = toSerializedInteractions(chat.messages, chat.llm?.model),
     )
   }
+}
+
+// Converts to UTC string
+fun convertDateFormat(inputDate: String?): String? {
+    if (inputDate == null) {
+        return null
+    }
+    val inputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
+    val outputFormatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ENGLISH).withZone(ZoneOffset.UTC)
+
+    val dateTime = LocalDateTime.parse(inputDate, inputFormatter)
+    val instant = dateTime.toInstant(ZoneOffset.UTC)
+
+    return outputFormatter.format(instant)
 }
 
 private fun toSerializedInteractions(

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -64,7 +64,7 @@ class SettingsMigration : Activity {
 
     DeprecatedChatLlmMigration.migrate(project)
     ChatTagsLlmMigration.migrate(project)
-    RunOnceUtil.runOnceForProject(project, "CodyMigrateChatHistory") {
+    RunOnceUtil.runOnceForProject(project, "CodyMigrateChatHistory-v2") {
       ChatHistoryMigration.migrate(project)
     }
   }

--- a/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/config/SettingsMigrationTest.kt
@@ -436,9 +436,9 @@ class SettingsMigrationTest : BasePlatformTestCase() {
         mapOf(
             "https://sourcegraph.com-account1" to
                 mapOf(
-                    chat1.internalId to
+                    chat1.updatedAt!! to
                         SerializedChatTranscript(
-                            id = chat1.internalId!!,
+                            id = chat1.updatedAt!!,
                             lastInteractionTimestamp = chat1.updatedAt!!,
                             interactions =
                                 listOf(
@@ -457,9 +457,9 @@ class SettingsMigrationTest : BasePlatformTestCase() {
                                                         .Assistant))))),
             "https://sourcegraph.com-account2" to
                 mapOf(
-                    chat2.internalId to
+                    chat2.updatedAt to
                         SerializedChatTranscript(
-                            id = chat2.internalId!!,
+                            id = chat2.updatedAt!!,
                             lastInteractionTimestamp = chat2.updatedAt!!,
                             interactions =
                                 listOf(


### PR DESCRIPTION
Tie in for https://github.com/sourcegraph/cody/pull/5407. Properly constructs chat transcripts and during import.

## Test plan
Updated unit tests