### PR TITLE
fix/Windows: Open Cody Settings Editor should not pass file paths as URIs

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/actions/OpenCodySettingsEditorAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/actions/OpenCodySettingsEditorAction.kt
@@ -21,7 +21,7 @@ class OpenCodySettingsEditorAction : DumbAwareEDTAction("Open Cody Settings Edit
 
     val settingsVf =
         CodyEditorUtil.createFileOrScratchFromUntitled(
-            project, ConfigUtil.getSettingsFile(project).toString(), content = "{\n  \n}")
+            project, ConfigUtil.getSettingsFile(project).toUri().toString(), content = "{\n  \n}")
             ?: run {
               logger.warn("Could not create settings file")
               return


### PR DESCRIPTION
Fixes #2201

## Test plan

Manually tested:

1. Open the Cody sidebar.
2. ... , Open Cody Settings Editor

Verify this opens a file with some curly braces instead of throwing an exception.