### PR TITLE
Fix windows build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -235,9 +235,9 @@ fun Test.sharedIntegrationTestConfig(buildCodyDir: File, mode: String) {
 val isWindows = System.getProperty("os.name").lowercase().contains("win")
 val pnpmPath =
     if (isWindows) {
-      "pnpm.cmd"
+      arrayOf("cmd", "/k", "pnpm")
     } else {
-      "pnpm"
+      arrayOf("pnpm")
     }
 
 tasks {
@@ -268,15 +268,15 @@ tasks {
     val sourcegraphDir = unzipCodeSearch()
     exec {
       workingDir(sourcegraphDir.toString())
-      commandLine(pnpmPath, "install", "--frozen-lockfile")
+      commandLine(*pnpmPath, "install", "--frozen-lockfile", "--fix-lockfile")
     }
     exec {
       workingDir(sourcegraphDir.toString())
-      commandLine(pnpmPath, "generate")
+      commandLine(*pnpmPath, "generate")
     }
     val jetbrainsDir = sourcegraphDir.resolve("client").resolve("jetbrains")
     exec {
-      commandLine(pnpmPath, "build")
+      commandLine(*pnpmPath, "build")
       workingDir(jetbrainsDir)
     }
     val buildOutput =
@@ -328,12 +328,12 @@ tasks {
     println("Using cody from codyDir=$codyDir")
     exec {
       workingDir(codyDir)
-      commandLine(pnpmPath, "install", "--frozen-lockfile")
+      commandLine(*pnpmPath, "install", "--frozen-lockfile")
     }
     val agentDir = codyDir.resolve("agent")
     exec {
       workingDir(agentDir)
-      commandLine(pnpmPath, "run", "build")
+      commandLine(*pnpmPath, "run", "build")
     }
     copy {
       from(agentDir.resolve("dist"))


### PR DESCRIPTION
## Changes

Finally fixes windows gradle/pnpm build.

Couple of additional deps I had to install manually (but it could be due to my `node` version or some other setup detail):
`npx install gulp`
`npx install gulp-cli`
`npx install cross-env`
`npx update-browserlist-db@latest` // possibly not needed

Also, windows comandline can be more picky, e.g.
`.\gradlew :runIDE -PplatformRuntimeVersion='2024.1.2'`
(notice '' around a version)

## Test plan

N/A