### PR TITLE
Fix shortcuts for Edit Code on Windows

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.edit.actions
 
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.diagnostic.Logger
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.edit.EditCommandPrompt
@@ -13,6 +14,13 @@ class EditCodeAction :
         logger.warn("EditCodeAction invoked with null project")
       }
     }) {
+
+  override fun update(event: AnActionEvent) {
+    super.update(event)
+    val commandPrompt = EditCommandPrompt.EDIT_COMMAND_PROMPT_KEY.get(event.project)
+    event.presentation.isEnabledAndVisible = commandPrompt?.isVisible != true
+  }
+
   companion object {
     val logger = Logger.getInstance(EditCodeAction::class.java)
     val completedEditTasks = ConcurrentHashMap<String, EditTask>()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -243,7 +243,7 @@
                         class="com.sourcegraph.cody.edit.actions.EditCodeAction"
                         description="Opens the Edit Code dialog"
                         text="Edit Code...">
-                    <keyboard-shortcut replace-all="true" first-keystroke="alt ENTER" keymap="$default"/>
+                    <keyboard-shortcut replace-all="true" first-keystroke="ctrl ENTER" keymap="$default"/>
                     <keyboard-shortcut replace-all="true" first-keystroke="ctrl alt ENTER" keymap="Mac OS X 10.5+"/>
                     <override-text place="GoToAction" text="Cody: Edit Code..."/>
                 </action>

--- a/src/test/kotlin/com/sourcegraph/cody/KeyboardShortcutTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/KeyboardShortcutTest.kt
@@ -25,7 +25,7 @@ class KeyboardShortcutTest : BasePlatformTestCase() {
             "cody.command.Smell" to arrayOf("ctrl alt 2", "ctrl alt 2"),
 
             // This command also handles cody.inlineEditRetryAction:
-            "cody.editCodeAction" to arrayOf("alt ENTER", "ctrl alt ENTER"),
+            "cody.editCodeAction" to arrayOf("ctrl ENTER", "ctrl alt ENTER"),
             "cody.documentCodeAction" to arrayOf("alt H", "ctrl alt H"),
             "cody.testCodeAction" to arrayOf("alt G", "ctrl alt G"),
             "cody.fixup.codelens.diff" to arrayOf("alt D", "ctrl alt K"),


### PR DESCRIPTION
## Changes

Removes annoying `Alt + Enter` shortcut and unifies both bringing `Edit Code` prompt and confirming an edit into a single shortcut.

## Test plan

1. Select some code in the editor
2. Hit `Ctrl Enter` to show `Edit Code` prompt
3. Add some instruction, e.g. to add comments
4. Hit `Ctrl Enter` again to confirm the changes and do an edit 