### PR TITLE
Fix Cody failures when saving files with schemes not supported by NIO

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsChangeListener.kt
@@ -4,13 +4,17 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.LocalFileSystem
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.config.ConfigUtil
 
 class CodySettingsChangeListener(private val project: Project) : FileDocumentManagerListener {
   override fun beforeDocumentSaving(document: Document) {
     val currentFile = FileDocumentManager.getInstance().getFile(document)
-    if (currentFile?.toNioPath() == ConfigUtil.getSettingsFile(project)) {
+    val configFile =
+        LocalFileSystem.getInstance()
+            .refreshAndFindFileByNioFile(ConfigUtil.getSettingsFile(project))
+    if (currentFile == configFile) {
       CodyAgentService.getInstance(project).restartAgent(project)
       // TODO: we should instead call `extensionConfiguration_didChange` there:
       // `it.server.extensionConfiguration_didChange(ConfigUtil.getAgentConfiguration(project,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2209

## Changes 

We should not use `toNioPath`... ever. Not all IJ files have propen NIO represenataion.
Generally we should try to always stick stick to `VirtualFiles`.

## Test plan

Unfortunately I found no easy way to reproduce it...yet.
