### PR TITLE
Add CodyInlineCompletionProvider as an alternative for inlay completions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -507,8 +507,7 @@ tasks {
 
   buildPlugin {
     dependsOn(project.tasks.getByPath("buildCody"))
-    val get = composedJar.get()
-    get.exclude("com/intellij/codeInsight/inline/completion/**")
+    composedJar.get().exclude("com/intellij/codeInsight/inline/completion/**")
     from(
         fileTree(buildCodyDir) {
           include("*")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -478,7 +478,7 @@ tasks {
           "cody-agent.panic-when-out-of-sync" to
               (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "true"),
           "cody-agent.fullDocumentSyncEnabled" to
-              (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "true"),
+              (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "false"),
           "cody.autocomplete.enableFormatting" to
               (project.property("cody.autocomplete.enableFormatting") ?: "true"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,14 +171,6 @@ kotlin {
   }
 }
 
-sourceSets {
-  create("integrationTest") {
-    kotlin.srcDir("src/integrationTest/kotlin")
-    compileClasspath += main.get().output + configurations.testCompileClasspath.get()
-    runtimeClasspath += compileClasspath + configurations.testRuntimeClasspath.get()
-  }
-}
-
 fun download(url: String, output: File) {
   if (output.exists()) {
     println("Cached $output")
@@ -588,6 +580,14 @@ tasks {
   }
 
   test { dependsOn(project.tasks.getByPath("buildCody")) }
+
+  sourceSets {
+    create("integrationTest") {
+      kotlin.srcDir("src/integrationTest/kotlin")
+      compileClasspath += main.get().output + configurations.testCompileClasspath.get()
+      runtimeClasspath += compileClasspath + configurations.testRuntimeClasspath.get()
+    }
+  }
 
   register<Test>("integrationTest") {
     description = "Runs the integration tests."

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -478,7 +478,7 @@ tasks {
           "cody-agent.panic-when-out-of-sync" to
               (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "true"),
           "cody-agent.fullDocumentSyncEnabled" to
-              (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "false"),
+              (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "true"),
           "cody.autocomplete.enableFormatting" to
               (project.property("cody.autocomplete.enableFormatting") ?: "true"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,7 +152,7 @@ spotless {
     ktfmt()
     trimTrailingWhitespace()
     target("src/**/*.kt")
-    targetExclude("src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**/*.kt")
+    targetExclude("src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/**")
     toggleOffOn()
   }
 }
@@ -168,6 +168,14 @@ kotlin {
   jvmToolchain {
     languageVersion.set(JavaLanguageVersion.of(javaVersion.toInt()))
     vendor = JvmVendorSpec.JETBRAINS
+  }
+}
+
+sourceSets {
+  create("integrationTest") {
+    kotlin.srcDir("src/integrationTest/kotlin")
+    compileClasspath += main.get().output + configurations.testCompileClasspath.get()
+    runtimeClasspath += compileClasspath + configurations.testRuntimeClasspath.get()
   }
 }
 
@@ -499,6 +507,8 @@ tasks {
 
   buildPlugin {
     dependsOn(project.tasks.getByPath("buildCody"))
+    val get = composedJar.get()
+    get.exclude("com/intellij/codeInsight/inline/completion/**")
     from(
         fileTree(buildCodyDir) {
           include("*")
@@ -579,19 +589,6 @@ tasks {
   }
 
   test { dependsOn(project.tasks.getByPath("buildCody")) }
-
-  configurations {
-    create("integrationTestImplementation") { extendsFrom(configurations.testImplementation.get()) }
-    create("integrationTestRuntimeClasspath") { extendsFrom(configurations.testRuntimeOnly.get()) }
-  }
-
-  sourceSets {
-    create("integrationTest") {
-      kotlin.srcDir("src/integrationTest/kotlin")
-      compileClasspath += main.get().output + configurations.testCompileClasspath.get()
-      runtimeClasspath += compileClasspath + configurations.testRuntimeClasspath.get()
-    }
-  }
 
   register<Test>("integrationTest") {
     description = "Runs the integration tests."

--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionEvent.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionEvent.kt
@@ -1,0 +1,72 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
+package com.intellij.codeInsight.inline.completion
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.editor.Caret
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.UserDataHolderBase
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.util.PsiUtilBase
+import com.intellij.util.concurrency.annotations.RequiresBlockingContext
+
+class InlineCompletionRequest(
+    val event: InlineCompletionEvent,
+    val file: PsiFile,
+    val editor: Editor,
+    val document: Document,
+    val startOffset: Int,
+    val endOffset: Int,
+    val lookupElement: LookupElement? = null,
+) : UserDataHolderBase()
+
+/**
+ * Be aware that creating your own event is unsafe for a while and might face compatibility issues
+ */
+interface InlineCompletionEvent {
+
+  @RequiresBlockingContext fun toRequest(): InlineCompletionRequest?
+
+  /** A class representing a direct call in the code editor by [InsertInlineCompletionAction]. */
+  class DirectCall(
+      val editor: Editor,
+      val caret: Caret,
+      val context: DataContext? = null,
+  ) : InlineCompletionEvent {
+    override fun toRequest(): InlineCompletionRequest? {
+      val offset = runReadAction { caret.offset }
+      val project = editor.project ?: return null
+      val file = getPsiFile(caret, project) ?: return null
+      return InlineCompletionRequest(this, file, editor, editor.document, offset, offset)
+    }
+  }
+}
+
+@RequiresBlockingContext
+private fun getPsiFile(caret: Caret, project: Project): PsiFile? {
+  return runReadAction {
+    val file =
+        PsiDocumentManager.getInstance(project).getPsiFile(caret.editor.document)
+            ?: return@runReadAction null
+    // * [PsiUtilBase] takes into account injected [PsiFile] (like in Jupyter Notebooks)
+    // * However, it loads a file into the memory, which is expensive
+    // * Some tests forbid loading a file when tearing down
+    // * On tearing down, Lookup Cancellation happens, which causes the event
+    // * Existence of [treeElement] guarantees that it's in the memory
+    if (file.isLoadedInMemory()) {
+      PsiUtilBase.getPsiFileInEditor(caret, project)
+    } else {
+      file
+    }
+  }
+}
+
+private fun PsiFile.isLoadedInMemory(): Boolean {
+  return (this as? PsiFileImpl)?.treeElement != null
+}

--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionSuggestion.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionSuggestion.kt
@@ -1,0 +1,34 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
+package com.intellij.codeInsight.inline.completion
+
+import com.intellij.codeInsight.inline.completion.elements.InlineCompletionElement
+import com.intellij.openapi.util.UserDataHolderBase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+
+/**
+ * Abstract class representing an inline completion suggestion.
+ *
+ * Provides the suggestion flow for generating only one suggestion.
+ *
+ * @see InlineCompletionElement
+ */
+abstract class InlineCompletionSuggestion : UserDataHolderBase() {
+  abstract val suggestionFlow: Flow<InlineCompletionElement>
+
+  class Default(override val suggestionFlow: Flow<InlineCompletionElement>) :
+      InlineCompletionSuggestion()
+
+  companion object {
+    fun empty(): InlineCompletionSuggestion = Default(emptyFlow())
+
+    fun withFlow(
+        buildSuggestion: suspend FlowCollector<InlineCompletionElement>.() -> Unit
+    ): InlineCompletionSuggestion {
+      return Default(flow(buildSuggestion))
+    }
+  }
+}

--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionElement.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionElement.kt
@@ -1,0 +1,5 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
+package com.intellij.codeInsight.inline.completion.elements
+
+interface InlineCompletionElement

--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionGrayTextElement.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionGrayTextElement.kt
@@ -1,0 +1,5 @@
+// Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
+package com.intellij.codeInsight.inline.completion.elements
+
+class InlineCompletionGrayTextElement(val text: String) : InlineCompletionElement

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -15,7 +15,6 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.InlayModel
 import com.intellij.openapi.editor.colors.EditorColorsManager
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
@@ -28,29 +27,15 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.AutocompleteItem
-import com.sourcegraph.cody.agent.protocol.AutocompleteParams
 import com.sourcegraph.cody.agent.protocol.AutocompleteResult
-import com.sourcegraph.cody.agent.protocol.AutocompleteTriggerKind
 import com.sourcegraph.cody.agent.protocol.CompletionItemParams
-import com.sourcegraph.cody.agent.protocol.ErrorCode
-import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
-import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.uriFor
-import com.sourcegraph.cody.agent.protocol.RateLimitError.Companion.toRateLimitError
-import com.sourcegraph.cody.agent.protocol.SelectedCompletionInfo
-import com.sourcegraph.cody.agent.protocol_extensions.Position
-import com.sourcegraph.cody.agent.protocol_generated.Position
-import com.sourcegraph.cody.agent.protocol_generated.Range
+import com.sourcegraph.cody.autocomplete.Utils.triggerAutocompleteAsync
 import com.sourcegraph.cody.autocomplete.render.AutocompleteRendererType
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteBlockElementRenderer
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteElementRenderer
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteSingleLineRenderer
 import com.sourcegraph.cody.autocomplete.render.InlayModelUtil.getAllInlaysForEditor
 import com.sourcegraph.cody.config.CodyAuthenticationManager
-import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
-import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
-import com.sourcegraph.cody.statusbar.CodyStatus
-import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
@@ -58,7 +43,6 @@ import com.sourcegraph.cody.vscode.IntelliJTextDocument
 import com.sourcegraph.cody.vscode.TextDocument
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.CodyBundle.fmt
-import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil.isCodyEnabled
 import com.sourcegraph.config.UserLevelConfig
 import com.sourcegraph.utils.CodyEditorUtil.getAllOpenEditors
@@ -68,13 +52,8 @@ import com.sourcegraph.utils.CodyEditorUtil.isCommandExcluded
 import com.sourcegraph.utils.CodyEditorUtil.isEditorValidForAutocomplete
 import com.sourcegraph.utils.CodyEditorUtil.isImplicitAutocompleteEnabledForEditor
 import com.sourcegraph.utils.CodyFormatter
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.stream.Collectors
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
 /** Responsible for triggering and clearing inline code completions (the autocomplete feature). */
 @Service
@@ -199,110 +178,11 @@ class CodyAutocompleteManager {
         triggerKind,
         cancellationToken,
         lookupString,
-        originalText)
-  }
-
-  /** Asynchronously triggers auto-complete for the given editor and offset. */
-  private fun triggerAutocompleteAsync(
-      project: Project,
-      editor: Editor,
-      offset: Int,
-      textDocument: TextDocument,
-      triggerKind: InlineCompletionTriggerKind,
-      cancellationToken: CancellationToken,
-      lookupString: String?,
-      originalText: String
-  ): CompletableFuture<Void?> {
-    val position = textDocument.positionAt(offset)
-    val lineNumber = editor.document.getLineNumber(offset)
-    var startPosition = 0
-    if (!lookupString.isNullOrEmpty()) {
-      startPosition = findLastCommonSuffixElementPosition(originalText, lookupString)
-    }
-
-    val virtualFile =
-        FileDocumentManager.getInstance().getFile(editor.document)
-            ?: return CompletableFuture.completedFuture(null)
-    val params =
-        if (lookupString.isNullOrEmpty())
-            AutocompleteParams(
-                uriFor(virtualFile),
-                Position(position.line, position.character),
-                if (triggerKind == InlineCompletionTriggerKind.INVOKE)
-                    AutocompleteTriggerKind.INVOKE.value
-                else AutocompleteTriggerKind.AUTOMATIC.value)
-        else
-            AutocompleteParams(
-                uriFor(virtualFile),
-                Position(position.line, position.character),
-                AutocompleteTriggerKind.AUTOMATIC.value,
-                SelectedCompletionInfo(
-                    lookupString,
-                    if (startPosition < 0) Range(position, position)
-                    else Range(Position(lineNumber, startPosition), position)))
-    notifyApplication(project, CodyStatus.AutocompleteInProgress)
-
-    val resultOuter = CompletableFuture<Void?>()
-    CodyAgentService.withAgent(project) { agent ->
-      if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
-          IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
-              IgnorePolicy.USE) {
-        ActionInIgnoredFileNotification.maybeNotify(project)
-        resetApplication(project)
-        resultOuter.cancel(true)
-      } else {
-        val completions = agent.server.autocompleteExecute(params)
-
-        // Important: we have to `.cancel()` the original `CompletableFuture<T>` from lsp4j. As soon
-        // as we use `thenAccept()` we get a new instance of `CompletableFuture<Void>` which does
-        // not
-        // correctly propagate the cancellation to the agent.
-        cancellationToken.onCancellationRequested { completions.cancel(true) }
-
-        ApplicationManager.getApplication().executeOnPooledThread {
-          completions
-              .handle { result, error ->
-                if (error != null) {
-                  if (triggerKind == InlineCompletionTriggerKind.INVOKE ||
-                      !UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown) {
-                    handleError(project, error)
-                  }
-                } else if (result != null && result.items.isNotEmpty()) {
-                  UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = false
-                  UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
-                  processAutocompleteResult(editor, offset, triggerKind, result, cancellationToken)
-                }
-                null
-              }
-              .exceptionally { error: Throwable? ->
-                if (!(error is CancellationException || error is CompletionException)) {
-                  logger.warn("failed autocomplete request $params", error)
-                }
-                null
-              }
-              .completeOnTimeout(null, 3, TimeUnit.SECONDS)
-              .thenRun { // This is a terminal operation, so we needn't call get().
-                resetApplication(project)
-                resultOuter.complete(null)
-              }
+        originalText,
+        logger) { autocompleteResult ->
+          processAutocompleteResult(
+              editor, offset, triggerKind, autocompleteResult, cancellationToken)
         }
-      }
-    }
-    cancellationToken.onCancellationRequested { resultOuter.cancel(true) }
-    return resultOuter
-  }
-
-  private fun handleError(project: Project, error: Throwable?) {
-    if (error is ResponseErrorException) {
-      if (error.toErrorCode() == ErrorCode.RateLimitError) {
-        val rateLimitError = error.toRateLimitError()
-        UpgradeToCodyProNotification.autocompleteRateLimitError.set(rateLimitError)
-        UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = true
-        ApplicationManager.getApplication().executeOnPooledThread {
-          UpgradeToCodyProNotification.notify(error.toRateLimitError(), project)
-        }
-      }
-    }
   }
 
   private fun processAutocompleteResult(
@@ -511,21 +391,6 @@ class CodyAutocompleteManager {
     val lineSpacing = fontPreferences.lineSpacing.toInt()
     val extraMargin = 4
     return fontSize + lineSpacing + extraMargin
-  }
-
-  private fun findLastCommonSuffixElementPosition(
-      stringToFindSuffixIn: String,
-      suffix: String
-  ): Int {
-    var i = 0
-    while (i <= suffix.length) {
-      val partY = suffix.substring(0, suffix.length - i)
-      if (stringToFindSuffixIn.endsWith(partY)) {
-        return stringToFindSuffixIn.length - (suffix.length - i)
-      }
-      i++
-    }
-    return 0
   }
 
   private fun cancelCurrentJob(project: Project?) {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -141,7 +141,10 @@ class CodyAutocompleteManager {
       return
     }
     val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
-    if (isTriggeredImplicitly && !isImplicitAutocompleteEnabledForEditor(editor) && !isRemoteDev) {
+    if (isRemoteDev) {
+      return
+    }
+    if (isTriggeredImplicitly && !isImplicitAutocompleteEnabledForEditor(editor)) {
       return
     }
     val currentCommand = CommandProcessor.getInstance().currentCommandName

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -5,6 +5,7 @@ import com.github.difflib.patch.DeltaType
 import com.github.difflib.patch.Patch
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.command.CommandProcessor
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.components.Service
@@ -160,7 +161,8 @@ class CodyAutocompleteManager {
       }
       return
     }
-    if (isTriggeredImplicitly && !isImplicitAutocompleteEnabledForEditor(editor)) {
+    val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
+    if (isTriggeredImplicitly && !isImplicitAutocompleteEnabledForEditor(editor) && !isRemoteDev) {
       return
     }
     val currentCommand = CommandProcessor.getInstance().currentCommandName

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -7,46 +7,23 @@ import com.intellij.codeInsight.inline.completion.InlineCompletionRequest
 import com.intellij.codeInsight.inline.completion.InlineCompletionSuggestion
 import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
 import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.DocumentEvent
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.TextRange
 import com.intellij.util.concurrency.annotations.RequiresEdt
-import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.AutocompleteParams
 import com.sourcegraph.cody.agent.protocol.AutocompleteResult
-import com.sourcegraph.cody.agent.protocol.AutocompleteTriggerKind
-import com.sourcegraph.cody.agent.protocol.ErrorCode
-import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
-import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.uriFor
-import com.sourcegraph.cody.agent.protocol.RateLimitError.Companion.toRateLimitError
-import com.sourcegraph.cody.agent.protocol.SelectedCompletionInfo
-import com.sourcegraph.cody.agent.protocol_extensions.Position
-import com.sourcegraph.cody.agent.protocol_generated.Position
-import com.sourcegraph.cody.agent.protocol_generated.Range
-import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
-import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
-import com.sourcegraph.cody.statusbar.CodyStatus
-import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
 import com.sourcegraph.cody.vscode.CancellationToken
 import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
 import com.sourcegraph.cody.vscode.IntelliJTextDocument
-import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil.isImplicitAutocompleteEnabledForEditor
 import com.sourcegraph.utils.ThreadingUtil
-import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionException
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
 @JvmInline value class InlineCompletionProviderID(val id: String)
 
@@ -97,121 +74,31 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
       cancellationToken: CancellationToken,
       lookupString: String?,
   ): CompletableFuture<AutocompleteResult?> {
-
     val textDocument = IntelliJTextDocument(editor, project)
     val offset = editor.caretModel.offset
-    val position = textDocument.positionAt(offset)
     val lineNumber = editor.document.getLineNumber(offset)
     val caretPositionInLine = offset - editor.document.getLineStartOffset(lineNumber)
     val originalText = editor.document.getText(TextRange(offset - caretPositionInLine, offset))
 
-    var startPosition = 0
-    if (!lookupString.isNullOrEmpty()) {
-      startPosition = findLastCommonSuffixElementPosition(originalText, lookupString)
-    }
-
-    val virtualFile =
-        FileDocumentManager.getInstance().getFile(editor.document)
-            ?: return CompletableFuture.completedFuture(null)
-    val params =
-        if (lookupString.isNullOrEmpty())
-            AutocompleteParams(
-                uriFor(virtualFile),
-                Position(position.line, position.character),
-                if (triggerKind == InlineCompletionTriggerKind.INVOKE)
-                    AutocompleteTriggerKind.INVOKE.value
-                else AutocompleteTriggerKind.AUTOMATIC.value)
-        else
-            AutocompleteParams(
-                uriFor(virtualFile),
-                Position(position.line, position.character),
-                AutocompleteTriggerKind.AUTOMATIC.value,
-                SelectedCompletionInfo(
-                    lookupString,
-                    if (startPosition < 0) Range(position, position)
-                    else Range(Position(lineNumber, startPosition), position)))
-    notifyApplication(project, CodyStatus.AutocompleteInProgress)
-
-    val resultOuter = CompletableFuture<AutocompleteResult?>()
-    CodyAgentService.withAgent(project) { agent ->
-      if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
-          IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
-              IgnorePolicy.USE) {
-        ActionInIgnoredFileNotification.maybeNotify(project)
-        resetApplication(project)
-        resultOuter.cancel(true)
-      } else {
-        val completions = agent.server.autocompleteExecute(params)
-
-        // Important: we have to `.cancel()` the original `CompletableFuture<T>` from lsp4j. As soon
-        // as we use `thenAccept()` we get a new instance of `CompletableFuture<Void>` which does
-        // not correctly propagate the cancellation to the agent.
-        cancellationToken.onCancellationRequested { completions.cancel(true) }
-
-        ApplicationManager.getApplication().executeOnPooledThread {
-          completions
-              .handle { result, error ->
-                if (error != null) {
-                  if (triggerKind == InlineCompletionTriggerKind.INVOKE ||
-                      !UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown) {
-                    handleError(project, error)
-                  }
-                } else if (result != null && result.items.isNotEmpty()) {
-                  UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = false
-                  UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
-                  resultOuter.complete(result)
-                }
-                null
-              }
-              .exceptionally { error: Throwable? ->
-                if (!(error is CancellationException || error is CompletionException)) {
-                  logger.warn("failed autocomplete request $params", error)
-                }
-                null
-              }
-              .completeOnTimeout(null, 3, TimeUnit.SECONDS)
-              .thenRun { // This is a terminal operation, so we needn't call get().
-                resetApplication(project)
-                resultOuter.complete(null)
-              }
+    val result = CompletableFuture<AutocompleteResult?>()
+    Utils.triggerAutocompleteAsync(
+        project,
+        editor,
+        offset,
+        textDocument,
+        triggerKind,
+        cancellationToken,
+        lookupString,
+        originalText,
+        logger) { autocompleteResult ->
+          result.complete(autocompleteResult)
         }
-      }
-    }
-    cancellationToken.onCancellationRequested { resultOuter.cancel(true) }
-    return resultOuter
-  }
-
-  private fun handleError(project: Project, error: Throwable?) {
-    if (error is ResponseErrorException) {
-      if (error.toErrorCode() == ErrorCode.RateLimitError) {
-        val rateLimitError = error.toRateLimitError()
-        UpgradeToCodyProNotification.autocompleteRateLimitError.set(rateLimitError)
-        UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = true
-        ApplicationManager.getApplication().executeOnPooledThread {
-          UpgradeToCodyProNotification.notify(error.toRateLimitError(), project)
-        }
-      }
-    }
+    return result
   }
 
   private fun cancelCurrentJob(project: Project?) {
     currentJob.get().abort()
     project?.let { resetApplication(it) }
-  }
-
-  private fun findLastCommonSuffixElementPosition(
-      stringToFindSuffixIn: String,
-      suffix: String
-  ): Int {
-    var i = 0
-    while (i <= suffix.length) {
-      val partY = suffix.substring(0, suffix.length - i)
-      if (stringToFindSuffixIn.endsWith(partY)) {
-        return stringToFindSuffixIn.length - (suffix.length - i)
-      }
-      i++
-    }
-    return 0
   }
 
   fun isEnabled(event: InlineCompletionEvent): Boolean {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -59,7 +59,7 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
                 InlineCompletionTriggerKind.AUTOMATIC,
                 cancellationToken,
                 lookupString)
-            .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+            .completeOnTimeout(null, 1, TimeUnit.SECONDS)
             .get() ?: return InlineCompletionSuggestion.empty()
 
     return InlineCompletionSuggestion.withFlow {

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -6,7 +6,9 @@ import com.intellij.codeInsight.inline.completion.InlineCompletionProvider
 import com.intellij.codeInsight.inline.completion.InlineCompletionRequest
 import com.intellij.codeInsight.inline.completion.InlineCompletionSuggestion
 import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.client.ClientSessionsManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.DocumentEvent
@@ -46,8 +48,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
 
-@JvmInline
-value class InlineCompletionProviderID(val id: String)
+@JvmInline value class InlineCompletionProviderID(val id: String)
 
 class CodyInlineCompletionProvider : InlineCompletionProvider {
   private val logger = Logger.getInstance(CodyInlineCompletionProvider::class.java)
@@ -214,14 +215,25 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
   }
 
   fun isEnabled(event: InlineCompletionEvent): Boolean {
-    return ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled()
+    return isEnabled()
   }
 
-  override suspend fun getProposals(request: InlineCompletionRequest): List<InlineCompletionElement> {
-    TODO("Not yet implemented")
+  override suspend fun getProposals(
+      request: InlineCompletionRequest
+  ): List<InlineCompletionElement> {
+    return emptyList()
   }
 
   override fun isEnabled(event: DocumentEvent): Boolean {
-    TODO("Not yet implemented")
+    return isEnabled()
+  }
+
+  private fun isEnabled(): Boolean {
+    val ideVersion = ApplicationInfo.getInstance().build.baselineVersion
+    val isRemoteDev = ClientSessionsManager.getAppSession()?.isRemote ?: false
+    return ideVersion >= 233 &&
+        isRemoteDev &&
+        ConfigUtil.isCodyEnabled() &&
+        ConfigUtil.isCodyAutocompleteEnabled()
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -71,12 +71,10 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
                 if (System.getProperty("cody.autocomplete.enableFormatting") == "false") {
                   it.insertText
                 } else {
-                  WriteCommandAction.runWriteCommandAction<String>(
-                      editor.project,
-                      {
-                        CodyFormatter.formatStringBasedOnDocument(
-                            it.insertText, project, editor.document, range, offset)
-                      })
+                  WriteCommandAction.runWriteCommandAction<String>(editor.project) {
+                    CodyFormatter.formatStringBasedOnDocument(
+                        it.insertText, project, editor.document, range, offset)
+                  }
                 }
 
             // ...
@@ -131,10 +129,6 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
     currentJob.get().abort()
     project?.let { resetApplication(it) }
   }
-
-  //  fun restartOn(event: InlineCompletionEvent): Boolean {
-  //    return event is InlineCompletionEvent.InlineLookupEvent
-  //  }
 
   fun isEnabled(event: InlineCompletionEvent): Boolean {
     return isEnabled()

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -1,0 +1,227 @@
+package com.sourcegraph.cody.autocomplete
+
+import com.intellij.codeInsight.inline.completion.InlineCompletionElement
+import com.intellij.codeInsight.inline.completion.InlineCompletionEvent
+import com.intellij.codeInsight.inline.completion.InlineCompletionProvider
+import com.intellij.codeInsight.inline.completion.InlineCompletionRequest
+import com.intellij.codeInsight.inline.completion.InlineCompletionSuggestion
+import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.DocumentEvent
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.util.concurrency.annotations.RequiresEdt
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.AutocompleteParams
+import com.sourcegraph.cody.agent.protocol.AutocompleteResult
+import com.sourcegraph.cody.agent.protocol.AutocompleteTriggerKind
+import com.sourcegraph.cody.agent.protocol.ErrorCode
+import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
+import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.uriFor
+import com.sourcegraph.cody.agent.protocol.RateLimitError.Companion.toRateLimitError
+import com.sourcegraph.cody.agent.protocol.SelectedCompletionInfo
+import com.sourcegraph.cody.agent.protocol_extensions.Position
+import com.sourcegraph.cody.agent.protocol_generated.Position
+import com.sourcegraph.cody.agent.protocol_generated.Range
+import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
+import com.sourcegraph.cody.ignore.IgnoreOracle
+import com.sourcegraph.cody.ignore.IgnorePolicy
+import com.sourcegraph.cody.statusbar.CodyStatus
+import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
+import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
+import com.sourcegraph.cody.vscode.CancellationToken
+import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
+import com.sourcegraph.cody.vscode.IntelliJTextDocument
+import com.sourcegraph.common.UpgradeToCodyProNotification
+import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.utils.CodyEditorUtil.isImplicitAutocompleteEnabledForEditor
+import com.sourcegraph.utils.ThreadingUtil
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+
+@JvmInline
+value class InlineCompletionProviderID(val id: String)
+
+class CodyInlineCompletionProvider : InlineCompletionProvider {
+  private val logger = Logger.getInstance(CodyInlineCompletionProvider::class.java)
+  private val currentJob = AtomicReference(CancellationToken())
+  val id = InlineCompletionProviderID("Cody")
+
+  suspend fun getSuggestion(request: InlineCompletionRequest): InlineCompletionSuggestion {
+    val editor = request.editor
+    val project = editor.project ?: return InlineCompletionSuggestion.empty()
+    if (!isImplicitAutocompleteEnabledForEditor(editor)) {
+      return InlineCompletionSuggestion.empty()
+    }
+    val lookupString: String? = null // todo: can we use this provider for lookups?
+
+    cancelCurrentJob(project)
+    val cancellationToken = CancellationToken()
+    currentJob.set(cancellationToken)
+
+    val completions =
+        ThreadingUtil.runInEdtAndGet {
+          fetchCompletions(
+                  project,
+                  editor,
+                  InlineCompletionTriggerKind.AUTOMATIC,
+                  cancellationToken,
+                  lookupString)
+              .get()
+        } ?: return InlineCompletionSuggestion.empty()
+
+    val offset = request.endOffset
+    val lineNumber = editor.document.getLineNumber(offset)
+    val caretPositionInLine = offset - editor.document.getLineStartOffset(lineNumber)
+
+    return InlineCompletionSuggestion.withFlow {
+      completions.items
+          .map { InlineCompletionGrayTextElement(it.insertText.substring(caretPositionInLine)) }
+          .forEach { emit(it) }
+    }
+  }
+
+  @RequiresEdt
+  private fun fetchCompletions(
+      project: Project,
+      editor: Editor,
+      triggerKind: InlineCompletionTriggerKind,
+      cancellationToken: CancellationToken,
+      lookupString: String?,
+  ): CompletableFuture<AutocompleteResult?> {
+
+    val textDocument = IntelliJTextDocument(editor, project)
+    val offset = editor.caretModel.offset
+    val position = textDocument.positionAt(offset)
+    val lineNumber = editor.document.getLineNumber(offset)
+    val caretPositionInLine = offset - editor.document.getLineStartOffset(lineNumber)
+    val originalText = editor.document.getText(TextRange(offset - caretPositionInLine, offset))
+
+    var startPosition = 0
+    if (!lookupString.isNullOrEmpty()) {
+      startPosition = findLastCommonSuffixElementPosition(originalText, lookupString)
+    }
+
+    val virtualFile =
+        FileDocumentManager.getInstance().getFile(editor.document)
+            ?: return CompletableFuture.completedFuture(null)
+    val params =
+        if (lookupString.isNullOrEmpty())
+            AutocompleteParams(
+                uriFor(virtualFile),
+                Position(position.line, position.character),
+                if (triggerKind == InlineCompletionTriggerKind.INVOKE)
+                    AutocompleteTriggerKind.INVOKE.value
+                else AutocompleteTriggerKind.AUTOMATIC.value)
+        else
+            AutocompleteParams(
+                uriFor(virtualFile),
+                Position(position.line, position.character),
+                AutocompleteTriggerKind.AUTOMATIC.value,
+                SelectedCompletionInfo(
+                    lookupString,
+                    if (startPosition < 0) Range(position, position)
+                    else Range(Position(lineNumber, startPosition), position)))
+    notifyApplication(project, CodyStatus.AutocompleteInProgress)
+
+    val resultOuter = CompletableFuture<AutocompleteResult?>()
+    CodyAgentService.withAgent(project) { agent ->
+      if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
+          IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
+              IgnorePolicy.USE) {
+        ActionInIgnoredFileNotification.maybeNotify(project)
+        resetApplication(project)
+        resultOuter.cancel(true)
+      } else {
+        val completions = agent.server.autocompleteExecute(params)
+
+        // Important: we have to `.cancel()` the original `CompletableFuture<T>` from lsp4j. As soon
+        // as we use `thenAccept()` we get a new instance of `CompletableFuture<Void>` which does
+        // not correctly propagate the cancellation to the agent.
+        cancellationToken.onCancellationRequested { completions.cancel(true) }
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+          completions
+              .handle { result, error ->
+                if (error != null) {
+                  if (triggerKind == InlineCompletionTriggerKind.INVOKE ||
+                      !UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown) {
+                    handleError(project, error)
+                  }
+                } else if (result != null && result.items.isNotEmpty()) {
+                  UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = false
+                  UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+                  resultOuter.complete(result)
+                }
+                null
+              }
+              .exceptionally { error: Throwable? ->
+                if (!(error is CancellationException || error is CompletionException)) {
+                  logger.warn("failed autocomplete request $params", error)
+                }
+                null
+              }
+              .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+              .thenRun { // This is a terminal operation, so we needn't call get().
+                resetApplication(project)
+                resultOuter.complete(null)
+              }
+        }
+      }
+    }
+    cancellationToken.onCancellationRequested { resultOuter.cancel(true) }
+    return resultOuter
+  }
+
+  private fun handleError(project: Project, error: Throwable?) {
+    if (error is ResponseErrorException) {
+      if (error.toErrorCode() == ErrorCode.RateLimitError) {
+        val rateLimitError = error.toRateLimitError()
+        UpgradeToCodyProNotification.autocompleteRateLimitError.set(rateLimitError)
+        UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = true
+        ApplicationManager.getApplication().executeOnPooledThread {
+          UpgradeToCodyProNotification.notify(error.toRateLimitError(), project)
+        }
+      }
+    }
+  }
+
+  private fun cancelCurrentJob(project: Project?) {
+    currentJob.get().abort()
+    project?.let { resetApplication(it) }
+  }
+
+  private fun findLastCommonSuffixElementPosition(
+      stringToFindSuffixIn: String,
+      suffix: String
+  ): Int {
+    var i = 0
+    while (i <= suffix.length) {
+      val partY = suffix.substring(0, suffix.length - i)
+      if (stringToFindSuffixIn.endsWith(partY)) {
+        return stringToFindSuffixIn.length - (suffix.length - i)
+      }
+      i++
+    }
+    return 0
+  }
+
+  fun isEnabled(event: InlineCompletionEvent): Boolean {
+    return ConfigUtil.isCodyEnabled() && ConfigUtil.isCodyAutocompleteEnabled()
+  }
+
+  override suspend fun getProposals(request: InlineCompletionRequest): List<InlineCompletionElement> {
+    TODO("Not yet implemented")
+  }
+
+  override fun isEnabled(event: DocumentEvent): Boolean {
+    TODO("Not yet implemented")
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -1,0 +1,156 @@
+package com.sourcegraph.cody.autocomplete
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol.AutocompleteParams
+import com.sourcegraph.cody.agent.protocol.AutocompleteResult
+import com.sourcegraph.cody.agent.protocol.AutocompleteTriggerKind
+import com.sourcegraph.cody.agent.protocol.ErrorCode
+import com.sourcegraph.cody.agent.protocol.ErrorCodeUtils.toErrorCode
+import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument.Companion.uriFor
+import com.sourcegraph.cody.agent.protocol.RateLimitError.Companion.toRateLimitError
+import com.sourcegraph.cody.agent.protocol.SelectedCompletionInfo
+import com.sourcegraph.cody.agent.protocol_extensions.Position
+import com.sourcegraph.cody.agent.protocol_generated.Position
+import com.sourcegraph.cody.agent.protocol_generated.Range
+import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
+import com.sourcegraph.cody.ignore.IgnoreOracle
+import com.sourcegraph.cody.ignore.IgnorePolicy
+import com.sourcegraph.cody.statusbar.CodyStatus
+import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
+import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
+import com.sourcegraph.cody.vscode.CancellationToken
+import com.sourcegraph.cody.vscode.InlineCompletionTriggerKind
+import com.sourcegraph.cody.vscode.TextDocument
+import com.sourcegraph.common.UpgradeToCodyProNotification
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.TimeUnit
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException
+
+object Utils {
+  fun triggerAutocompleteAsync(
+      project: Project,
+      editor: Editor,
+      offset: Int,
+      textDocument: TextDocument,
+      triggerKind: InlineCompletionTriggerKind,
+      cancellationToken: CancellationToken,
+      lookupString: String?,
+      originalText: String,
+      logger: Logger,
+      successCallback: (AutocompleteResult) -> Unit,
+  ): CompletableFuture<out AutocompleteResult?> {
+    val position = textDocument.positionAt(offset)
+    val lineNumber = editor.document.getLineNumber(offset)
+    var startPosition = 0
+    if (!lookupString.isNullOrEmpty()) {
+      startPosition = findLastCommonSuffixElementPosition(originalText, lookupString)
+    }
+
+    val virtualFile =
+        FileDocumentManager.getInstance().getFile(editor.document)
+            ?: return CompletableFuture.completedFuture(null)
+    val params =
+        if (lookupString.isNullOrEmpty())
+            AutocompleteParams(
+                uriFor(virtualFile),
+                Position(position.line, position.character),
+                if (triggerKind == InlineCompletionTriggerKind.INVOKE)
+                    AutocompleteTriggerKind.INVOKE.value
+                else AutocompleteTriggerKind.AUTOMATIC.value)
+        else
+            AutocompleteParams(
+                uriFor(virtualFile),
+                Position(position.line, position.character),
+                AutocompleteTriggerKind.AUTOMATIC.value,
+                SelectedCompletionInfo(
+                    lookupString,
+                    if (startPosition < 0) Range(position, position)
+                    else Range(Position(lineNumber, startPosition), position)))
+    notifyApplication(project, CodyStatus.AutocompleteInProgress)
+
+    val resultOuter = CompletableFuture<AutocompleteResult?>()
+    CodyAgentService.withAgent(project) { agent ->
+      if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
+          IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
+              IgnorePolicy.USE) {
+        ActionInIgnoredFileNotification.maybeNotify(project)
+        resetApplication(project)
+        resultOuter.cancel(true)
+      } else {
+        val completions = agent.server.autocompleteExecute(params)
+
+        // Important: we have to `.cancel()` the original `CompletableFuture<T>` from lsp4j. As soon
+        // as we use `thenAccept()` we get a new instance of `CompletableFuture<Void>` which does
+        // not
+        // correctly propagate the cancellation to the agent.
+        cancellationToken.onCancellationRequested { completions.cancel(true) }
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+          completions
+              .handle { result, error ->
+                if (error != null) {
+                  if (triggerKind == InlineCompletionTriggerKind.INVOKE ||
+                      !UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown) {
+                    handleError(project, error)
+                  }
+                } else if (result != null && result.items.isNotEmpty()) {
+                  UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = false
+                  UpgradeToCodyProNotification.autocompleteRateLimitError.set(null)
+                  successCallback(result)
+                  resultOuter.complete(result)
+                }
+                null
+              }
+              .exceptionally { error: Throwable? ->
+                if (!(error is CancellationException || error is CompletionException)) {
+                  logger.warn("failed autocomplete request $params", error)
+                }
+                null
+              }
+              .completeOnTimeout(null, 3, TimeUnit.SECONDS)
+              .thenRun { // This is a terminal operation, so we needn't call get().
+                resetApplication(project)
+                resultOuter.complete(null)
+              }
+        }
+      }
+    }
+    cancellationToken.onCancellationRequested { resultOuter.cancel(true) }
+    return resultOuter
+  }
+
+  private fun handleError(project: Project, error: Throwable?) {
+    if (error is ResponseErrorException) {
+      if (error.toErrorCode() == ErrorCode.RateLimitError) {
+        val rateLimitError = error.toRateLimitError()
+        UpgradeToCodyProNotification.autocompleteRateLimitError.set(rateLimitError)
+        UpgradeToCodyProNotification.isFirstRLEOnAutomaticAutocompletionsShown = true
+        ApplicationManager.getApplication().executeOnPooledThread {
+          UpgradeToCodyProNotification.notify(error.toRateLimitError(), project)
+        }
+      }
+    }
+  }
+
+  private fun findLastCommonSuffixElementPosition(
+      stringToFindSuffixIn: String,
+      suffix: String
+  ): Int {
+    var i = 0
+    while (i <= suffix.length) {
+      val partY = suffix.substring(0, suffix.length - i)
+      if (stringToFindSuffixIn.endsWith(partY)) {
+        return stringToFindSuffixIn.length - (suffix.length - i)
+      }
+      i++
+    }
+    return 0
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -25,7 +25,6 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
     }
   }
 
-  // todo: documentChanged
   override fun documentChangedNonBulk(event: DocumentEvent) {
     try {
       // Can be called on non-EDT during IDE shutdown.

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -25,6 +25,7 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
     }
   }
 
+  // todo: documentChanged
   override fun documentChangedNonBulk(event: DocumentEvent) {
     try {
       // Can be called on non-EDT during IDE shutdown.

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -96,6 +96,7 @@
 
         <keymapExtension implementation="com.sourcegraph.cody.config.CodyKeymapExtension"/>
 
+        <inline.completion.provider implementation="com.sourcegraph.cody.autocomplete.CodyInlineCompletionProvider"/>
         <!-- Web UI Sidebar Views
              For each sourcegraph/cody/vscode/package.json "views" entry with type "webview",
              add a toolWindow with factoryClass="com.sourcegraph.cody.sidebar.WebUIToolWindowFactory"


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3742.

<!-- start git-machete generated -->

# Based on PR #2303

## Full chain of PRs as of 2024-09-16

* PR #2304:
  `mkondratek/feat/completion-provider` ➔ `mkondratek/chore/ui-fixes`
* PR #2303:
  `mkondratek/chore/ui-fixes` ➔ `main`

<!-- end git-machete generated -->



## Test plan

AUTOMATIC
1. Run IDE in Remote Development mode 
2. Open a project, open a file
3. Hit Enter to trigger autocomplete 
Expected: autocompletion suggested

INVOKE
1. `shift + option + \` on **macOS**
Expected: autocompletion suggested