### PR TITLE
Rewrite EditCommandPrompt implementation from custom JFrame to JBPopup

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
@@ -17,8 +17,8 @@ class EditCodeAction :
 
   override fun update(event: AnActionEvent) {
     super.update(event)
-    val commandPrompt = EditCommandPrompt.EDIT_COMMAND_PROMPT_KEY.get(event.project)
-    event.presentation.isEnabledAndVisible = commandPrompt?.isVisible != true
+    event.presentation.isEnabledAndVisible =
+        event.project?.let { !EditCommandPrompt.isVisible(it) } ?: true
   }
 
   companion object {


### PR DESCRIPTION
Fixes CODY-3645

## Changes

Rewrite EditCommandPrompt implementation from custom JFrame to JBPopup.

JBPopup already contains some features we were re-implementing by hand, and it is laso guaranteed to be correctly handled by Gateway (as JetBrains uses it in a lot of places).


## Test plan

1. Hit `shift shift`
2. Search for `Edit Code...`
3. Type your edit command and run it
4. Make sure edit was applied correctly. Note that most likely you will see some side error due to faulty lenses implementation
