### PR TITLE
Backport 7.0.4 fixes to 7.0.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=6a33dae30dfbccdeafc09e0d3718442f67d8c0d6
+cody.commit=d430a0d5e733f77c16840ec6f1fd4f168d47667a

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -122,6 +122,7 @@ private constructor(
                               edit = ClientCapabilities.EditEnum.Enabled,
                               editWorkspace = ClientCapabilities.EditWorkspaceEnum.Enabled,
                               codeLenses = ClientCapabilities.CodeLensesEnum.Enabled,
+                              disabledMentionsProviders = listOf("symbol"),
                               showDocument = ClientCapabilities.ShowDocumentEnum.Enabled,
                               ignore = ClientCapabilities.IgnoreEnum.Enabled,
                               untitledDocuments = ClientCapabilities.UntitledDocumentsEnum.Enabled,

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -29,8 +29,19 @@ import kotlin.math.min
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
 import org.cef.callback.CefAuthCallback
+import org.cef.callback.CefBeforeDownloadCallback
 import org.cef.callback.CefCallback
-import org.cef.handler.*
+import org.cef.callback.CefDownloadItem
+import org.cef.callback.CefDownloadItemCallback
+import org.cef.handler.CefCookieAccessFilter
+import org.cef.handler.CefDownloadHandler
+import org.cef.handler.CefFocusHandler
+import org.cef.handler.CefFocusHandlerAdapter
+import org.cef.handler.CefLifeSpanHandler
+import org.cef.handler.CefLoadHandler
+import org.cef.handler.CefRequestHandler
+import org.cef.handler.CefResourceHandler
+import org.cef.handler.CefResourceRequestHandler
 import org.cef.misc.BoolRef
 import org.cef.misc.IntRef
 import org.cef.misc.StringRef
@@ -151,6 +162,26 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
       });
     """
               .trimIndent()
+
+      browser.jbCefClient.addDownloadHandler(
+          object : CefDownloadHandler {
+            override fun onBeforeDownload(
+                browser: CefBrowser?,
+                downloadItem: CefDownloadItem?,
+                suggestedName: String?,
+                callback: CefBeforeDownloadCallback?
+            ) {
+              callback?.Continue(/* downloadPath = */ "", /* showDialog = */ true)
+            }
+
+            override fun onDownloadUpdated(
+                browser: CefBrowser?,
+                downloadItem: CefDownloadItem?,
+                callback: CefDownloadItemCallback?
+            ) {}
+          },
+          browser.cefBrowser)
+
       browser.jbCefClient.addRequestHandler(
           ExtensionRequestHandler(proxy, apiScript), browser.cefBrowser)
       browser.jbCefClient.addLifeSpanHandler(


### PR DESCRIPTION
## Changes

This PR backports JetBrains 7.0.4 fixes to 7.0.2, as we need to rollback due to few cody agent issues we found in the meantime.

Cherry-picked bugfixes:

- 1e2c35be Fix IndexOutOfBounds from the highlight pass (#2252)
- ee82e90f Fix Cody failures when saving files with schemes not supported by NIO (#2251)
- e83914b7 fix/Webview: Make Cody: Restart Cody close Webview panels and restore Webview views (#2227)


## Test plan

Full QA