### PR TITLE
Fix cody status icon in remote environments

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarWidget.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusBarWidget.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.StatusBarWidget
 import com.intellij.openapi.wm.WindowManager
 import com.intellij.openapi.wm.impl.status.EditorBasedStatusBarPopup
+import com.intellij.util.ui.GraphicsUtil
 
 class CodyStatusBarWidget(project: Project) : EditorBasedStatusBarPopup(project, false) {
   override fun ID(): String = CodyWidgetFactory.ID
@@ -20,7 +21,9 @@ class CodyStatusBarWidget(project: Project) : EditorBasedStatusBarPopup(project,
     if (currentStatus == CodyStatus.CodyDisabled) {
       return WidgetState.HIDDEN
     }
-    val state = WidgetState(currentStatus.presentableText, "", true)
+    // Remote environment does not support rendering icons, so we use a placeholder text instead
+    val text = if (GraphicsUtil.isRemoteEnvironment()) "Cody" else ""
+    val state = WidgetState(currentStatus.presentableText, text, true)
     state.icon = currentStatus.icon
     return state
   }


### PR DESCRIPTION
Fixes CODY-3710

## Changes

Looks like rendering status icons is not supported in the remote environments.
Instead, we are forced to display a text replacement.

## Test plan

1. Run Cody in the remote client mode (you can use `:customRunIde -PsplitMode=true`)
2. Make sure "Cody" text is visible instead of the icon

![image](https://github.com/user-attachments/assets/c6297314-4738-4ae6-9eeb-f74149aa4818)
