### PR TITLE
Fix incorrect null project warning

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/EditCodeAction.kt
@@ -11,6 +11,7 @@ class EditCodeAction :
       val project = editor.project
       if (project != null) {
         EditCommandPrompt(project, editor, "Edit Code with Cody")
+      } else {
         logger.warn("EditCodeAction invoked with null project")
       }
     }) {


### PR DESCRIPTION
## Test plan

1. Run `Edit Code` action
2. Make sure there is no `EditCodeAction invoked with null project` warning in the logs 