### PR TITLE
fix/chat: Send workspace root as the expected URI, not a path

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgent.kt
@@ -115,7 +115,7 @@ private constructor(
                       ideVersion = ApplicationInfo.getInstance().build.toString(),
                       workspaceRootUri =
                           ProtocolTextDocument.normalizeUriOrPath(
-                              ConfigUtil.getWorkspaceRootPath(project).toString()),
+                              ConfigUtil.getWorkspaceRootPath(project).toUri().toString()),
                       extensionConfiguration = ConfigUtil.getAgentConfiguration(project),
                       capabilities =
                           ClientCapabilities(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocument.kt
@@ -212,7 +212,7 @@ private constructor(
       }
 
       // Normalize drive letters for Windows
-      val driveLetterPattern = """^(\w):/""".toRegex()
+      val driveLetterPattern = """^(/?\w):/""".toRegex()
       val normalizedPath =
           driveLetterPattern.replace(path) { matchResult ->
             val driveLetter = matchResult.groupValues[1].lowercase(Locale.getDefault())

--- a/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/agent/protocol/ProtocolTextDocumentTest.kt
@@ -233,6 +233,8 @@ class ProtocolTextDocumentTest : BasePlatformTestCase() {
             "D:/home/person" to "d:/home/person",
             "file://\\\\wsl$\\Ubuntu\\home\\person" to "file:////wsl.localhost/Ubuntu/home/person",
             "file://c:/home/person" to "file:///c:/home/person",
+            "file://Z:/home/PERSON" to "file:///z:/home/PERSON",
+            "file:///C:/Users/person" to "file:///c:/Users/person",
             "/home/person/documents" to "/home/person/documents",
             "file:///home/person/documents" to "file:///home/person/documents")
 


### PR DESCRIPTION
JetBrains was initializing Agent passing a path instead of a workspace root URI. This is fine on UNIX-style systems, because the string `/foo/bar` is interpreted as a file URI. But on Windows it meant we were passing paths like `c:/Users/bob/project` (yes... we convert the path separator to a forward slash etc.) and Agent was treating this as `/Users/bob/project` which is wrong.

The fix is simply to pass a URI instead of a file.

In addition, `normalizeUriOrPath` was lowercasing drive letters, but in the URI case *only* if the URI was `file://C:/foo`; this fixes it to also handle `file:///C:/foo` (note the extra slash.)

Note, Extension handling often? converts these URLs from `file:///c:/foo` to `file:///c%3a/foo` and does prefix checks on URIs as strings or paths, so we should consider canonicalizing colons in file URLs too, but that will take more care and attention. This change is enough to unbreak Prompt Library mentions on Windows.

## Test plan

On Windows,

- Run with prompts as commands enabled (currently set up on s2)
- Open a file, right click, Cody, Explain Code.
- Check that the filename has a `@file.txt` presentation on a mention slab, instead of `@C:\full\path\to\file.txt` without a mention slab.

![Screenshot 2024-09-26 143056](https://github.com/user-attachments/assets/27b2bdda-23b0-46eb-b666-c1c6e1663612)

## Changelog

- Agent is now configured with an accurate workspace on root on Windows, like `file:///c:/Users/Bob/project` not `/Users/bob/project`.
- On Windows, at-mentions for explain, document, smell, etc. display as tiles with short names.