### PR TITLE
Add a script for searching for Cody commits by JetBrains version

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/scripts/canhaz.ts
+++ b/scripts/canhaz.ts
@@ -71,11 +71,11 @@ tags.forEach(tag => {
         if (match) {
             codyCommit = match[1];
         } else {
-            console.log(`${tag}: ? No cody.commit found`);
+            console.log(`? ${tag}: No cody.commit found`);
             return;
         }
     } catch (error) {
-        console.log(`${tag}: ? Error reading gradle.properties`);
+        console.log(`? ${tag}: Error reading gradle.properties`);
         return;
     }
 
@@ -83,21 +83,21 @@ tags.forEach(tag => {
     try {
         execSync(`git -C ${CODY_DIR} fetch origin ${codyCommit}`, {stdio: 'ignore'});
     } catch (error) {
-        console.log(`${tag}: ? Error fetching commit ${codyCommit}`);
+        console.log(`? ${tag}: Error fetching commit ${codyCommit}`);
         return;
     }
 
     // Step 5: Determine if the target commit is in the history of codyCommit
     try {
         execSync(`git -C ${CODY_DIR} merge-base --is-ancestor ${targetCommit} ${codyCommit}`);
-        console.log(`${tag}: ✓`);
+        console.log(`✔️ ${tag}`);
     } catch (error: any) {
         if (error.status === 1) {
             // Exit code 1 means the target commit is not an ancestor
-            console.log(`${tag}: ✗`);
+            console.log(`❌ ${tag}`);
         } else {
             // Any other error
-            console.log(`${tag}: ? Error checking merge-base`);
+            console.log(`? ${tag}: Error checking merge-base`);
         }
     }
 });

--- a/scripts/canhaz.ts
+++ b/scripts/canhaz.ts
@@ -26,7 +26,7 @@ if (!targetCommit) {
     process.exit(1);
 }
 
-// Step 2: Enumerate matching tags and sort them in reverse order
+// Enumerate matching tags and sort them in reverse order
 let tags: string[];
 try {
     tags = execSync('git tag -l "v[0-9]*.[0-9]*.[0-9]*"')
@@ -62,8 +62,8 @@ try {
     process.exit(1);
 }
 
-// Step 3: Extract cody.commit from gradle.properties for each tag
 tags.forEach(tag => {
+    // Extract cody.commit from gradle.properties for each tag
     let codyCommit;
     try {
         const gradleProperties = execSync(`git show ${tag}:gradle.properties`).toString();
@@ -79,7 +79,7 @@ tags.forEach(tag => {
         return;
     }
 
-    // Step 4: Fetch the relevant commit in the Cody repository
+    // Fetch the relevant commit in the Cody repository
     try {
         execSync(`git -C ${CODY_DIR} fetch origin ${codyCommit}`, {stdio: 'ignore'});
     } catch (error) {
@@ -87,7 +87,7 @@ tags.forEach(tag => {
         return;
     }
 
-    // Step 5: Determine if the target commit is in the history of codyCommit
+    // Determine if the target commit is in the history of codyCommit
     try {
         execSync(`git -C ${CODY_DIR} merge-base --is-ancestor ${targetCommit} ${codyCommit}`);
         console.log(`✔️ ${tag}`);

--- a/scripts/canhaz.ts
+++ b/scripts/canhaz.ts
@@ -1,0 +1,103 @@
+/**
+ * Checks whether a given JetBrains release contains a specific Cody commit.
+ */
+
+const {execSync} = require("child_process");
+
+console.log(`
+This script checks whether a given JetBrains release contains a specific Cody commit.
+To fetch version git tags from origin, run:
+  git fetch origin 'refs/tags/v*:refs/tags/v*'
+`);
+
+// Check if CODY_DIR is set
+const CODY_DIR = process.env.CODY_DIR;
+if (CODY_DIR) {
+    console.log(`Using sourcegraph/cody repo in ${CODY_DIR}`)
+} else {
+    console.error('Error: CODY_DIR environment variable is not set.');
+    process.exit(1);
+}
+
+// Check if targetCommit is provided as a command-line argument
+const targetCommit = process.argv[2];
+if (!targetCommit) {
+    console.error('Error: specify a commit to search for as a command-line argument.');
+    process.exit(1);
+}
+
+// Step 2: Enumerate matching tags and sort them in reverse order
+let tags: string[];
+try {
+    tags = execSync('git tag -l "v[0-9]*.[0-9]*.[0-9]*"')
+        .toString()
+        .trim()
+        .split('\n')
+        .sort((a: string, b: string) => {
+            const parseVersion = (version: string) => {
+                const [main, modifier] = version.slice(1).split('-');
+                const [major, minor, patch] = main.split('.').map(Number);
+                return { major, minor, patch, modifier };
+            };
+
+            const aVersion = parseVersion(a);
+            const bVersion = parseVersion(b);
+
+            if (aVersion.major !== bVersion.major) {
+                return bVersion.major - aVersion.major;
+            }
+            if (aVersion.minor !== bVersion.minor) {
+                return bVersion.minor - aVersion.minor;
+            }
+            if (aVersion.patch !== bVersion.patch) {
+                return bVersion.patch - aVersion.patch;
+            }
+            if (aVersion.modifier && bVersion.modifier) {
+                return aVersion.modifier.localeCompare(bVersion.modifier);
+            }
+            return aVersion.modifier ? -1 : 1;
+        });
+} catch (error: any) {
+    console.error(`Error fetching tags: ${error?.message}`);
+    process.exit(1);
+}
+
+// Step 3: Extract cody.commit from gradle.properties for each tag
+tags.forEach(tag => {
+    let codyCommit;
+    try {
+        const gradleProperties = execSync(`git show ${tag}:gradle.properties`).toString();
+        const match = gradleProperties.match(/^cody\.commit=(.*)$/m);
+        if (match) {
+            codyCommit = match[1];
+        } else {
+            console.log(`${tag}: ? No cody.commit found`);
+            return;
+        }
+    } catch (error) {
+        console.log(`${tag}: ? Error reading gradle.properties`);
+        return;
+    }
+
+    // Step 4: Fetch the relevant commit in the Cody repository
+    try {
+        execSync(`git -C ${CODY_DIR} fetch origin ${codyCommit}`, {stdio: 'ignore'});
+    } catch (error) {
+        console.log(`${tag}: ? Error fetching commit ${codyCommit}`);
+        return;
+    }
+
+    // Step 5: Determine if the target commit is in the history of codyCommit
+    try {
+        execSync(`git -C ${CODY_DIR} merge-base --is-ancestor ${targetCommit} ${codyCommit}`);
+        console.log(`${tag}: ✓`);
+    } catch (error: any) {
+        if (error.status === 1) {
+            // Exit code 1 means the target commit is not an ancestor
+            console.log(`${tag}: ✗`);
+        } else {
+            // Any other error
+            console.log(`${tag}: ? Error checking merge-base`);
+        }
+    }
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+	"scripts": {
+		"canhaz": "ts-node canhaz.ts"
+	},
+	"type": "commonjs",
+	"devDependencies": {
+		"@types/node": "^22.7.2",
+		"ts-node": "^10.9.2",
+		"typescript": "^5.6.2"
+	}
+}

--- a/scripts/pnpm-lock.yaml
+++ b/scripts/pnpm-lock.yaml
@@ -1,0 +1,143 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+devDependencies:
+  '@types/node':
+    specifier: ^22.7.2
+    version: 22.7.2
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@22.7.2)(typescript@5.6.2)
+  typescript:
+    specifier: ^5.6.2
+    version: 5.6.2
+
+packages:
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@jridgewell/resolve-uri@3.1.2:
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.5.0:
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+    dev: true
+
+  /@tsconfig/node10@1.0.11:
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
+  /@types/node@22.7.2:
+    resolution: {integrity: sha512-866lXSrpGpgyHBZUa2m9YNWqHDjjM0aBTJlNtYaGEw4rqY/dcD7deRVTbBBAJelfA7oaGDbNftXF/TL/A6RgoA==}
+    dependencies:
+      undici-types: 6.19.8
+    dev: true
+
+  /acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      acorn: 8.12.1
+    dev: true
+
+  /acorn@8.12.1:
+    resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /ts-node@10.9.2(@types/node@22.7.2)(typescript@5.6.2):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.7.2
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /typescript@5.6.2:
+    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+    dev: true
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "*": ["node_modules/*"]
+    }
+  },
+  "include": ["canhaz.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
By running `pnpm run canhaz nnnn` where nnnn is a sourcegraph/cody commit, this script will print which JetBrains versions contain that commit. You must set the CODY_DIR environment variable to a sourcegraph/cody repo; this script will fetch commits in that repo.

This reads version tags from the repo containing the working directory. If you need to fetch version tags, run the command mentioned in the script first.

## Test plan

This adds a script, it does not affect the product.

```
$ CODY_DIR=~/dev/cody pnpm run canhaz 343d9cfe7539806f447f23e0f9a4be70dcf713c3

> @ canhaz C:\Users\DominicCooney\dev\jetbrains\scripts
> ts-node canhaz.ts "343d9cfe7539806f447f23e0f9a4be70dcf713c3"


This script checks whether a given JetBrains release contains a specific Cody commit.
To fetch version git tags from origin, run:
  git fetch origin 'refs/tags/v*:refs/tags/v*'

Using sourcegraph/cody repo in C:/Users/DominicCooney/dev/cody
✔️ v7.0.6-nightly
✔️ v7.0.6
✔️ v7.0.5-nightly
✔️ v7.0.4-nightly
✔️ v7.0.4
✔️ v7.0.3-nightly
✔️ v7.0.2-nightly
✔️ v7.0.2
✔️ v7.0.1-nightly
✔️ v7.0.1
✔️ v7.0.0-nightly
✔️ v7.0.0
✔️ v6.0.38-nightly
✔️ v6.0.37-nightly
✔️ v6.0.36-nightly
✔️ v6.0.35-nightly
❌ v6.0.34-nightly
❌ v6.0.34
❌ v6.0.33-nightly
✔️ v6.0.32-nightly
✔️ v6.0.31-nightly
❌ v6.0.30-nightly
❌ v6.0.29-nightly
❌ v6.0.28-nightly
❌ v6.0.27-experimental
```

