### PR TITLE
Bump pluginUntilBuild to 243.*

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
             ideaIC:2023.2
             ideaIC:2024.2.3
           failure-levels: |
-            COMPATIBILITY_WARNINGS
             OVERRIDE_ONLY_API_USAGES
             NON_EXTENDABLE_API_USAGES
             PLUGIN_STRUCTURE_WARNINGS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
           plugin-location: '*.zip'
           ide-versions: |
             ideaIC:2023.2
-            ideaIC:2024.2
+            ideaIC:2024.2.3
           failure-levels: |
             COMPATIBILITY_WARNINGS
             OVERRIDE_ONLY_API_USAGES

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,6 @@ val versionsToValidate =
     }
 val skippedFailureLevels =
     EnumSet.of(
-        FailureLevel.COMPATIBILITY_PROBLEMS, // blocked by: compatibility hack for IJ 2022.1 / 2024+
         FailureLevel.DEPRECATED_API_USAGES,
         FailureLevel.INTERNAL_API_USAGES,
         FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") 
 // Remove unsupported old versions from this list.
 // Update gradle.properties pluginSinceBuild, pluginUntilBuild to match the min, max versions in
 // this list.
-val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2").sorted()
+val versionsOfInterest = listOf("2023.2", "2023.3", "2024.1", "2024.2.3").sorted()
 val versionsToValidate =
     when (project.properties["validation"]?.toString()) {
       "lite" -> listOf(versionsOfInterest.first(), versionsOfInterest.last())

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=232
-pluginUntilBuild=242.*
+pluginUntilBuild=243.*
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType=IC
 platformVersion=2023.2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,7 @@
 
     <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
 
+    <depends>com.intellij.modules.json</depends>
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>


### PR DESCRIPTION
We this PR we test our compatibility for the incoming 2024.3. 

Compatibility verification in Marketplace gave us a single error about the missing package:
[Package 'com.jetbrains.jsonSchema' is not found ](https://plugins.jetbrains.com/plugin/9682-cody-ai-coding-assistant-with-autocomplete--chat/edit/versions)

That results with the error on `Open Cody Settings Editor`:
```
java.lang.NoClassDefFoundError: com/jetbrains/jsonSchema/UserDefinedJsonSchemaConfiguration
	at com.sourcegraph.cody.config.actions.OpenCodySettingsEditorAction.reloadSchemaAsync$lambda$3(OpenCodySettingsEditorAction.kt:45)
	at com.sourcegraph.cody.agent.CodyAgentService$Companion.withAgent$lambda$2(CodyAgentService.kt:186)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport$executeOnPooledThread$1.run(AnyThreadWriteThreadingSupport.kt:126)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at com.intellij.util.concurrency.ContextCallable.lambda$call$1(ContextCallable.java:74)
	at com.intellij.util.concurrency.ContextCallable.call(ContextCallable.java:83)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:101)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:101)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:107)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:101)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:24)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: com.jetbrains.jsonSchema.UserDefinedJsonSchemaConfiguration PluginClassLoader(plugin=PluginDescriptor(name=Sourcegraph, id=com.sourcegraph.jetbrains, descriptorPath=plugin.xml, path=~/Library/Application Support/JetBrains/IntelliJIdea2024.3/plugins/Sourcegraph, version=6.0-localbuild, package=null, isBundled=false), packagePrefix=null, state=active, parents=PluginDescriptor(name=Git, id=Git4Idea, moduleName=intellij.vcs.git/terminal, descriptorPath=intellij.vcs.git.terminal.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/plugins/vcs-git, version=243.16718.32, package=git4idea.terminal, isBundled=true), PluginDescriptor(name=Git, id=Git4Idea, moduleName=intellij.vcs.git/newUiOnboarding, descriptorPath=intellij.vcs.git.newUiOnboarding.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/plugins/vcs-git, version=243.16718.32, package=git4idea.newUiOnboarding, isBundled=true), PluginDescriptor(name=Git, id=Git4Idea, moduleName=intellij.vcs.git.coverage, descriptorPath=intellij.vcs.git.coverage.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/plugins/vcs-git, version=243.16718.32, package=com.intellij.vcs.git.coverage, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.impl, descriptorPath=intellij.platform.vcs.impl.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/lib, version=243.16718.32, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.log.impl, descriptorPath=intellij.platform.vcs.log.impl.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/lib, version=243.16718.32, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.vcs.dvcs.impl, descriptorPath=intellij.platform.vcs.dvcs.impl.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/lib, version=243.16718.32, package=null, isBundled=true), PluginDescriptor(name=IDEA CORE, id=com.intellij, moduleName=intellij.platform.collaborationTools, descriptorPath=intellij.platform.collaborationTools.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/lib, version=243.16718.32, package=null, isBundled=true), PluginDescriptor(name=Git, id=Git4Idea, descriptorPath=plugin.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/plugins/vcs-git, version=243.16718.32, package=git4idea, isBundled=true), PluginDescriptor(name=Perforce Helix Core, id=PerforceDirectPlugin, descriptorPath=plugin.xml, path=~/Applications/IntelliJ IDEA Ultimate 2024.3 EAP.app/Contents/plugins/vcs-perforce, version=243.16718.32, package=null, isBundled=true), )
	at com.intellij.ide.plugins.cl.PluginClassLoader.loadClass(PluginClassLoader.kt:157)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 19 more
```

## Test plan
1. Open Cody Settings Editor

--- 

We should resolve the compatibility issue before merging this one. The package may have been moved or deleted (and replaced by some other lib or smth). 

## TODO
- [ ] Resolve the compatibility issue with the `jsonSchema` package
