### PR TITLE
Simplify build properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 fun properties(key: String) = project.findProperty(key)?.toString()
 
-val isForceBuild = properties("forceBuild") == "true"
-val isForceAgentBuild =
-    isForceBuild ||
-        properties("forceCodyBuild") == "true" ||
-        properties("forceAgentBuild") == "true"
-val isForceCodeSearchBuild = isForceBuild || properties("forceCodeSearchBuild") == "true"
+val isForceAgentBuild = properties("forceAgentBuild") == "true"
+val isForceCodeSearchBuild = properties("forceCodeSearchBuild") == "true"
 
 // As https://www.jetbrains.com/updates/updates.xml adds a new "IntelliJ IDEA" YYYY.N version, add
 // it to this list.


### PR DESCRIPTION
- Remove redundant `forceCodyBuild` variable, use `forceAgentBuild`
- Remove undocumented `forceBuild` variable

## Test plan

```
./gradlew buildPlugin -PforceAgentBuild=true
./gradlew buildPlugin -PforceAgentBuild=true
```

and verify that the Cody step, ` pnpm run -s build:root && pnpm run -s build:webviews && pnpm run -s build:agent`, runs both times.