### PR TITLE
Remove dep on `m.intellij.modules.lang`

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,7 +12,6 @@
     <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
 
     <depends>com.intellij.modules.json</depends>
-    <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>
     <depends optional="true" config-file="plugin-perforce.xml">


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-3895/drop-dependency-on-comintellijmoduleslang-to-support-gateway.

I removed this dep. I tried our features. I see no problems. Verifier does not complain about it missing. I seems that the dependence is redundant. 

## Test plan
1. Full QA, try autocomplete
