### PR TITLE
Fix `com.intellij.jetbrains.client` compatibility

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,8 +9,6 @@
     <change-notes>
         <![CDATA[Update notes are available on <a href="https://github.com/sourcegraph/jetbrains/releases">GitHub</a>.]]></change-notes>
 
-    <incompatible-with>com.intellij.jetbrains.client</incompatible-with>
-
     <depends>com.intellij.modules.json</depends>
     <depends>com.intellij.modules.platform</depends>
     <depends optional="true" config-file="plugin-git.xml">Git4Idea</depends>


### PR DESCRIPTION
Reverts https://github.com/sourcegraph/jetbrains/pull/540.

We encountered an issue on when insallig the plugin on windows. Maybe we can remove it... (manual testing in progress)

## Test plan
1. Remote Dev works on windows (install plugin from disk on windows in remote dev)
