### PR TITLE
Add toolbar menu item for opening WebView DevTools

### DIFF
--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
@@ -33,6 +33,11 @@ public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
           customCodySettings.add(new OpenPluginSettingsAction("Cody Settings..."));
           customCodySettings.add(new OpenCodySettingsEditorAction());
           customCodySettings.addSeparator();
+
+          if (ConfigUtil.isFeatureFlagEnabled("cody.feature.internals-menu")) {
+            customCodySettings.add(new OpenWebviewDevToolsAction(toolWindowContent));
+          }
+
           toolWindow.setAdditionalGearActions(customCodySettings);
           return null;
         });

--- a/src/main/kotlin/com/sourcegraph/cody/OpenWebviewDevToolsAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/OpenWebviewDevToolsAction.kt
@@ -1,0 +1,11 @@
+package com.sourcegraph.cody
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.sourcegraph.common.ui.DumbAwareEDTAction
+
+class OpenWebviewDevToolsAction(val toolWindowContent: CodyToolWindowContent) :
+    DumbAwareEDTAction("Open WebView DevTools") {
+  override fun actionPerformed(e: AnActionEvent) {
+    toolWindowContent.openDevTools()
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIProxy.kt
@@ -58,7 +58,6 @@ private const val MAIN_RESOURCE_URL = "${PSEUDO_HOST_URL_PREFIX}main-resource-no
 
 internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCefBrowserBase) {
   companion object {
-
     /**
      * TODO: Hopefully this can be removed when JetBrains will patch focus handler implementation
      *   https://youtrack.jetbrains.com/issue/IJPL-158952/Focus-issue-when-using-multiple-JCEF-instances
@@ -110,8 +109,6 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
           JBCefBrowserBuilder()
               .apply {
                 setOffScreenRendering(CodyApplicationSettings.instance.isOffScreenRenderingEnabled)
-                // TODO: Make this conditional on running in a debug configuration.
-                setEnableOpenDevToolsMenuItem(true)
               }
               .build()
 
@@ -207,6 +204,10 @@ internal class WebUIProxy(private val host: WebUIHost, private val browser: JBCe
           browser.cefBrowser)
       return proxy
     }
+  }
+
+  fun openDevTools() {
+    browser.openDevtools()
   }
 
   private fun handleCefQuery(query: String) {

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
@@ -20,11 +20,12 @@ private interface WebviewHost {
   fun reset()
 }
 
-private class CodyToolWindowContentWebviewHost(private val owner: CodyToolWindowContent) :
+internal class CodyToolWindowContentWebviewHost(private val owner: CodyToolWindowContent) :
     WebviewHost {
   override val id = "cody.chat"
 
   var proxy: WebUIProxy? = null
+    private set
 
   override val viewDelegate =
       object : WebviewViewDelegate {
@@ -37,11 +38,10 @@ private class CodyToolWindowContentWebviewHost(private val owner: CodyToolWindow
     runInEdt {
       assert(this.proxy == null)
       this.proxy = proxy
-      val component = proxy.component
-      if (component == null) {
+      if (proxy.component == null) {
         thisLogger().warn("expected browser component to be created, but was null")
       }
-      owner.setWebviewComponent(component)
+      owner.setWebviewComponent(this)
     }
   }
 


### PR DESCRIPTION
sourcegraph/cody webview swallows right clicks, so the menu item to open devtools is no longer available. This adds a menu item to the tool window when the `CODY_JETBRAINS_FEATURES=cody.features.internals-menu=true` environment variable is set.

Caveats:
- The menu item does nothing if the WebView is not started.
- We're simply using JCEF `JBCefBrowserBase.openDevTools()` to show the devtools, and this is basically a one-off operation. After you close that window, JCEF disposes the devtools and you cannot open them a second time. Annoying, but not working around this right now.

## Test plan

1. Click on the Cody tool window overflow menu, no menu item should appear.
2. Restart the IDE with `CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true` and click on the toolbar window, menu item to open devtools should appear.
3. Open devtools and inspect the webview content.

![image](https://github.com/user-attachments/assets/7c32355e-868a-4489-89f9-73563fd02fbf)
