### PR TITLE
Get model availability form endpoint instead of computing it manually

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=744d4cf37487275817db55f39188bfea50d12fe5
+cody.commit=f4138ff864446cf4d1bb7270406d7d8af6b9dd9f

--- a/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
+++ b/src/integrationTest/resources/recordings/integration-test_2927926756/recording.har.yaml
@@ -36,19 +36,19 @@ log:
         queryString: []
         url: https://sourcegraph.com/.api/client-config
       response:
-        bodySize: 227
+        bodySize: 224
         content:
           encoding: base64
           mimeType: text/plain; charset=utf-8
-          size: 227
-          text: "[\"H4sIAAAA\",\"AAAAA2yOsQrCMBRF935F6Ozk2K0Eh26Fgs6v5omBvLySd4OK+O8uFZfM\
-            59zDfXfOOddfNbxOmdbEoR8cSuXDDu6EJqAK9SpbYnB7WQ0qXkUoB2s3gBLXiqj5z2+\
-            U7CeYUIHXDH7iEnPQR7MjGjjZOE/tSiKwYanbpgUc9tdRsy0oTDLO05mLRc394I7dp/\
-            sCAAD//wMARx9M/RUBAAA=\"]"
+          size: 224
+          text: "[\"H4sIAAAAAAAAA2yOsQrCMBRF935F6Ozo1K0Eh26Fgs6v5omBvLySd4OK+O8uFZfM59zDf\
+            XfOOddfNbxOmdbEoR8cSuXDDu6EJqAK9SpbYnB7WQ0qXkUoB2s3gBLXiqj5z2+U7CeY\
+            UIHXDH7iEnPQR7MjGjjZOE/tSiKwYanbpgUc9tdRsy0oTDLO05mLRc394I7dp/sCAAD\
+            //wMAm0An2BUBAAA=\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:30 GMT
+            value: Fri, 04 Oct 2024 13:59:37 GMT
           - name: content-type
             value: text/plain; charset=utf-8
           - name: transfer-encoding
@@ -79,7 +79,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:29.810Z
+      startedDateTime: 2024-10-04T13:59:37.468Z
       time: 0
       timings:
         blocked: -1
@@ -106,7 +106,7 @@ log:
           - name: user-agent
             value: JetBrains / 6.0-localbuild
           - name: traceparent
-            value: 00-9b4e74b88c22decc5ed5bc93db05d813-cbd81cec67fc71b7-01
+            value: 00-ed85f1af6f4d7fa2902df02563cd0939-91e6e37e2e48582c-01
           - name: connection
             value: keep-alive
           - name: host
@@ -207,14 +207,14 @@ log:
             value: 6.0-localbuild
         url: https://sourcegraph.com/.api/completions/stream?api-version=2&client-name=jetbrains&client-version=6.0-localbuild
       response:
-        bodySize: 790
+        bodySize: 777
         content:
           mimeType: text/event-stream
-          size: 790
+          size: 777
           text: >+
             event: completion
 
-            data: {"deltaText":"\n/**\n * Imports the necessary Java utility classes, such as the `ArrayList` implementation of the `List` interface.\n */\n","stopReason":"stop_sequence"}
+            data: {"deltaText":"\n/**\n * Imports the necessary Java utility classes, including ArrayList, for use within the Foo class.\n */\n","stopReason":"stop_sequence"}
 
 
             event: done
@@ -224,7 +224,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:31 GMT
+            value: Fri, 04 Oct 2024 13:59:39 GMT
           - name: content-type
             value: text/event-stream
           - name: transfer-encoding
@@ -253,7 +253,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:30.472Z
+      startedDateTime: 2024-10-04T13:59:38.148Z
       time: 0
       timings:
         blocked: -1
@@ -291,7 +291,7 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 418
+        headersSize: 345
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -318,29 +318,19 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 260
+        bodySize: 255
         content:
           encoding: base64
           mimeType: application/json
-          size: 260
-          text: "[\"H4sIAAAAAAAAA3zOTQrCMBCG4bvM2tAxFcRuu7U7LzAmUxtSMyVJ/UF6d1ERxYKrgQ/eh\
-            7mBpUxQ3SC5zI9rxF6326aW0LrDGCk7Cc+9o9yI5R4qoJC7KIMzhelptKxKlSQEzkqj\
-            XqHWG1h8goYuO/EcElRLjYgLaCnl+r/XkfPjiytxDT/NnDRyHHp+PPtGWxf5LNGnwjI\
-            PidkrI5ajOmnVu8xqT4lhVn7RG0Scpmm6AwAA//8DAFuWIPolAQAA\"]"
-          textDecoded:
-            data:
-              site:
-                codyLLMConfiguration:
-                  chatModel: anthropic/claude-3-sonnet-20240229
-                  chatModelMaxTokens: 12000
-                  completionModel: fireworks/deepseek-coder-v2-lite-base
-                  completionModelMaxTokens: 9000
-                  fastChatModel: anthropic/claude-3-haiku-20240307
-                  fastChatModelMaxTokens: 12000
+          size: 255
+          text: "[\"H4sIAAAAAAAAA4TOTQ6CMBAF4LvMmmqDEA1btrLzAmM7QAN2SH+MhvTuBjYSNXH1ksmbL\
+            28GjQGhmsGbQEsq1s/zuanZtqaLDoNhu957DA1rGqECz9Ep6hxO/V6NGDWJw64Unq2l\
+            ANm72+DjwgNZD1VRSikzaNGH+g8lejRDhI/yxjqulOLbNNKy7xemiSZPNAjFmpy452I\
+            0gcQVPcHX78bOZXFKKaUXAAAA//8=\",\"AwAw4f3QGgEAAA==\"]"
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:28 GMT
+            value: Fri, 04 Oct 2024 13:59:36 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -371,7 +361,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:28.630Z
+      startedDateTime: 2024-10-04T13:59:36.347Z
       time: 0
       timings:
         blocked: -1
@@ -431,22 +421,22 @@ log:
             value: null
         url: https://sourcegraph.com/.api/graphql?CurrentSiteCodyLlmConfiguration
       response:
-        bodySize: 132
+        bodySize: 136
         content:
           encoding: base64
           mimeType: application/json
-          size: 132
+          size: 136
           text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdHJ+SmVPj6+zvl5aZnppUWJJZn5eWD53MSiE\
-            uf8vJLUipLwzLyU/HIlK6XUvMSknNQUpdra2loAAAAA//8DAOgINKVLAAAA\"]"
+            uf8vJLUipLwzLyU/HIlK6WUzOLEpJzUFKXa2tpaAAAAAP//AwArMNn0TAAAAA==\"]"
           textDecoded:
             data:
               site:
                 codyLLMConfiguration:
-                  smartContextWindow: enabled
+                  smartContextWindow: disabled
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:28 GMT
+            value: Fri, 04 Oct 2024 13:59:36 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -477,7 +467,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:28.672Z
+      startedDateTime: 2024-10-04T13:59:36.516Z
       time: 0
       timings:
         blocked: -1
@@ -515,7 +505,7 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 413
+        headersSize: 340
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -552,7 +542,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:29 GMT
+            value: Fri, 04 Oct 2024 13:59:36 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -583,7 +573,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:28.652Z
+      startedDateTime: 2024-10-04T13:59:36.371Z
       time: 0
       timings:
         blocked: -1
@@ -680,7 +670,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:28 GMT
+            value: Fri, 04 Oct 2024 13:59:36 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -711,7 +701,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:28.690Z
+      startedDateTime: 2024-10-04T13:59:36.540Z
       time: 0
       timings:
         blocked: -1
@@ -796,7 +786,7 @@ log:
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:29 GMT
+            value: Fri, 04 Oct 2024 13:59:37 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -827,7 +817,7 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:29.000Z
+      startedDateTime: 2024-10-04T13:59:36.892Z
       time: 0
       timings:
         blocked: -1
@@ -865,7 +855,7 @@ log:
             value: gzip,deflate
           - name: host
             value: sourcegraph.com
-        headersSize: 405
+        headersSize: 332
         httpVersion: HTTP/1.1
         method: POST
         postData:
@@ -890,16 +880,16 @@ log:
           encoding: base64
           mimeType: application/json
           size: 136
-          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkaWhhbmFvFGB\
-            kYmugaWuoaW8aZ65rrmxomJSaZmlkmGlslKtbW1AAAAAP//AwBQhF16SQAAAA==\"]"
+          text: "[\"H4sIAAAAAAAAA6pWSkksSVSyqlYqzixJBdEFRfkppcklYalFxZn5eUpWSkaWxhaGZvFGB\
+            kYmuoYGugYm8aZ65rrJyclJyYmmRokpJilKtbW1AAAAAP//AwDesQeISQAAAA==\"]"
           textDecoded:
             data:
               site:
-                productVersion: 291878_2024-09-19_5.7-73aab569b19c
+                productVersion: 293816_2024-10-04_5.7-cccbca52ad4d
         cookies: []
         headers:
           - name: date
-            value: Fri, 20 Sep 2024 10:58:28 GMT
+            value: Fri, 04 Oct 2024 13:59:36 GMT
           - name: content-type
             value: application/json
           - name: transfer-encoding
@@ -930,7 +920,101 @@ log:
         redirectURL: ""
         status: 200
         statusText: OK
-      startedDateTime: 2024-09-20T10:58:28.590Z
+      startedDateTime: 2024-10-04T13:59:36.294Z
+      time: 0
+      timings:
+        blocked: -1
+        connect: -1
+        dns: -1
+        receive: 0
+        send: 0
+        ssl: -1
+        wait: 0
+    - _id: a1889526ab4ac60a56dc11d08e0510f9
+      _order: 0
+      cache: {}
+      request:
+        bodySize: 0
+        cookies: []
+        headers:
+          - _fromType: array
+            name: authorization
+            value: token
+              REDACTED_3dd704711f82a44ff6aba261b53b61a03fb8edba658774639148630d838c2d1d
+          - _fromType: array
+            name: user-agent
+            value: JetBrains / 6.0-localbuild
+          - _fromType: array
+            name: accept
+            value: "*/*"
+          - _fromType: array
+            name: accept-encoding
+            value: gzip,deflate
+          - name: host
+            value: sourcegraph.com
+        headersSize: 270
+        httpVersion: HTTP/1.1
+        method: GET
+        queryString: []
+        url: https://sourcegraph.com/.api/modelconfig/supported-models.json
+      response:
+        bodySize: 1103
+        content:
+          encoding: base64
+          mimeType: text/plain; charset=utf-8
+          size: 1103
+          text: "[\"H4sIAAA=\",\"AAAAAP/smE1P4zgYx+/9FFaui4ubtpTNDbpiF2kZ0ICYw4iD6zxtrSax\
+            ZTt9EeK7j5I0YdKYJkVVURl6SuP/87fj3+PX5xZCCDmaTSGkj6A0F5HjIafTJs5JVqZ\
+            gzvPXpE3a5C8f5nmhVGLOfVDa8dDP9FXyey6eUhH3k1gamakSkrN1bFHscy0DuvpGQ0\
+            h0F4WukL2cbLcecwULoWa6xvqq0DW2nggxCaDG999M1NhUSIgorzG9lRBdXDc3Dbk2i\
+            gY1rjdr1att+vS05hkKH4KtMFPFdxiXkHqeS9wuJmeYdDyPBTT2AXfbfaxFFIGpadMw\
+            1aNuu4/urfq0zlydu+PcHbvE7ZEzl2yGMSrpiAfccCh/UqEAn29WlkVOqfX9eiSUCp4\
+            qtRqYCLVKO4ixWFG22myZNtTESZuSp1E1vwwHlSa2gkoZE5GBpfnBI18sHG+DT9ZfdH\
+            kdydg8iBlESTW9PiHE8j0hXd7GpqQkhJR0Lw0ScIecwELGdcM0zwd0a9HacyFxzfLAd\
+            f/ecx40pi3MFNR7UUslPhnpKeWzuCnq/2xiO+vUN4PdJYOPgq0lgP/R43pwMNjFEut5\
+            847naUMVE3413Tf43huqhjZdCe2bbvUwaWwEE6EMwMCRwXNJ77wRPLd/tk92PoDUADO\
+            cdjmeuzjgBvCI6rp9zj8A8h5ghh5d9D83gC4tMSWylDERR0afahErBhNF5fQ022Sc7t\
+            COrzzYRx5ke9ksCSYQ8ojjTruPLSvP5v42FaNOu4/uquIS8O2+h5qcRzSgEft4tAdcj\
+            d+AOw6onjbHe2WTvwXY6v1Hrb8H5Ls+3mWAQ75M/uDz5WCEeaSNilndKesmi0Hny8Fl\
+            szm7WDfyGbtRtfUJcISgD7fRyu4G0i11DxM33VJPpMG92kn67sEiKo9dq8/xH5OP7+x\
+            ko8yEv8JJl2KpYM5hgQnpNLokQqKTx2w/QjWpYd/jtx7ugnITcF2ZST4/Xrcx3mTR3Z\
+            ltxf6L7Va2rd++1/FhTOPA3OQ3oq/NyDrpffefzphqM2wWX7lBSSDDMDvlrG/kdzjbt\
+            bJvfGn9CgAA//8QR+8r9RcAAA==\"]"
+        cookies: []
+        headers:
+          - name: date
+            value: Fri, 04 Oct 2024 13:59:37 GMT
+          - name: content-type
+            value: text/plain; charset=utf-8
+          - name: transfer-encoding
+            value: chunked
+          - name: connection
+            value: keep-alive
+          - name: access-control-allow-credentials
+            value: "true"
+          - name: access-control-allow-origin
+            value: ""
+          - name: cache-control
+            value: no-cache, max-age=0
+          - name: content-encoding
+            value: gzip
+          - name: vary
+            value: Cookie,Accept-Encoding,Authorization,Cookie, Authorization,
+              X-Requested-With,Cookie
+          - name: x-content-type-options
+            value: nosniff
+          - name: x-frame-options
+            value: DENY
+          - name: x-xss-protection
+            value: 1; mode=block
+          - name: strict-transport-security
+            value: max-age=31536000; includeSubDomains; preload
+        headersSize: 1342
+        httpVersion: HTTP/1.1
+        redirectURL: ""
+        status: 200
+        statusText: OK
+      startedDateTime: 2024-10-04T13:59:37.668Z
       time: 0
       timings:
         blocked: -1

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ModelUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ModelUtil.kt
@@ -19,6 +19,6 @@ fun Model.displayName(): String = buildString {
   append(" by $provider")
 }
 
-fun Model.isCodyProOnly(): Boolean = tags.contains("pro")
+fun Model.isCodyProOnly(): Boolean = tags?.contains("pro") == true
 
-fun Model.isDeprecated(): Boolean = tags.contains("deprecated")
+fun Model.isDeprecated(): Boolean = tags?.contains("deprecated") == true

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatTagsLlmMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/ChatTagsLlmMigration.kt
@@ -20,7 +20,7 @@ object ChatTagsLlmMigration {
       val models =
           chatModels.completeOnTimeout(null, 10, TimeUnit.SECONDS).get()?.models ?: return@withAgent
 
-      migrateHistory(HistoryService.getInstance(project).state.accountData, models)
+      migrateHistory(HistoryService.getInstance(project).state.accountData, models.map { it.model })
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/DeprecatedChatLlmMigration.kt
@@ -29,7 +29,7 @@ object DeprecatedChatLlmMigration {
 
       migrateHistory(
           HistoryService.getInstance(project).state.accountData,
-          models,
+          models.map { it.model },
           this::showLlmUpgradeNotification)
     }
   }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -30,7 +30,7 @@ import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.ModelUsage
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_RetryParams
-import com.sourcegraph.cody.agent.protocol_generated.Model
+import com.sourcegraph.cody.agent.protocol_generated.ModelAvailabilityStatus
 import com.sourcegraph.cody.chat.PromptHistory
 import com.sourcegraph.cody.chat.ui.LlmDropdown
 import com.sourcegraph.cody.edit.EditUtil.namedButton
@@ -150,12 +150,12 @@ class EditCommandPrompt(
                   }
                 })
             renderer =
-                object : ListCellRenderer<Model> {
+                object : ListCellRenderer<ModelAvailabilityStatus> {
                   private val defaultRenderer = renderer
 
                   override fun getListCellRendererComponent(
-                      list: JList<out Model>?,
-                      value: Model?,
+                      list: JList<out ModelAvailabilityStatus>?,
+                      value: ModelAvailabilityStatus?,
                       index: Int,
                       isSelected: Boolean,
                       cellHasFocus: Boolean

--- a/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/history/state/LLMState.kt
@@ -23,7 +23,7 @@ class LLMState : BaseState() {
         it.model = chatModel.id
         it.title = chatModel.title
         it.provider = chatModel.provider
-        it.tags = chatModel.tags.toMutableList()
+        it.tags = chatModel.tags?.toMutableList() ?: mutableListOf()
         it.usage = chatModel.usage.toMutableList()
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/LlmComboBoxRenderer.kt
@@ -5,8 +5,7 @@ import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.Icons
 import com.sourcegraph.cody.agent.protocol_extensions.displayName
 import com.sourcegraph.cody.agent.protocol_extensions.getIcon
-import com.sourcegraph.cody.agent.protocol_extensions.isCodyProOnly
-import com.sourcegraph.cody.agent.protocol_generated.Model
+import com.sourcegraph.cody.agent.protocol_generated.ModelAvailabilityStatus
 import com.sourcegraph.cody.chat.ui.LlmDropdown
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import java.awt.BorderLayout
@@ -21,15 +20,18 @@ class LlmComboBoxRenderer(private val llmDropdown: LlmDropdown) : DefaultListCel
 
   override fun getListCellRendererComponent(
       list: JList<*>?,
-      model: Any?,
+      modelAvailabilityStatus: Any?,
       index: Int,
       isSelected: Boolean,
       cellHasFocus: Boolean
   ): Component {
-    val component = super.getListCellRendererComponent(list, model, index, isSelected, cellHasFocus)
-    if (model !is Model) {
+    val component =
+        super.getListCellRendererComponent(
+            list, modelAvailabilityStatus, index, isSelected, cellHasFocus)
+    if (modelAvailabilityStatus !is ModelAvailabilityStatus) {
       return this
     }
+    val model = modelAvailabilityStatus.model
     val panel = CellRendererPanel(BorderLayout())
     val iconLabel = JLabel(model.getIcon())
     panel.add(iconLabel, BorderLayout.WEST)
@@ -38,7 +40,7 @@ class LlmComboBoxRenderer(private val llmDropdown: LlmDropdown) : DefaultListCel
     val displayNameLabel = JLabel(model.displayName())
     textBadgePanel.add(displayNameLabel, BorderLayout.CENTER)
     textBadgePanel.border = BorderFactory.createEmptyBorder(0, 5, 0, 0)
-    if (model.isCodyProOnly() && llmDropdown.isCurrentUserFree()) {
+    if (!modelAvailabilityStatus.isModelAvailable) {
       textBadgePanel.add(JLabel(Icons.LLM.ProSticker), BorderLayout.EAST)
     }
     val isInline = llmDropdown.parentDialog != null


### PR DESCRIPTION
## Changes

Follow-up to https://github.com/sourcegraph/cody/pull/5804

Instead of manually fetching account tier and computing model availability we instead receiving it from agent.
This makes code simpler, ensures the same consitions are used by both Cody and JetBrains, and is less error prone.

## Test plan

**Free user**

1. Login as free user
2. Open Edit Code popup
3. Ensure models are visible
4. Choose one without `Pro` label and do the edit -> it should success
5. Choose one with `Pro` label and do the edit -> it should open the account upgrade website

**Pro use**

1. Login as pro user
2. Open Edit Code popup
3. Ensure models are visible, and there are no `Pro` labels anywhere
4. Choose model which was previously marked as pro on the free tier and do the edit -> it should success

**Enterprise user**

1. Login as enterprise user
2. Open Edit Code popup
3. Ensure models are visible, and there are no `Pro` labels anywhere
4. Choose model which was previously marked as pro (if such exists) on the free tier and do the edit -> it should success

Attention: This is different than the current behaviour, but I checked Cody and it allows for model selection for the enterprise accounts so I think JetBrains behaviour drifted there.
