### PR TITLE
RD: Distinguish INVOKE trigger kind in the completion provider

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -52,13 +52,15 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
     val cancellationToken = CancellationToken()
     currentJob.set(cancellationToken)
 
+    val triggerKind =
+        if (request.event is InlineCompletionEvent.DirectCall) {
+          InlineCompletionTriggerKind.INVOKE
+        } else {
+          InlineCompletionTriggerKind.AUTOMATIC
+        }
+
     val completions =
-        fetchCompletions(
-                project,
-                editor,
-                InlineCompletionTriggerKind.AUTOMATIC,
-                cancellationToken,
-                lookupString)
+        fetchCompletions(project, editor, triggerKind, cancellationToken, lookupString)
             .completeOnTimeout(null, 1, TimeUnit.SECONDS)
             .get() ?: return InlineCompletionSuggestion.empty()
 


### PR DESCRIPTION
Previously, we were assigning AUTOMATIC trigger kind even for a direct call (manually triggered) autocompletions. This PR sets the proper trigger kind for manual triggers.

## Test plan
1. In RD trigger `shift + option + \` 
