### PR TITLE
Remove redundant title from the edit dialog (fixes https://linear.app/sourcegraph/issue/QA-72)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -77,13 +77,11 @@ class LlmDropdown(
     val selectedFromHistory = HistoryService.getInstance(project).getDefaultLlm()
 
     selectedItem =
-        availableModels
-            .map { it.model }
-            .find {
-              it.id == model ||
-                  it.id == selectedFromHistory?.model ||
-                  it.id == selectedFromChatState?.id
-            } ?: models.firstOrNull()
+        availableModels.find {
+          it.model.id == model ||
+              it.model.id == selectedFromHistory?.model ||
+              it.model.id == selectedFromChatState?.id
+        } ?: models.firstOrNull()
 
     // If the dropdown is already disabled, don't change it. It can happen
     // in the case of the legacy commands (updateAfterFirstMessage happens before this call).

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -234,7 +234,6 @@ class EditCommandPrompt(
     popup =
         JBPopupFactory.getInstance()
             .createComponentPopupBuilder(createPopupContent(), instructionsField)
-            .setTitle(dialogTitle)
             .setMovable(true)
             .setResizable(true)
             .setRequestFocus(true)


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-99/null-model-in-inline-edit.
Fixes https://linear.app/sourcegraph/issue/QA-72/jetbrains-title-for-edit-code-with-cody-is-misplaced

## Test plan
1. Inline Edits work properly
