### PR TITLE
Rewrite InstructionsInputTextArea to use JBTextArea

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -125,7 +125,7 @@ class EditCommandPrompt(
       }
 
   private val instructionsField =
-      InstructionsInputTextArea(this).apply { text = previousEdit?.instruction ?: lastPrompt }
+      InstructionsInputTextArea().apply { text = previousEdit?.instruction ?: lastPrompt }
 
   private val historyManager = TextAreaHistoryManager(instructionsField, promptHistory)
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/InstructionsInputTextArea.kt
@@ -1,86 +1,22 @@
 package com.sourcegraph.cody.edit
 
-import com.intellij.openapi.Disposable
-import com.intellij.openapi.util.Disposer
+import com.intellij.ui.SimpleTextAttributes
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.components.TextComponentEmptyText
 import com.intellij.util.ui.JBUI
-import com.sourcegraph.cody.edit.EditCommandPrompt.Companion.textFieldBackground
-import java.awt.Graphics
-import java.awt.Graphics2D
-import java.awt.RenderingHints
-import java.awt.event.FocusEvent
-import java.awt.event.FocusListener
-import javax.swing.JTextArea
-import javax.swing.event.DocumentEvent
-import javax.swing.event.DocumentListener
+import java.util.function.Predicate
 
-class InstructionsInputTextArea(parentDisposable: Disposable) :
-    JTextArea(), FocusListener, Disposable {
-
-  private inner class GhostTextDocumentListener : DocumentListener {
-    private var previousTextEmpty = true
-
-    override fun insertUpdate(e: DocumentEvent) {
-      handleDocumentChange(e)
-    }
-
-    override fun removeUpdate(e: DocumentEvent) {
-      handleDocumentChange(e)
-    }
-
-    override fun changedUpdate(e: DocumentEvent) {
-      // Ignore changedUpdate events
-    }
-
-    private fun handleDocumentChange(e: DocumentEvent) {
-      val currentTextEmpty = e.document.getText(0, e.document.length).isNullOrBlank()
-      if (currentTextEmpty != previousTextEmpty) {
-        previousTextEmpty = currentTextEmpty
-        repaint()
-      }
-    }
-  }
-
-  private val ghostTextDocumentListener = GhostTextDocumentListener()
+class InstructionsInputTextArea : JBTextArea() {
 
   init {
-    Disposer.register(parentDisposable, this)
-
-    addFocusListener(this)
-    document.addDocumentListener(ghostTextDocumentListener)
-
     lineWrap = true
     wrapStyleWord = true
     border = JBUI.Borders.empty(JBUI.insets(10, 15))
-  }
 
-  override fun paintComponent(g: Graphics) {
-    background = textFieldBackground()
-    (g as Graphics2D).background = textFieldBackground()
-    super.paintComponent(g)
-
-    if (text.isNullOrBlank()) {
-      g.apply {
-        setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
-        color = EditUtil.getThemeColor("Component.infoForeground")
-        val leftMargin = 15
-        drawString(GHOST_TEXT, leftMargin, (fontMetrics.height * 1.5).toInt() - 2)
-      }
-    }
-  }
-
-  // Focus tracking ensures the ghost text is hidden or shown on focus change.
-  // The superclass has a tendency to hide the text when we lose the focus.
-  override fun focusGained(e: FocusEvent?) {
-    repaint()
-  }
-
-  override fun focusLost(e: FocusEvent?) {
-    repaint()
-  }
-
-  override fun dispose() {
-    removeFocusListener(this)
-    document.removeDocumentListener(ghostTextDocumentListener)
+    emptyText.appendText(GHOST_TEXT, SimpleTextAttributes.GRAY_ATTRIBUTES)
+    putClientProperty(
+        TextComponentEmptyText.STATUS_VISIBLE_FUNCTION,
+        Predicate { c: JBTextArea -> c.text.isEmpty() })
   }
 
   companion object {


### PR DESCRIPTION
## Changes

Some users reported that text in the edit window does not render properly.
I cannot reproduce it but I suspect it might be due to custom rendering we are doing, I hope switching back to default IJ component might solve the issue (and if not, it's still simpler and less code).

## Test plan

1. Run Edit Code command
2. Ghost test saying `"Type what changes you want to make to this file..."` should be visible
3. Ghost text should disappear when user type anything in the window
4. Ghost text should reappear when text is removed