### PR TITLE
Fix auth workflow

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -85,16 +85,10 @@ class CodyToolWindowContent(project: Project) {
   @RequiresEdt
   internal fun setWebviewComponent(host: CodyToolWindowContentWebviewHost?) {
     webview = host
-    if (webview == null) {
-      refreshPanelsVisibility()
-    } else {
-      val component = host?.proxy?.component
-      if (component == null) {
-        logger.warn("expected browser component to be created, but was null")
-      } else {
-        showView(component)
-      }
+    if (host != null && host.proxy?.component == null) {
+      logger.warn("expected browser component to be created, but was null")
     }
+    refreshPanelsVisibility()
   }
 
   fun openDevTools() {

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAccountListModel.kt
@@ -76,7 +76,7 @@ class CodyAccountListModel(private val project: Project) :
 
     val account = CodyAccount(login, displayName, server, id)
     if (accountsListModel.isEmpty) {
-      activeAccount = account
+      CodyAuthenticationManager.getInstance().setActiveAccount(account)
     }
     if (!accountsListModel.toList().contains(account)) {
       accountsListModel.add(account)

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
@@ -8,19 +8,19 @@ import com.intellij.openapi.vfs.LocalFileSystem
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.config.ConfigUtil
 
-class CodySettingsChangeListener(private val project: Project) : FileDocumentManagerListener {
+class CodySettingsFileChangeListener(private val project: Project) : FileDocumentManagerListener {
   override fun beforeDocumentSaving(document: Document) {
     val currentFile = FileDocumentManager.getInstance().getFile(document)
     val configFile =
         LocalFileSystem.getInstance()
             .refreshAndFindFileByNioFile(ConfigUtil.getSettingsFile(project))
     if (currentFile == configFile) {
-      CodyAgentService.getInstance(project).restartAgent(project)
-      // TODO: we should instead call `extensionConfiguration_didChange` there:
-      // `it.server.extensionConfiguration_didChange(ConfigUtil.getAgentConfiguration(project,
-      // document.text))` but it seams that some of the settings changes (like enabling/disabling
-      // autocomplete) requires agent restart to take effect.
-
+      // TODO: it seams that some of the settings changes (like enabling/disabling autocomplete)
+      // requires agent restart to take effect.
+      CodyAgentService.withAgentRestartIfNeeded(project) {
+        it.server.extensionConfiguration_didChange(
+            ConfigUtil.getAgentConfiguration(project, document.text))
+      }
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -241,6 +241,7 @@ class EditCommandPrompt(
             .createPopup()
 
     popup?.showInBestPositionFor(editor)
+
     popup?.addListener(
         object : JBPopupListener {
           override fun onClosed(event: LightweightWindowEvent) {

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -2,14 +2,17 @@ package com.sourcegraph.cody.initialization
 
 import com.intellij.AppTopics
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEventMulticasterEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.config.CodyAuthenticationManager
-import com.sourcegraph.cody.config.CodySettingsChangeListener
+import com.sourcegraph.cody.config.CodySettingsFileChangeListener
 import com.sourcegraph.cody.config.migration.SettingsMigration
+import com.sourcegraph.cody.config.notification.AccountSettingChangeListener
+import com.sourcegraph.cody.config.notification.CodySettingChangeListener
 import com.sourcegraph.cody.config.ui.CheckUpdatesTask
 import com.sourcegraph.cody.listeners.CodyCaretListener
 import com.sourcegraph.cody.listeners.CodyDocumentListener
@@ -51,7 +54,12 @@ class PostStartupActivity : ProjectActivity {
     multicaster.addDocumentListener(CodyDocumentListener(project), disposable)
     project.messageBus
         .connect(disposable)
-        .subscribe(AppTopics.FILE_DOCUMENT_SYNC, CodySettingsChangeListener(project))
+        .subscribe(AppTopics.FILE_DOCUMENT_SYNC, CodySettingsFileChangeListener(project))
+
+    // DO NOT remove those lines.
+    // Project level listeners need to be used at least once to get initialized.
+    project.service<AccountSettingChangeListener>()
+    project.service<CodySettingChangeListener>()
 
     TelemetryV2.sendTelemetryEvent(project, "extension", "started")
   }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-71
Fixes https://linear.app/sourcegraph/issue/QA-105
Fixes https://linear.app/sourcegraph/issue/CODY-3884

## Fixes

1. Changes done in the account management panel were not triggering `AccountSettingChangeContext` event and whole flow connected with it (fixed in `CodyAccountListModel.kt`)
2. After webview is ready and we should not switch to it immediately but instead call `refreshPanelsVisibility` to establish proper state
3. Change listeners being project services need to be invoked at least once to be initialised and in turn connected to the event bus. Otherwise they will not process any events.

All in all, considering amount of bugs there, I'm surprised that there were not even more issues visible.

There is one minor remaining issue:
Sometimes when switching to webview, loging panel from webview is visible for a fraction of second.
I think we can live with it until we will fully switch to webview.

## Test plan

1. Start new IJ project.
2. Wait 20s to make sure no webview login panel will appear
3. Login to the Cody using native login panel
4. Webview should be displayed
5. Restart IDE - you should be still logged in with the same account, webview chat view should appear 
6. Open Account Management and remove account, then click Ok. You should be moved back to the native login panel.
7. Wait some time to make sure webview login panel won't appear.
8. Login to the Cody using native login panel
9. Click `Manage Accounts` in Cody status bar and add new account of different tier.
10. Click on the `Account` tab in the Cody panel and make sure account was switched
11. Click `Sign Out`. Native login panel should appear immediately.
12. Click `Manage Accounts` in Cody status bar and make sure both accounts are still there, but neither is marked as active.
13. Mark one of them as active and click OK. Webview chat should be displayed