### PR TITLE
Fix "Open Revision Diff in Sourcegraph Web" issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,8 @@ val skippedFailureLevels =
         // remote IDE
         FailureLevel.DEPRECATED_API_USAGES,
         FailureLevel.INTERNAL_API_USAGES,
-        FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES, // blocked by: Kotlin UI DSL Cell.align
+        FailureLevel
+            .SCHEDULED_FOR_REMOVAL_API_USAGES, // HttpConfigurable, migration to coroutines, others
         FailureLevel.EXPERIMENTAL_API_USAGES,
         FailureLevel.NOT_DYNAMIC)!!
 

--- a/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -77,7 +77,6 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
                 } else {
                   url =
                       URLBuilder.buildEditorFileUrl(
-                          project,
                           repoInfo.remoteUrl,
                           repoInfo.remoteBranchName,
                           repoInfo.relativePath,

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -167,4 +167,3 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
                 new RevisionContext(repository.getCurrentRevision(), repository.getRoot()));
   }
 }
-

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -82,6 +82,7 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
 
               String url;
               try {
+                // todo: this is broken. url contains `null` in the path. we need to fix it.
                 url =
                     URLBuilder.buildCommitUrl(
                         ConfigUtil.getServerPath().getUrl(),
@@ -131,6 +132,7 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
 
   @NotNull
   private Optional<RevisionContext> getLogRevisionContext(@NotNull AnActionEvent event) {
+    // todo: it does not work when triggered from the editor's context menu. we need to fix it.
     VcsLogCommitSelection log =
         event.getDataContext().getData(VcsLogDataKeys.VCS_LOG_COMMIT_SELECTION);
     Project project = event.getProject();

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -87,7 +87,6 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
 
               String url;
               try {
-                // todo: this is broken. url contains `null` in the path. we need to fix it.
                 url =
                     URLBuilder.buildCommitUrl(
                         ConfigUtil.getServerPath().getUrl(),

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.VcsDataKeys;
 import com.intellij.openapi.vcs.history.VcsFileRevision;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.vcs.log.VcsLog;
+import com.intellij.vcs.log.VcsLogCommitSelection;
 import com.intellij.vcs.log.VcsLogDataKeys;
 import com.intellij.vcsUtil.VcsUtil;
 import com.sourcegraph.common.BrowserOpener;
@@ -131,18 +131,19 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
 
   @NotNull
   private Optional<RevisionContext> getLogRevisionContext(@NotNull AnActionEvent event) {
-    VcsLog log = event.getDataContext().getData(VcsLogDataKeys.VCS_LOG);
+    VcsLogCommitSelection log =
+        event.getDataContext().getData(VcsLogDataKeys.VCS_LOG_COMMIT_SELECTION);
     Project project = event.getProject();
 
     if (project == null) {
       return Optional.empty();
     }
-    if (log == null || log.getSelectedCommits().isEmpty()) {
+    if (log == null || log.getCommits().isEmpty()) {
       return Optional.empty();
     }
 
-    String revision = log.getSelectedCommits().get(0).getHash().asString();
-    VirtualFile root = log.getSelectedCommits().get(0).getRoot();
+    String revision = log.getCommits().get(0).getHash().asString();
+    VirtualFile root = log.getCommits().get(0).getRoot();
     return Optional.of(new RevisionContext(revision, root));
   }
 }

--- a/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -62,8 +62,7 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
                   String codeHostUrl =
                       (scope == Scope.REPOSITORY) ? repoInfo.getCodeHostUrl() : null;
                   String repoName = (scope == Scope.REPOSITORY) ? repoInfo.getRepoName() : null;
-                  url =
-                      URLBuilder.buildDirectSearchUrl(project, selectedText, codeHostUrl, repoName);
+                  url = URLBuilder.buildDirectSearchUrl(selectedText, codeHostUrl, repoName);
                 } else {
                   url = URLBuilder.buildEditorSearchUrl(selectedText, remoteUrl, remoteBranchName);
                 }

--- a/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -99,9 +99,11 @@ public class URLBuilder {
     }
 
     URI remote = URI.create(remoteUrl);
+    String host = remote.getHost() != null ? remote.getHost() : "";
+    String slash = sourcegraphBase.endsWith("/") ? "" : "/";
 
     return sourcegraphBase
-        + String.format("/%s%s", remote.getHost(), remote.getPath())
+        + String.format("%s%s%s", slash, host, remote.getPath())
         + String.format("/-/commit/%s", revisionNumber)
         + String.format("?editor=%s", URLEncoder.encode("JetBrains", StandardCharsets.UTF_8))
         + String.format(

--- a/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -66,10 +66,7 @@ public class URLBuilder {
 
   @NotNull
   public static String buildDirectSearchUrl(
-      @NotNull Project project,
-      @NotNull String search,
-      @Nullable String codeHost,
-      @Nullable String repoName) {
+      @NotNull String search, @Nullable String codeHost, @Nullable String repoName) {
     String repoFilter =
         (codeHost != null && repoName != null)
             ? "repo:^" + RegexEscaper.INSTANCE.escapeRegexChars(codeHost + "/" + repoName) + "$"

--- a/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -1,7 +1,6 @@
 package com.sourcegraph.website;
 
 import com.intellij.openapi.editor.LogicalPosition;
-import com.intellij.openapi.project.Project;
 import com.sourcegraph.common.RegexEscaper;
 import com.sourcegraph.config.ConfigUtil;
 import java.net.URI;
@@ -13,7 +12,6 @@ import org.jetbrains.annotations.Nullable;
 public class URLBuilder {
   @NotNull
   public static String buildEditorFileUrl(
-      @NotNull Project project,
       @NotNull String remoteUrl,
       @NotNull String branchName,
       @NotNull String relativePath,

--- a/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/ui/SimpleAccountsListCellRenderer.kt
@@ -12,9 +12,20 @@ import com.sourcegraph.cody.auth.Account
 import com.sourcegraph.cody.auth.AccountDetails
 import com.sourcegraph.cody.auth.ServerAccount
 import com.sourcegraph.cody.config.CachingCodyUserAvatarLoader
-import java.awt.*
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.FlowLayout
+import java.awt.Font
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Image
 import java.util.concurrent.CompletableFuture
-import javax.swing.*
+import javax.swing.Icon
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.ListCellRenderer
 import org.jetbrains.annotations.Nls
 
 class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
@@ -97,7 +108,7 @@ class SimpleAccountsListCellRenderer<A : Account, D : AccountDetails>(
     UIUtil.setBackgroundRecursively(
         this, ListUiUtil.WithTallRow.background(list, isSelected, list.hasFocus()))
     val primaryTextColor = ListUiUtil.WithTallRow.foreground(isSelected, list.hasFocus())
-    val secondaryTextColor = ListUiUtil.WithTallRow.secondaryForeground(list, isSelected)
+    val secondaryTextColor = ListUiUtil.WithTallRow.secondaryForeground(isSelected, list.hasFocus())
 
     accountName.apply {
       text = account.name

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -36,7 +36,7 @@ abstract class BaseCommandAction : DumbAwareEDTAction() {
       ReadAction.nonBlocking(
               Callable { IgnoreOracle.getInstance(project).policyForUri(protocolFile.uri).get() })
           .expireWith(project)
-          .finishOnUiThread(ModalityState.NON_MODAL) {
+          .finishOnUiThread(ModalityState.nonModal()) {
             when (it) {
               IgnorePolicy.USE -> {
                 CodyAgentService.withAgent(project) { agent ->

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -155,7 +155,7 @@ class CodyAuthenticationManager :
 
     if (token != null) {
       val executor = SourcegraphApiRequestExecutor.Factory.instance.create(theAccount.server, token)
-      val progressIndicator = EmptyProgressIndicator(ModalityState.NON_MODAL)
+      val progressIndicator = EmptyProgressIndicator(ModalityState.nonModal())
       val submitIOTask =
           service<ProgressManager>().submitIOTask(progressIndicator) {
             if (theAccount.isEnterpriseAccount()) {

--- a/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphInstanceLoginDialog.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/SourcegraphInstanceLoginDialog.kt
@@ -143,7 +143,7 @@ class SourcegraphInstanceLoginDialog(
     val server = deriveServerPath()
 
     acquireDetailsAndToken(emptyProgressIndicator)
-        .successOnEdt(ModalityState.NON_MODAL) { (details, token) ->
+        .successOnEdt(ModalityState.nonModal()) { (details, token) ->
           codyAuthData =
               CodyAuthData(
                   CodyAccount(details.username, details.displayName, server, details.id),
@@ -151,7 +151,7 @@ class SourcegraphInstanceLoginDialog(
                   token)
           close(OK_EXIT_CODE, true)
         }
-        .errorOnEdt(ModalityState.NON_MODAL) {
+        .errorOnEdt(ModalityState.nonModal()) {
           if (advancedSettings.isSelected.not()) {
             isAcquiringToken.isSelected = false
           }

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -87,7 +87,7 @@ class SettingsMigration : Activity {
         loadUserDetails(
             SourcegraphApiRequestExecutor.Factory.instance,
             token,
-            EmptyProgressIndicator(ModalityState.NON_MODAL),
+            EmptyProgressIndicator(ModalityState.nonModal()),
             server) {
               codyAccount.id = it.id
               CodyAuthenticationManager.getInstance().updateAccountToken(codyAccount, token)
@@ -175,14 +175,14 @@ class SettingsMigration : Activity {
             dotcomAccessToken,
             server,
             requestExecutorFactory,
-            EmptyProgressIndicator(ModalityState.NON_MODAL))
+            EmptyProgressIndicator(ModalityState.nonModal()))
       } else {
         addAccountIfUnique(
             project,
             dotcomAccessToken,
             server,
             requestExecutorFactory,
-            EmptyProgressIndicator(ModalityState.NON_MODAL))
+            EmptyProgressIndicator(ModalityState.nonModal()))
       }
     }
   }
@@ -203,14 +203,14 @@ class SettingsMigration : Activity {
                   enterpriseAccessToken,
                   it,
                   requestExecutorFactory,
-                  EmptyProgressIndicator(ModalityState.NON_MODAL))
+                  EmptyProgressIndicator(ModalityState.nonModal()))
             } else {
               addAccountIfUnique(
                   project,
                   enterpriseAccessToken,
                   it,
                   requestExecutorFactory,
-                  EmptyProgressIndicator(ModalityState.NON_MODAL))
+                  EmptyProgressIndicator(ModalityState.nonModal()))
             }
           }) {
             LOG.warn("Unable to parse enterprise server url: '$enterpriseUrl'", it)

--- a/src/test/kotlin/com/sourcegraph/website/URLBuilderTest.kt
+++ b/src/test/kotlin/com/sourcegraph/website/URLBuilderTest.kt
@@ -24,6 +24,25 @@ class URLBuilderTest : BasePlatformTestCase() {
         url)
   }
 
+  fun `test base with slash`() {
+    val url =
+        URLBuilder.buildCommitUrl(
+            "https://www.sourcegraph.com/",
+            "1fa8d5d6286c24924b55c15ed4d1a0b85c44b4d5",
+            "https://github.com/sourcegraph/sourcegraph-jetbrains.git",
+            "intellij",
+            "1.1")
+
+    val version = ConfigUtil.getPluginVersion()
+    assertEquals(
+        "https://www.sourcegraph.com/github.com/sourcegraph/sourcegraph-jetbrains.git/-/commit/1fa8d5d6286c24924b55c15ed4d1a0b85c44b4d5?" +
+            "editor=JetBrains&" +
+            "version=v$version&" +
+            "utm_product_name=intellij&" +
+            "utm_product_version=1.1",
+        url)
+  }
+
   fun `test missing base URI throws exception`() {
     val base = ""
     assertThrows(RuntimeException::class.java) {


### PR DESCRIPTION
This PR fix `Open Revision Diff in Sourcegraph Web` issues.
Btw, it moves away from some deprecated API.

## Test plan
1. `Open Revision Diff in Sourcegraph Web` from the context menu in the editor
2. `Open Revision Diff in Sourcegraph Web` from Git log 


