### PR TITLE
Fix codyErrorSubmitter issues with too long url

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -12,6 +12,7 @@ import com.intellij.util.Consumer
 import java.awt.Component
 import java.net.URLEncoder
 import java.util.concurrent.CompletableFuture
+import kotlin.math.max
 
 class CodyErrorSubmitter : ErrorReportSubmitter() {
   private val DOTS = "..."
@@ -54,13 +55,12 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
             "&projects=sourcegraph/381"
 
     val title = throwableText?.let { "&title=${encode(getTitle(it))}" } ?: ""
-    val text = getAboutText(project).get()
-    val about = "&about=${encode(text.repeat(6))}"
+    val about = "&about=${encode(getAboutText(project).get())}"
 
     val availableSpace =
         MAX_URL_LENGTH - baseUrl.length - title.length - about.length - "&logs=".length
 
-    val trimmedLogs = trimLogs(throwableText, additionalInfo, availableSpace)
+    val trimmedLogs = trimLogs(throwableText, additionalInfo, max(0, availableSpace))
 
     return "$baseUrl$title$about&logs=$trimmedLogs"
   }

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -14,6 +14,7 @@ import java.net.URLEncoder
 import java.util.concurrent.CompletableFuture
 
 class CodyErrorSubmitter : ErrorReportSubmitter() {
+  private val DOTS = "..."
 
   override fun getReportActionText() = "Open GitHub Issue"
 
@@ -46,13 +47,22 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
       throwableText: String? = null,
       additionalInfo: String? = null
   ): String {
-    return "https://github.com/sourcegraph/jetbrains/issues/new" +
-        "?template=bug_report.yml" +
-        "&labels=bug" +
-        "&projects=sourcegraph/381" +
-        (throwableText?.let { "&title=${encode(getTitle(throwableText))}" } ?: "") +
-        "&about=${encode(getAboutText(project).get())}" +
-        "&logs=${encode(formatLogs(throwableText, additionalInfo))}"
+    val baseUrl =
+        "https://github.com/sourcegraph/jetbrains/issues/new" +
+            "?template=bug_report.yml" +
+            "&labels=bug" +
+            "&projects=sourcegraph/381"
+
+    val title = throwableText?.let { "&title=${encode(getTitle(it))}" } ?: ""
+    val text = getAboutText(project).get()
+    val about = "&about=${encode(text.repeat(6))}"
+
+    val availableSpace =
+        MAX_URL_LENGTH - baseUrl.length - title.length - about.length - "&logs=".length
+
+    val trimmedLogs = trimLogs(throwableText, additionalInfo, availableSpace)
+
+    return "$baseUrl$title$about&logs=$trimmedLogs"
   }
 
   private fun getTitle(throwableText: String): String {
@@ -66,15 +76,20 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
     return result
   }
 
+  private fun trimLogs(throwableText: String?, additionalInfo: String?, maxLength: Int): String {
+    val formattedLogs = encode(formatLogs(throwableText, additionalInfo))
+    return if (formattedLogs.length > maxLength) {
+      formattedLogs.take(maxLength - DOTS.length) + DOTS
+    } else {
+      formattedLogs
+    }
+  }
+
   private fun formatLogs(throwableText: String?, additionalInfo: String?) =
-      formatAttributes(
-          "Stacktrace" to
-              throwableText?.let { trimPostfix(throwableText, 6000) }, // max total length is 8192
-          "Additional info" to additionalInfo)
+      formatAttributes("Stacktrace" to throwableText, "Additional info" to additionalInfo)
 
   private fun trimPostfix(text: String, maxLength: Int): String {
-    val postfix = "..."
-    return if (text.length > maxLength) text.take(maxLength - postfix.length) + postfix else text
+    return if (text.length > maxLength) text.take(maxLength - DOTS.length) + DOTS else text
   }
 
   private fun formatAttributes(vararg pairs: Pair<String, String?>) =
@@ -86,4 +101,8 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
       if (text.lines().size != 1) "$label:\n```text\n$text\n```" else "$label: ```$text```"
 
   private fun encode(text: String) = URLEncoder.encode(text, "UTF-8")
+
+  companion object {
+    const val MAX_URL_LENGTH = 8192 - 1
+  }
 }

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
@@ -1,0 +1,53 @@
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.sourcegraph.cody.error.CodyErrorSubmitter
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class CodyErrorSubmitterTest : BasePlatformTestCase() {
+
+  private val codyErrorSubmitter = CodyErrorSubmitter()
+
+  @Test
+  fun testGetEncodedUrlWithNullProject() {
+    val encodedUrl = codyErrorSubmitter.getEncodedUrl(null)
+    assertTrue(
+        encodedUrl.startsWith(
+            "https://github.com/sourcegraph/jetbrains/issues/new?template=bug_report.yml"))
+    assertTrue(encodedUrl.contains("&labels=bug"))
+    assertTrue(encodedUrl.contains("&projects=sourcegraph/381"))
+    assertFalse(encodedUrl.contains("&title="))
+  }
+
+  @Test
+  fun testGetEncodedUrlWithThrowableText() {
+    val throwableText = "NullPointerException: Something went wrong"
+    val encodedUrl = codyErrorSubmitter.getEncodedUrl(null, throwableText)
+    assertTrue(encodedUrl.contains("&title=bug%3A+NullPointerException%3A+Something+went+wrong"))
+  }
+
+  @Test
+  fun testGetEncodedUrlWithAdditionalInfo() {
+    val additionalInfo = "Additional debug information"
+    val encodedUrl = codyErrorSubmitter.getEncodedUrl(null, null, additionalInfo)
+    assertTrue(
+        encodedUrl.contains("&logs=Additional+info%3A+%60%60%60Additional+debug+information"))
+  }
+
+  @Test
+  fun testGetEncodedUrlWithProjectAndThrowableText() {
+    val mockProject = mock(Project::class.java)
+    val throwableText = "IllegalArgumentException: Invalid input"
+    val encodedUrl = codyErrorSubmitter.getEncodedUrl(mockProject, throwableText)
+    assertTrue(encodedUrl.contains("&title=bug%3A+IllegalArgumentException%3A+Invalid+input"))
+    assertTrue(encodedUrl.contains("&about="))
+  }
+
+  @Test
+  fun testGetEncodedUrlMaxLength() {
+    val longThrowableText = "A".repeat(10000)
+    val longAdditionalInfo = "B".repeat(10000)
+    val encodedUrl = codyErrorSubmitter.getEncodedUrl(null, longThrowableText, longAdditionalInfo)
+    assertTrue(encodedUrl.length <= CodyErrorSubmitter.MAX_URL_LENGTH)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2420.
Fixes https://github.com/sourcegraph/jetbrains/issues/2402.
Fixes https://github.com/sourcegraph/jetbrains/issues/2361.
Fixes https://github.com/sourcegraph/jetbrains/issues/2268.
Fixes https://github.com/sourcegraph/jetbrains/issues/2315.
Fixes https://github.com/sourcegraph/jetbrains/issues/2231.

## Test plan
1. When the plugin encounters an error, report it with to GitHub Issues.
