### PR TITLE
Fix Generate Unit Tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=ddd048c4ee3b6c10c356659c61e14e26fa566833
+cody.commit=f4138ff864446cf4d1bb7270406d7d8af6b9dd9f

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=f4138ff864446cf4d1bb7270406d7d8af6b9dd9f
+cody.commit=ddd048c4ee3b6c10c356659c61e14e26fa566833

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -21,6 +21,8 @@ import com.sourcegraph.cody.agent.protocol_generated.ClientInfo
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
+import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
+import com.sourcegraph.cody.agent.protocol_generated.CustomCommandResult
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
@@ -139,6 +141,9 @@ interface _LegacyAgentServer {
 
   @JsonRequest("editTask/cancel")
   fun cancelEditTask(params: EditTask_CancelParams): CompletableFuture<Void?>
+
+  @JsonRequest("commands/custom")
+  fun commands_custom(params: Commands_CustomParams): CompletableFuture<CustomCommandResult>
 
   @JsonRequest("editCommands/document") fun commandsDocument(): CompletableFuture<EditTask>
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -150,8 +150,6 @@ interface _LegacyAgentServer {
   @JsonRequest("editCommands/code")
   fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>
 
-  @JsonRequest("editCommands/test") fun commandsTest(): CompletableFuture<EditTask>
-
   @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
 
   @JsonRequest("webview/receiveMessageStringEncoded")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -145,8 +145,6 @@ interface _LegacyAgentServer {
   @JsonRequest("commands/custom")
   fun commands_custom(params: Commands_CustomParams): CompletableFuture<CustomCommandResult>
 
-  @JsonRequest("editCommands/document") fun commandsDocument(): CompletableFuture<EditTask>
-
   @JsonRequest("editCommands/code")
   fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
@@ -1,13 +1,16 @@
 package com.sourcegraph.cody.edit.actions
 
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
+import com.sourcegraph.cody.agent.protocol_generated.CustomEditCommandResult
 
 class DocumentCodeAction :
     BaseEditCodeAction({ editor ->
       editor.project?.let { project ->
         CodyAgentService.withAgent(project) { agent ->
-          val result = agent.server.commandsDocument().get()
-          EditCodeAction.completedEditTasks[result.id] = result
+          val customCommandResult = agent.server.commands_custom(Commands_CustomParams("doc")).get()
+          val result = customCommandResult as? CustomEditCommandResult ?: return@withAgent
+          EditCodeAction.completedEditTasks[result.editResult.id] = result.editResult
         }
       }
     }) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/TestCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/TestCodeAction.kt
@@ -1,13 +1,17 @@
 package com.sourcegraph.cody.edit.actions
 
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
+import com.sourcegraph.cody.agent.protocol_generated.CustomEditCommandResult
 
 class TestCodeAction :
     BaseEditCodeAction({ editor ->
       editor.project?.let { project ->
         CodyAgentService.withAgent(project) { agent ->
-          val result = agent.server.commandsTest().get()
-          EditCodeAction.completedEditTasks[result.id] = result
+          val customCommandResult =
+              agent.server.commands_custom(Commands_CustomParams("test")).get()
+          val result = customCommandResult as? CustomEditCommandResult ?: return@withAgent
+          EditCodeAction.completedEditTasks[result.editResult.id] = result.editResult
         }
       }
     }) {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-110.

## Test plan
1. `Generate Unit Tests` from the context menu works.
