### PR TITLE
Fix threading issues with showDocument

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -100,17 +100,20 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
 
   @JsonRequest("textDocument/show")
   fun textDocument_show(params: TextDocument_ShowParams): CompletableFuture<Boolean> {
-    return acceptOnEventThreadAndGet {
-      val selection = params.options?.selection
-      val preserveFocus = params.options?.preserveFocus
-      val vf = CodyEditorUtil.findFileOrScratch(project, params.uri)
-      if (vf != null) {
-        CodyEditorUtil.showDocument(project, vf, selection, preserveFocus)
-        true
-      } else {
-        false
-      }
-    }
+    val vf =
+        acceptOnEventThreadAndGet { CodyEditorUtil.findFileOrScratch(project, params.uri) }.get()
+
+    val result =
+        if (vf != null) {
+          val selection = params.options?.selection
+          val preserveFocus = params.options?.preserveFocus
+          CodyEditorUtil.showDocument(project, vf, selection, preserveFocus)
+          true
+        } else {
+          false
+        }
+
+    return CompletableFuture.completedFuture(result)
   }
 
   @JsonRequest("textDocument/openUntitledDocument")

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -108,7 +108,6 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
           val selection = params.options?.selection
           val preserveFocus = params.options?.preserveFocus
           CodyEditorUtil.showDocument(project, vf, selection, preserveFocus)
-          true
         } else {
           false
         }

--- a/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
@@ -1,11 +1,16 @@
 package com.sourcegraph.utils
 
+import com.intellij.openapi.application.ApplicationManager
+import java.awt.EventQueue.invokeAndWait
 import java.util.concurrent.CompletableFuture
-import javax.swing.SwingUtilities.invokeAndWait
 
 object ThreadingUtil {
 
   fun <T> runInEdtAndGet(task: () -> T): T {
+    val app = ApplicationManager.getApplication()
+    if (app.isDispatchThread) {
+      return task()
+    }
     val future = CompletableFuture<T>()
     invokeAndWait {
       try {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/jetbrains/issues/2151.

The problem was that the descriptors constructor needs to be called in BGT while ::navigate requires EDT. 

## Test plan

A good approach to test it is to verify all code paths. There are three:
1. Context Menu > Generate Unit Tests 
2. Cody Tool Window > Options (...) > Open Cody Settings Editor
3. In the chat ask Cody to generate a file (e.g. "hello world page in html") > Apply (creating a new file)
