### PR TITLE
Fix new pannel not opening in IJ 242+

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebPanelProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebPanelProvider.kt
@@ -3,11 +3,9 @@ package com.sourcegraph.cody.ui.web
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorLocation
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
 import com.intellij.openapi.fileEditor.FileEditorState
-import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
@@ -77,8 +75,6 @@ class WebPanelProvider : FileEditorProvider, DumbAware {
 
   override fun createEditor(project: Project, file: VirtualFile): FileEditor {
     ApplicationManager.getApplication().assertIsDispatchThread()
-    // If this file is already open elsewhere, close it.
-    (FileEditorManager.getInstance(project) as? FileEditorManagerEx)?.closeFile(file)
 
     // If file was reopened we don't want to dispose WebView, as it means panel was just moved
     // between editors


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-112/

## Test plan

Please test with both lowest and highest supported IJ versions.

**Opening new panel:**

1. Open IJ  with Cody installed 
2. Click "Open in Editor" button (`[ | ]` icon)

**Moving panels around:**

1. Open IJ with Cody installed 
2. Click "Open in Editor" button (`[ | ]` icon) few times to open few tabs
3. Move them around - change tab orders, move them between split windows, etc

Expected result: new panel should be opened