### PR TITLE
feat(uninstall): delete auth credentials on uninstall (CODY-1043)

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -170,4 +170,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("testing/requestErrors")
   fun testingRequestErrors(): CompletableFuture<List<NetworkRequest>>
+
+  @JsonRequest("extension/reset") fun extension_reset(params: Null?): CompletableFuture<Null?>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -273,6 +273,12 @@ class CodyAuthenticationManager :
 
   fun showInvalidAccessTokenError() = getIsTokenInvalid().getNow(null) == true
 
+  fun removeAll() {
+    accountManager.accounts.forEach {
+     accountManager.removeAccount(it)
+    }
+  }
+
   override fun dispose() {
     scheduler.shutdown()
   }

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -274,9 +274,7 @@ class CodyAuthenticationManager :
   fun showInvalidAccessTokenError() = getIsTokenInvalid().getNow(null) == true
 
   fun removeAll() {
-    accountManager.accounts.forEach {
-     accountManager.removeAccount(it)
-    }
+    accountManager.accounts.forEach { accountManager.removeAccount(it) }
   }
 
   override fun dispose() {

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/UninstallListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/UninstallListener.kt
@@ -1,0 +1,35 @@
+package com.sourcegraph.cody.initialization
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.ide.plugins.PluginInstaller
+import com.intellij.ide.plugins.PluginStateListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.StartupActivity
+import com.sourcegraph.cody.agent.protocol.BillingCategory
+import com.sourcegraph.cody.agent.protocol.BillingMetadata
+import com.sourcegraph.cody.agent.protocol.BillingProduct
+import com.sourcegraph.cody.agent.protocol.TelemetryEventParameters
+import com.sourcegraph.cody.config.CodyAuthenticationManager
+import com.sourcegraph.cody.telemetry.TelemetryV2
+
+class UninstallListener :  StartupActivity {
+    override fun runActivity(project: Project) {
+        PluginInstaller.addStateListener(object: PluginStateListener {
+            override fun uninstall(descriptor: IdeaPluginDescriptor) {
+                CodyAuthenticationManager.getInstance().removeAll()
+                TelemetryV2.sendTelemetryEvent(
+                    project,
+                    "cody.extension",
+                    "uninstalled",
+                    TelemetryEventParameters(
+                        billingMetadata = BillingMetadata(BillingProduct.CODY, BillingCategory.BILLABLE)
+                    )
+                )
+
+        }
+
+            override fun install(descriptor: IdeaPluginDescriptor) {
+            }
+        })
+    }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/UninstallListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/UninstallListener.kt
@@ -5,31 +5,36 @@ import com.intellij.ide.plugins.PluginInstaller
 import com.intellij.ide.plugins.PluginStateListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
+import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.BillingCategory
 import com.sourcegraph.cody.agent.protocol.BillingMetadata
 import com.sourcegraph.cody.agent.protocol.BillingProduct
 import com.sourcegraph.cody.agent.protocol.TelemetryEventParameters
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.telemetry.TelemetryV2
+import java.util.concurrent.TimeUnit
 
-class UninstallListener :  StartupActivity {
-    override fun runActivity(project: Project) {
-        PluginInstaller.addStateListener(object: PluginStateListener {
-            override fun uninstall(descriptor: IdeaPluginDescriptor) {
-                CodyAuthenticationManager.getInstance().removeAll()
-                TelemetryV2.sendTelemetryEvent(
-                    project,
-                    "cody.extension",
-                    "uninstalled",
-                    TelemetryEventParameters(
-                        billingMetadata = BillingMetadata(BillingProduct.CODY, BillingCategory.BILLABLE)
-                    )
-                )
-
-        }
-
-            override fun install(descriptor: IdeaPluginDescriptor) {
+class UninstallListener : StartupActivity {
+  override fun runActivity(project: Project) {
+    PluginInstaller.addStateListener(
+        object : PluginStateListener {
+          override fun uninstall(descriptor: IdeaPluginDescriptor) {
+            val authManager = CodyAuthenticationManager.getInstance()
+            authManager.setActiveAccount(null)
+            authManager.removeAll()
+            TelemetryV2.sendTelemetryEvent(
+                project,
+                "cody.extension",
+                "uninstalled",
+                TelemetryEventParameters(
+                    billingMetadata =
+                        BillingMetadata(BillingProduct.CODY, BillingCategory.BILLABLE)))
+            CodyAgentService.withAgent(project) {
+              it.server.extension_reset(null).get(20, TimeUnit.SECONDS)
             }
+          }
+
+          override fun install(descriptor: IdeaPluginDescriptor) {}
         })
-    }
+  }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -65,6 +65,8 @@
         <projectService id="sourcegraph.findService"
                         serviceImplementation="com.sourcegraph.find.FindService"/>
         <postStartupActivity
+                implementation="com.sourcegraph.cody.initialization.UninstallListener"/>
+        <postStartupActivity
                 implementation="com.sourcegraph.cody.initialization.PostStartupActivity"/>
 
         <!-- Cody -->


### PR DESCRIPTION
This is the JetBrains half of the [CODY-1043](https://linear.app/sourcegraph/issue/CODY-1043/bug-account-credentials-are-cached-between-installs), the VSC half of it is in [this PR](https://github.com/sourcegraph/cody/pull/5819).

For VSCode I was able to write an E2E as there are electron & VSCode test utilities for opening / closing instances of VSC and installing / uninstalling plugins.

Does anyone know if we have similar utilities that we could use to write a test for this behavior in JB?

The good news is that JB actually has proper APIs for this hook so the complexity is much lower here.

## Test plan
I manually tested this by running `CODY_DIR='<my local cody>' ./gradlew -PforceAgentBuild=true buildPlugin` and then opening the plugins menu and installing a plugin from disk.
![image](https://github.com/user-attachments/assets/0b0c7482-9dce-4ce5-8f80-07b60857e1d9)

I logged in and then uninstalled from the same menu. After reinstalling, it takes me back to the login screen and all previous endpoints are cleared. When I log back into the same account I see my chat history is removed.
