### PR TITLE
Fix verification plugin issues related to InlineCompletionProviderID

### DIFF
--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionProviderID.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/InlineCompletionProviderID.kt
@@ -1,0 +1,3 @@
+package com.intellij.codeInsight.inline.completion
+
+@JvmInline value class InlineCompletionProviderID(val id: String)

--- a/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionElement.kt
+++ b/src/main/kotlin/com/intellij/codeInsight/inline/completion/elements/InlineCompletionElement.kt
@@ -2,4 +2,12 @@
 // Apache 2.0 license.
 package com.intellij.codeInsight.inline.completion.elements
 
+/**
+ * InlineCompletionElement is located in the following packages:
+ * - 2023.2 - com.intellij.codeInsight.inline.completion
+ * - 2023.3+ - com.intellij.codeInsight.inline.completion.elements
+ *
+ * We need that class in CodyInlineCompletionProvider::getSuggestion which is an API from 2023.3+ so
+ * we need to provide our own stub to make compiler happy with IntelliJ platform 2023.2.
+ */
 interface InlineCompletionElement

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -1,10 +1,6 @@
 package com.sourcegraph.cody.autocomplete
 
-import com.intellij.codeInsight.inline.completion.InlineCompletionElement
-import com.intellij.codeInsight.inline.completion.InlineCompletionEvent
-import com.intellij.codeInsight.inline.completion.InlineCompletionProvider
-import com.intellij.codeInsight.inline.completion.InlineCompletionRequest
-import com.intellij.codeInsight.inline.completion.InlineCompletionSuggestion
+import com.intellij.codeInsight.inline.completion.*
 import com.intellij.codeInsight.inline.completion.elements.InlineCompletionGrayTextElement
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
@@ -31,8 +27,6 @@ import com.sourcegraph.utils.CodyFormatter
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
-
-@JvmInline value class InlineCompletionProviderID(val id: String)
 
 class CodyInlineCompletionProvider : InlineCompletionProvider {
   private val logger = Logger.getInstance(CodyInlineCompletionProvider::class.java)
@@ -145,6 +139,9 @@ class CodyInlineCompletionProvider : InlineCompletionProvider {
     return isEnabled()
   }
 
+  // Needed to compile with IntelliJ platform 2023.2, not used in 2024.2+.
+  // What follows InlineCompletionElement need to be in the same package as in 2023.2, not in
+  // 2024.2+ (it was moved).
   override suspend fun getProposals(
       request: InlineCompletionRequest
   ): List<InlineCompletionElement> {


### PR DESCRIPTION
## Changes

1. Fixed `InlineCompletionProviderID` package
2. Added a few comments

## Test plan

N/A, it is related to the test/verification infrastructure.
It should decrease amount of compatibility issues reported by verification job on the marketplace.