### PR TITLE
Fix error in navigation from context files

### DIFF
--- a/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -6,6 +6,7 @@ import com.intellij.injected.editor.EditorWindow
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
@@ -31,7 +32,6 @@ import com.intellij.util.withScheme
 import com.sourcegraph.cody.agent.protocol_extensions.toOffsetRange
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.config.ConfigUtil
-import com.sourcegraph.utils.ThreadingUtil.runInEdtAndGet
 import java.net.URI
 import java.net.URISyntaxException
 import kotlin.io.path.createDirectories
@@ -184,7 +184,7 @@ object CodyEditorUtil {
                 selection.start.line.toInt(),
                 /* logicalColumn= */ selection.start.character.toInt())
           }
-      runInEdtAndGet { descriptor.navigate(/* requestFocus= */ preserveFocus != true) }
+      invokeLater { descriptor.navigate(/* requestFocus= */ preserveFocus != true) }
       return true
     } catch (e: Exception) {
       logger.error("Cannot switch view to file ${vf.path}", e)

--- a/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/CodyEditorUtil.kt
@@ -6,7 +6,6 @@ import com.intellij.injected.editor.EditorWindow
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Document
@@ -32,6 +31,7 @@ import com.intellij.util.withScheme
 import com.sourcegraph.cody.agent.protocol_extensions.toOffsetRange
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.utils.ThreadingUtil.runInEdtAndGet
 import java.net.URI
 import java.net.URISyntaxException
 import kotlin.io.path.createDirectories
@@ -184,7 +184,7 @@ object CodyEditorUtil {
                 selection.start.line.toInt(),
                 /* logicalColumn= */ selection.start.character.toInt())
           }
-      invokeLater { descriptor.navigate(/* requestFocus= */ preserveFocus != true) }
+      runInEdtAndGet { descriptor.navigate(/* requestFocus= */ preserveFocus != true) }
       return true
     } catch (e: Exception) {
       logger.error("Cannot switch view to file ${vf.path}", e)

--- a/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/utils/ThreadingUtil.kt
@@ -1,7 +1,6 @@
 package com.sourcegraph.utils
 
 import com.intellij.openapi.application.ApplicationManager
-import java.awt.EventQueue.invokeAndWait
 import java.util.concurrent.CompletableFuture
 
 object ThreadingUtil {
@@ -12,7 +11,7 @@ object ThreadingUtil {
       return task()
     }
     val future = CompletableFuture<T>()
-    invokeAndWait {
+    app.invokeLater {
       try {
         future.complete(task())
       } catch (exception: Exception) {


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-122/jetbrains-crash-occurred-while-clicking-on-file-name-from-chat-context.

## Test plan
1. Follow the repro steps from the QA report - that is, run Explain Code and try the context files navigation links 
