### PR TITLE
add repo/jetbrains label to bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,6 +6,7 @@ description: "File a bug report for any of the JetBrains IDEs: IntelliJ, Goland,
 title: "bug: "
 labels:
   - bug
+  - repo/jetbrains
 projects:
   - sourcegraph/381
 body:

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitter.kt
@@ -51,7 +51,7 @@ class CodyErrorSubmitter : ErrorReportSubmitter() {
     val baseUrl =
         "https://github.com/sourcegraph/jetbrains/issues/new" +
             "?template=bug_report.yml" +
-            "&labels=bug" +
+            "&labels=bug,repo/jetbrains" +
             "&projects=sourcegraph/381"
 
     val title = throwableText?.let { "&title=${encode(getTitle(it))}" } ?: ""

--- a/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
+++ b/src/test/kotlin/com/sourcegraph/cody/error/CodyErrorSubmitterTest.kt
@@ -14,7 +14,7 @@ class CodyErrorSubmitterTest : BasePlatformTestCase() {
     assertTrue(
         encodedUrl.startsWith(
             "https://github.com/sourcegraph/jetbrains/issues/new?template=bug_report.yml"))
-    assertTrue(encodedUrl.contains("&labels=bug"))
+    assertTrue(encodedUrl.contains("&labels=bug,repo/jetbrains"))
     assertTrue(encodedUrl.contains("&projects=sourcegraph/381"))
     assertFalse(encodedUrl.contains("&title="))
   }


### PR DESCRIPTION
Adding `repo/jetbrains` label to help distinguish where the issue came from when we sync it back to linear. Will also do the same to the Cody repo so that we have one single point of entry for all bugs 

## Test plan
N/A

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
