### PR TITLE
Move to the new `extensionConfiguration_change` endpoint

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -84,7 +84,9 @@ interface _SubsetGeneratedCodyAgentServer {
   fun extensionConfiguration_getSettingsSchema(params: Null?): CompletableFuture<String>
 
   @JsonNotification("extensionConfiguration/change")
-  fun extensionConfiguration_change(params: ExtensionConfiguration): CompletableFuture<ProtocolAuthStatus?>
+  fun extensionConfiguration_change(
+      params: ExtensionConfiguration
+  ): CompletableFuture<ProtocolAuthStatus?>
 
   //  // =============
   //  // Notifications

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -33,8 +33,8 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
 import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
 import com.sourcegraph.cody.agent.protocol_generated.Null
+import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
-import com.sourcegraph.cody.agent.protocol_generated.Window_DidChangeFocusParams
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
@@ -83,6 +83,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("extensionConfiguration/getSettingsSchema")
   fun extensionConfiguration_getSettingsSchema(params: Null?): CompletableFuture<String>
 
+  @JsonNotification("extensionConfiguration/change")
+  fun extensionConfiguration_change(params: ExtensionConfiguration): CompletableFuture<ProtocolAuthStatus?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -90,9 +93,6 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonNotification("initialized") fun initialized(params: Null?)
 
   @JsonNotification("exit") fun exit(params: Null?)
-
-  @JsonNotification("extensionConfiguration/didChange")
-  fun extensionConfiguration_didChange(params: ExtensionConfiguration)
 
   @JsonNotification("window/didChangeFocus")
   fun window_didChangeFocus(params: Window_DidChangeFocusParams)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -35,6 +35,7 @@ import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
 import com.sourcegraph.cody.agent.protocol_generated.Null
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
+import com.sourcegraph.cody.agent.protocol_generated.Window_DidChangeFocusParams
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyAuthenticationManager.kt
@@ -212,7 +212,7 @@ class CodyAuthenticationManager :
       ProjectManager.getInstance().openProjects.forEach { project ->
         CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
           if (!project.isDisposed) {
-            agent.server.extensionConfiguration_didChange(ConfigUtil.getAgentConfiguration(project))
+            agent.server.extensionConfiguration_change(ConfigUtil.getAgentConfiguration(project))
             publisher(project).afterAction(AccountSettingChangeContext(accessTokenChanged = true))
           }
         }
@@ -236,7 +236,7 @@ class CodyAuthenticationManager :
     ProjectManager.getInstance().openProjects.forEach { project ->
       CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
         if (!project.isDisposed) {
-          agent.server.extensionConfiguration_didChange(ConfigUtil.getAgentConfiguration(project))
+          agent.server.extensionConfiguration_change(ConfigUtil.getAgentConfiguration(project))
           if (serverUrlChanged || tierChanged || accountChanged) {
             publisher(project)
                 .afterAction(

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
@@ -18,7 +18,7 @@ class CodySettingsFileChangeListener(private val project: Project) : FileDocumen
       // TODO: it seams that some of the settings changes (like enabling/disabling autocomplete)
       // requires agent restart to take effect.
       CodyAgentService.withAgentRestartIfNeeded(project) {
-        it.server.extensionConfiguration_didChange(
+        it.server.extensionConfiguration_change(
             ConfigUtil.getAgentConfiguration(project, document.text))
       }
     }

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -33,7 +33,7 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
             // Notify Cody Agent about config changes.
             CodyAgentService.withAgentRestartIfNeeded(project) { agent ->
               if (ConfigUtil.isCodyEnabled()) {
-                agent.server.extensionConfiguration_didChange(
+                agent.server.extensionConfiguration_change(
                     ConfigUtil.getAgentConfiguration(project))
               }
             }


### PR DESCRIPTION



In this PR:
- [x] moved away from the deprecated agent API

## Test plan
1. N/A - I ve just switched the endpoints 
