### PR TITLE
Fix loading of CodyInlineCompletionProvider in IJ 2023

### DIFF
--- a/src/intellij2023/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/intellij2023/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -33,7 +33,8 @@ import java.util.concurrent.atomic.AtomicReference
 class CodyInlineCompletionProvider : InlineCompletionProvider {
   private val logger = Logger.getInstance(CodyInlineCompletionProvider::class.java)
   private val currentJob = AtomicReference(CancellationToken())
-  val id = InlineCompletionProviderID("Cody")
+  val id
+    get() = InlineCompletionProviderID("Cody")
 
   suspend fun getSuggestion(request: InlineCompletionRequest): InlineCompletionSuggestion {
     ApplicationManager.getApplication().assertIsNonDispatchThread()

--- a/src/intellij2024/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
+++ b/src/intellij2024/kotlin/com/sourcegraph/cody/autocomplete/CodyInlineCompletionProvider.kt
@@ -33,7 +33,8 @@ import java.util.concurrent.atomic.AtomicReference
 class CodyInlineCompletionProvider : InlineCompletionProvider {
   private val logger = Logger.getInstance(CodyInlineCompletionProvider::class.java)
   private val currentJob = AtomicReference(CancellationToken())
-  override val id = InlineCompletionProviderID("Cody")
+  override val id
+    get() = InlineCompletionProviderID("Cody")
 
   override suspend fun getSuggestion(request: InlineCompletionRequest): InlineCompletionSuggestion {
     ApplicationManager.getApplication().assertIsNonDispatchThread()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -96,7 +96,7 @@
 
         <keymapExtension implementation="com.sourcegraph.cody.config.CodyKeymapExtension"/>
 
-        <inline.completion.provider implementation="com.sourcegraph.cody.autocomplete.CodyInlineCompletionProvider"/>
+        <inline.completion.provider id="Cody" implementation="com.sourcegraph.cody.autocomplete.CodyInlineCompletionProvider"/>
         <!-- Web UI Sidebar Views
              For each sourcegraph/cody/vscode/package.json "views" entry with type "webview",
              add a toolWindow with factoryClass="com.sourcegraph.cody.sidebar.WebUIToolWindowFactory"


### PR DESCRIPTION
## Changes

Fixes BUGS-577 

In IJ 2023 we want `CodyInlineCompletionProvider` to be disabled, but we need to load the class to make the check.
`InlineCompletionProviderID` class does not exist in 2023.2 and younger, so loading class was failing.

## Test plan

1. Open IJ 2023.2 and check if autocomplete works. No exception should be thrown.
2. Open IJ 2024.2 in remote mode and check if autocomplete works. No exception should be thrown. 