### PR TITLE
Handle improve handling of codeActions/provide

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ val skippedFailureLevels =
 plugins {
   id("java")
   id("jvm-test-suite")
-  id("org.jetbrains.kotlin.jvm") version "2.0.20"
+  id("org.jetbrains.kotlin.jvm") version "2.0.21"
   id("org.jetbrains.intellij.platform") version "2.1.0"
   id("org.jetbrains.changelog") version "2.2.1"
   id("com.diffplug.spotless") version "6.25.0"

--- a/src/main/kotlin/com/sourcegraph/cody/config/CodyWindowAdapter.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodyWindowAdapter.kt
@@ -30,7 +30,7 @@ class CodyWindowAdapter(private val project: Project) : WindowAdapter() {
   }
 
   companion object {
-    fun addAuthChangeListener(project: Project) {
+    fun addWindowFocusListener(project: Project) {
       val frame = WindowManager.getInstance().getFrame(project)
       val listener = CodyWindowAdapter(project)
       frame?.addWindowListener(listener)

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -32,7 +32,7 @@ class PostStartupActivity : ProjectActivity {
     VerifyJavaBootRuntimeVersion().runActivity(project)
     SettingsMigration().runActivity(project)
     CodyAuthNotificationActivity().runActivity(project)
-    CodyWindowAdapter.addAuthChangeListener(project)
+    CodyWindowAdapter.addWindowFocusListener(project)
     ApplicationManager.getApplication().executeOnPooledThread {
       // Scheduling because this task takes ~2s to run
       CheckUpdatesTask(project).queue()


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-278/bug-javalangruntimeexception-javautilconcurrentexecutionexception.
Fixes https://github.com/sourcegraph/jetbrains/issues/2512.

I tested 7.0.6 and 7.0.13 (those versions have been mentioned in the reports) - no success on repro.

## Test plan
There is no repro for the error. I malformed the uri in the agent to get the error. It does not appear as internal ide error anymore.
