### PR TITLE
Make sure  context change is handled properly

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -54,12 +54,17 @@ class CodyToolWindowContent(val project: Project) {
   }
 
   @RequiresEdt
+  fun showLoginPanel() {
+    cardLayout.show(cardPanel, SIGN_IN_PANEL)
+    showView(cardPanel)
+  }
+
+  @RequiresEdt
   fun refreshPanelsVisibility() {
     val codyAuthenticationManager = CodyAuthenticationManager.getInstance()
     if (codyAuthenticationManager.hasNoActiveAccount() ||
         codyAuthenticationManager.showInvalidAccessTokenError()) {
-      cardLayout.show(cardPanel, SIGN_IN_PANEL)
-      showView(cardPanel)
+      showLoginPanel()
       return
     }
     val activeAccount = codyAuthenticationManager.account

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentClient.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.jetbrains.rd.util.firstOrNull
+import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.protocol.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol.WebviewCreateWebviewPanelParams
 import com.sourcegraph.cody.agent.protocol_generated.DebugMessage
@@ -20,6 +21,7 @@ import com.sourcegraph.cody.agent.protocol_generated.SaveDialogOptionsParams
 import com.sourcegraph.cody.agent.protocol_generated.TextDocumentEditParams
 import com.sourcegraph.cody.agent.protocol_generated.TextDocument_ShowParams
 import com.sourcegraph.cody.agent.protocol_generated.UntitledTextDocument
+import com.sourcegraph.cody.agent.protocol_generated.Window_DidChangeContextParams
 import com.sourcegraph.cody.agent.protocol_generated.WorkspaceEditParams
 import com.sourcegraph.cody.edit.EditService
 import com.sourcegraph.cody.edit.lenses.LensesService
@@ -227,5 +229,18 @@ class CodyAgentClient(private val project: Project, private val webview: NativeW
     }
 
     return saveFileFuture
+  }
+
+  @JsonNotification("window/didChangeContext")
+  fun window_didChangeContext(params: Window_DidChangeContextParams) {
+    if (params.key == "cody.activated") {
+      CodyToolWindowContent.executeOnInstanceIfNotDisposed(project) {
+        if (params.value?.toBoolean() == false) {
+          showLoginPanel()
+        } else {
+          refreshPanelsVisibility()
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-621/dumped-back-to-login-screen-in-v7018

## Test plan

I do not have reliable way to reproduce it manually.

Programatically I was testing it by forcing 'sign off' on the cody side (e.g. using `authProvider.setAuthPendingToEndpoint("sourcegraph.com")`) and observing behaviour in JetBrains.

Without my changes it was sometimes causing wrong login panel, or chat panel was not functioning properly.
After my changes it redirects user to the native sign-in panel.