### PR TITLE
Add Build with Cody workflow

### DIFF
--- a/.github/workflows/build-with-cody.yml
+++ b/.github/workflows/build-with-cody.yml
@@ -1,0 +1,46 @@
+name: Build with Cody
+on:
+  workflow_dispatch:
+    inputs:
+      cody-commit:
+        description: 'Cody commit to build the plugin with (latest by default)'
+        required: false
+        type: string
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+      # See note about QEMU and binfmt requirement here https://github.com/vercel/pkg#targets
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Gradle Wrapper Validation
+        uses: gradle/wrapper-validation-action@v3
+      - run: yarn global add pnpm@8.6.7
+      - run: |
+          echo "LATEST_COMMIT=$(git ls-remote https://github.com/sourcegraph/cody refs/heads/main | cut -f1)" >> $GITHUB_ENV 
+          echo "CODY_COMMIT=${{ github.event.inputs.cody-commit || LATEST_COMMIT }}" >> $GITHUB_ENV
+          echo "JB_VERSION=$(git describe --tags)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$JB_VERSION-$CODY_COMMIT" >> $GITHUB_ENV
+      - run: echo "Publishing version $RELEASE_VERSION"
+      - run: ./gradlew buildPlugin "-PpluginVersion=$RELEASE_VERSION" "-Pcody.commit=$CODY_COMMIT"
+      - run: ./gradlew --stop
+      - name: Upload the plugin package
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin
+          path: './build/distributions/Sourcegraph-*.zip'
+          compression-level: 0
+          retention-days: 3

--- a/.github/workflows/build-with-cody.yml
+++ b/.github/workflows/build-with-cody.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload the plugin package
         uses: actions/upload-artifact@v4
         with:
-          name: plugin
+          name: Plugin package for $RELEASE_VERSION
           path: './build/distributions/Sourcegraph-*.zip'
           compression-level: 0
           retention-days: 3

--- a/.github/workflows/build-with-cody.yml
+++ b/.github/workflows/build-with-cody.yml
@@ -35,14 +35,15 @@ jobs:
           else
             echo "CODY_COMMIT=${{ github.event.inputs.cody-commit }}" >> $GITHUB_ENV
           fi
+      - run: |
+          git fetch --prune --unshallow
           echo "RELEASE_VERSION=$(git describe --tags)-$CODY_COMMIT" >> $GITHUB_ENV
-      - run: echo "Publishing version $RELEASE_VERSION"
       - run: ./gradlew buildPlugin "-PpluginVersion=$RELEASE_VERSION" "-Pcody.commit=$CODY_COMMIT"
       - run: ./gradlew --stop
       - name: Upload the plugin package
         uses: actions/upload-artifact@v4
         with:
-          name: Plugin package for $RELEASE_VERSION
+          name: plugin-${{ env.RELEASE_VERSION }}
           path: './build/distributions/Sourcegraph-*.zip'
           compression-level: 0
           retention-days: 3

--- a/.github/workflows/build-with-cody.yml
+++ b/.github/workflows/build-with-cody.yml
@@ -7,7 +7,7 @@ on:
         required: false
         type: string
 jobs:
-  publish:
+  build_with_cody:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +30,12 @@ jobs:
         uses: gradle/wrapper-validation-action@v3
       - run: yarn global add pnpm@8.6.7
       - run: |
-          echo "LATEST_COMMIT=$(git ls-remote https://github.com/sourcegraph/cody refs/heads/main | cut -f1)" >> $GITHUB_ENV 
-          echo "CODY_COMMIT=${{ github.event.inputs.cody-commit || LATEST_COMMIT }}" >> $GITHUB_ENV
-          echo "JB_VERSION=$(git describe --tags)" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=$JB_VERSION-$CODY_COMMIT" >> $GITHUB_ENV
+          if [ -z "${{ github.event.inputs.cody-commit }}" ]; then
+            echo "CODY_COMMIT=$(git ls-remote https://github.com/sourcegraph/cody refs/heads/main | cut -f1)" >> $GITHUB_ENV
+          else
+            echo "CODY_COMMIT=${{ github.event.inputs.cody-commit }}" >> $GITHUB_ENV
+          fi
+          echo "RELEASE_VERSION=$(git describe --tags)-$CODY_COMMIT" >> $GITHUB_ENV
       - run: echo "Publishing version $RELEASE_VERSION"
       - run: ./gradlew buildPlugin "-PpluginVersion=$RELEASE_VERSION" "-Pcody.commit=$CODY_COMMIT"
       - run: ./gradlew --stop


### PR DESCRIPTION
This PR adds a workflow to build the plugin with the specified cody commit (or latest by default).

## Test plan
I tested this change in my fork: https://github.com/mkondratek/jetbrains/actions/runs/11577936424
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
