### PR TITLE
Make sure we are logging cody debug messages when debug logging is enabled

### DIFF
--- a/src/main/java/com/sourcegraph/config/CodyApplicationService.java
+++ b/src/main/java/com/sourcegraph/config/CodyApplicationService.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.util.xmlb.annotations.Transient;
 import com.sourcegraph.find.Search;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -72,11 +71,6 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     return url;
   }
 
-  @Transient
-  public void setSafeDotComAccessToken(@NotNull String accessToken) {
-    AccessTokenStorage.setApplicationDotComAccessToken(accessToken);
-  }
-
   @Nullable
   public String getCustomRequestHeaders() {
     return customRequestHeaders;
@@ -99,54 +93,10 @@ public class CodyApplicationService implements PersistentStateComponent<CodyAppl
     return null;
   }
 
-  @Transient
-  public void setSafeEnterpriseAccessToken(@NotNull String accessToken) {
-    AccessTokenStorage.setApplicationEnterpriseAccessToken(accessToken);
-  }
-
-  @Nullable
-  public String getAnonymousUserId() {
-    return anonymousUserId;
-  }
-
-  public boolean isInstallEventLogged() {
-    return isInstallEventLogged;
-  }
-
-  public boolean isUrlNotificationDismissed() {
-    return isUrlNotificationDismissed;
-  }
-
-  public void setCodyEnabled(boolean enabled) {
-    isCodyEnabled = enabled;
-  }
-
   public boolean isCodyAutocompleteEnabled() {
     return Optional.ofNullable(isCodyAutocompleteEnabled) // the current key takes priority
         .or(() -> Optional.ofNullable(areCodyCompletionsEnabled)) // fallback to the old key
         .orElse(false);
-  }
-
-  public boolean isCodyDebugEnabled() {
-    return Optional.ofNullable(isCodyDebugEnabled).orElse(false);
-  }
-
-  public boolean isCodyVerboseDebugEnabled() {
-    return Optional.ofNullable(isCodyVerboseDebugEnabled).orElse(false);
-  }
-
-  public boolean isAccessTokenNotificationDismissed() {
-    return isAccessTokenNotificationDismissed;
-  }
-
-  @Nullable
-  public Boolean getAuthenticationFailedLastTime() {
-    return authenticationFailedLastTime;
-  }
-
-  @Nullable
-  public String getLastUpdateNotificationPluginVersion() {
-    return lastUpdateNotificationPluginVersion;
   }
 
   @Nullable

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -5,39 +5,39 @@ import com.intellij.execution.ui.ConsoleViewContentType
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.Content
 import com.sourcegraph.cody.agent.protocol_generated.DebugMessage
+import com.sourcegraph.config.ConfigUtil
 
 @Service(Service.Level.PROJECT)
 class CodyConsole(project: Project) {
+  private val logger = Logger.getInstance(CodyConsole::class.java)
   private val consoleView = TextConsoleBuilderFactory.getInstance().createBuilder(project).console
   private val toolWindow = ToolWindowManager.getInstance(project).getToolWindow("Problems View")
   var content: Content? = null
 
-  val isEnabled =
-      System.getProperty("sourcegraph.verbose-logging") == "true" ||
-          System.getProperty("cody-agent.panic-when-out-of-sync") == "true"
-
   fun addMessage(message: DebugMessage) {
-    if (isEnabled) {
+    if (ConfigUtil.isCodyDebugEnabled()) {
       runInEdt {
+        val messageText = "${message.channel}: ${message.message}\n"
         if (message.message.contains("ERROR") || message.message.contains("PANIC")) {
           toolWindow?.show()
           content?.let { toolWindow?.contentManager?.setSelectedContent(it) }
-          consoleView.print(
-              "${message.channel}: ${message.message}\n", ConsoleViewContentType.ERROR_OUTPUT)
+          consoleView.print(messageText, ConsoleViewContentType.ERROR_OUTPUT)
+          logger.error(messageText)
         } else {
-          consoleView.print(
-              "${message.channel}: ${message.message}\n", ConsoleViewContentType.NORMAL_OUTPUT)
+          consoleView.print(messageText, ConsoleViewContentType.NORMAL_OUTPUT)
+          logger.info(messageText)
         }
       }
     }
   }
 
   init {
-    if (isEnabled) {
+    if (ConfigUtil.isCodyDebugEnabled()) {
       runInEdt {
         val factory = toolWindow?.contentManager?.factory
         content = factory?.createContent(consoleView.component, "Cody Console", true)

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -166,7 +166,8 @@ object ConfigUtil {
 
   @JvmStatic
   fun isCodyVerboseDebugEnabled(): Boolean =
-      CodyApplicationSettings.instance.isCodyVerboseDebugEnabled
+      CodyApplicationSettings.instance.isCodyVerboseDebugEnabled ||
+          System.getProperty("sourcegraph.verbose-logging") == "true"
 
   @JvmStatic
   fun isCodyAutocompleteEnabled(): Boolean =


### PR DESCRIPTION
## Test plan

1. Run IntelliJ using `:customRunIde` and make sure cody logs are present in the idea.log
2. Run normal IntelliJ instance with verbose logging **DISABLED** and make sure cody logs are **NOT** present in the idea.log
3. Run normal IntelliJ instance with verbose logging **ENABLED** and make sure cody logs are present in the idea.log