### PR TITLE
Send cody custom config as json, add support for dotted names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,7 @@ dependencies {
     }
   }
 
+  implementation("com.typesafe:config:1.4.3")
   implementation("org.commonmark:commonmark:0.22.0")
   implementation("org.commonmark:commonmark-ext-gfm-tables:0.22.0")
   implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.23.1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,4 +24,4 @@ kotlin.daemon.jvmargs=-Xmx2g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=23af99f690659084d820461a73a6fb094e52e998
+cody.commit=5dccf8dc97191083cc3fe2209b11edb0ebea0017


### PR DESCRIPTION
## Changes:

See: https://github.com/sourcegraph/cody/pull/6027

## Test plan

See: https://github.com/sourcegraph/cody/pull/6027