### PR TITLE
Remove potential infinite init loop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: JetBrains tests
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v4

--- a/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
+++ b/src/main/java/com/sourcegraph/cody/CodyToolWindowFactory.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.sourcegraph.cody.config.actions.OpenCodySettingsEditorAction;
+import com.sourcegraph.cody.ui.web.WebUIService;
 import com.sourcegraph.config.ConfigUtil;
 import com.sourcegraph.config.OpenPluginSettingsAction;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +40,10 @@ public class CodyToolWindowFactory implements ToolWindowFactory, DumbAware {
           }
 
           toolWindow.setAdditionalGearActions(customCodySettings);
+
+          WebUIService.getInstance(project)
+              .getViews$Sourcegraph()
+              .provideCodyToolWindowContent(toolWindowContent);
           return null;
         });
   }

--- a/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/CodyToolWindowContent.kt
@@ -48,8 +48,6 @@ class CodyToolWindowContent(val project: Project) {
     cardPanel.add(MissingJcefPanel(), CHANGE_RUNTIME_PANEL, CHANGE_RUNTIME_PANEL_INDEX)
     cardPanel.add(ErrorPanel(), ERROR_PANEL, ERROR_INDEX)
 
-    WebUIService.getInstance(project).views.provideCodyToolWindowContent(this)
-
     refreshPanelsVisibility()
   }
 


### PR DESCRIPTION
Accidentally, I found an infinite loop in cody tool window content initialization. It was likely a reason of the recent CI failures. This PR eliminates the risk of the inifinite loop.

## Test plan
1. Run integrationTests locally - should be all green, no sus logs, or errros indicating a loop in call stack 

