### PR TITLE
Improve logging cody debug messages

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -20,29 +20,28 @@ class CodyConsole(project: Project) {
   var content: Content? = null
 
   fun addMessage(message: DebugMessage) {
-    if (ConfigUtil.isCodyDebugEnabled()) {
-      runInEdt {
-        val messageText = "${message.channel}: ${message.message}\n"
-        if (message.message.contains("ERROR") || message.message.contains("PANIC")) {
-          toolWindow?.show()
-          content?.let { toolWindow?.contentManager?.setSelectedContent(it) }
-          consoleView.print(messageText, ConsoleViewContentType.ERROR_OUTPUT)
-          logger.error(messageText)
-        } else {
-          consoleView.print(messageText, ConsoleViewContentType.NORMAL_OUTPUT)
-          logger.info(messageText)
-        }
+    runInEdt {
+      val messageText = "${message.channel}: ${message.message}\n"
+      if (message.level == "error" || message.level == "warn") {
+        content?.let { toolWindow?.contentManager?.setSelectedContent(it) }
+        consoleView.print(messageText, ConsoleViewContentType.ERROR_OUTPUT)
+        logger.warn(messageText)
+      } else if (ConfigUtil.isCodyDebugEnabled()) {
+        consoleView.print(messageText, ConsoleViewContentType.NORMAL_OUTPUT)
+        logger.info(messageText)
+      }
+
+      if (ConfigUtil.isCodyDebugEnabled()) {
+        toolWindow?.show()
       }
     }
   }
 
   init {
-    if (ConfigUtil.isCodyDebugEnabled()) {
-      runInEdt {
-        val factory = toolWindow?.contentManager?.factory
-        content = factory?.createContent(consoleView.component, "Cody Console", true)
-        content?.let { toolWindow?.contentManager?.addContent(it) }
-      }
+    runInEdt {
+      val factory = toolWindow?.contentManager?.factory
+      content = factory?.createContent(consoleView.component, "Cody Console", true)
+      content?.let { toolWindow?.contentManager?.addContent(it) }
     }
   }
 


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-149

## Chnages

Adds detailed Cody logging, e.g. network errors.
Required dev mode (e.g. `:customRunIde`) or debug logging enabled in settings for trace/debug/info messages,
errors and warning are logged always. Cody Console is popping out only in dev mode regardless of the message severity.

## Test plan

1. Run `:customRunIde` - there is good chance you will notice some network errors at the start, but there should not be much of them
2. Go to the Cody settings and enable debug logging.
3. Restart IDE
4. Now you should see much more debug messages in Cody Console and in the logs

![image](https://github.com/user-attachments/assets/c7c92745-1cec-4e44-b348-22d4406ba419)
