### PR TITLE
Fix plugin name in the marketplace

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.sourcegraph.jetbrains
-pluginName=Sourcegraph
+pluginName=Cody: AI Coding Assistant with Autocomplete & Chat
 # SemVer format -> https://semver.org
 pluginVersion=6.0-localbuild
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html


### PR DESCRIPTION
## Test plan

1. Build and install the plugin
2. Check plugin name in `Settings > Plugins`

![image](https://github.com/user-attachments/assets/80a54bfa-abca-4f5c-8a0f-c0052a57b628)
