### PR TITLE
Add options for ConfigFactory to handle customConfig properly

### DIFF
--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.config
 
 import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
@@ -16,9 +17,6 @@ import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ServerAuthLoader
 import com.sourcegraph.cody.config.SourcegraphServerPath
 import com.sourcegraph.cody.config.SourcegraphServerPath.Companion.from
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigRenderOptions
-import com.typesafe.config.ConfigValueFactory
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.readText
@@ -141,11 +139,11 @@ object ConfigUtil {
 
     return try {
       val text = customConfigContent ?: getSettingsFile(project).readText()
-      val config = ConfigFactory.parseString(text).resolve()
+      val config = JsonParser.parseString(text).asJsonObject
       additionalProperties.forEach { (key, value) ->
-        config.withValue(key, ConfigValueFactory.fromAnyRef(value))
+        config.add(key, JsonParser.parseString(value))
       }
-      config.root().render(ConfigRenderOptions.defaults().setOriginComments(false))
+      config.toString()
     } catch (e: Exception) {
       logger.info("No user defined settings file found. Proceeding with empty custom config")
       ""

--- a/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
@@ -1,0 +1,66 @@
+import com.google.gson.JsonParser
+import com.intellij.openapi.project.Project
+import com.sourcegraph.config.ConfigUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class ConfigUtils {
+
+  private val mockProject = mock(Project::class.java)
+
+  @Test
+  fun testGetCustomConfiguration_addsAdditionalProperties() {
+    val input =
+        """
+    {
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    val parsed = JsonParser.parseString(result).asJsonObject
+
+    assertEquals(
+        "indentation-based",
+        parsed
+            .get("cody")
+            .asJsonObject
+            .get("experimental")
+            .asJsonObject
+            .get("foldingRanges")
+            .asString)
+  }
+
+  @Test
+  fun testGetCustomConfiguration_handlesTrailingCommas() {
+    val input =
+        """
+    {
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true,
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    assertNotNull(result)
+    val parsed = JsonParser.parseString(result).asJsonObject
+    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+  }
+
+  @Test
+  fun testGetCustomConfiguration_handlesComments() {
+    val input =
+        """
+    {
+       // This is a comment
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true,
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    assertNotNull(result)
+    val parsed = JsonParser.parseString(result).asJsonObject
+    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+  }
+}


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/CODY-4264/a-comment-in-cody-settingsjson-breaks-cody-initialization-stuck-at.


## Test plan
1. Have the cody_settings.json like this:
```
{
  // other providers...
  "openctx.providers": {
    "https://gist.githubusercontent.com/thenamankumar/3708f084fb2abd57adafe7f14620bdf7/raw/e7c7059cb5b04f6feead002e7b3a90c5b1a4bb96/provider.js": true
  }
}
```
2. Cody should initialize 


