### PR TITLE
Roll Cody to 876a2a3858ec3250371db50b356335d58ddab8d2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx4g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=70db14a86870e4df043c34547fc664518cd658bf
+cody.commit=876a2a3858ec3250371db50b356335d58ddab8d2


### PR DESCRIPTION
Roll sourcegraph/cody, pulling in these commits:

https://github.com/sourcegraph/cody/compare/70db14a86870e4df043c34547fc664518cd658bf...876a2a3858ec3250371db50b356335d58ddab8d2

This aligns with VSCode Insiders 1.41.1730930945.

## Test plan

QA