### PR TITLE
Always include IDE version in telemetry metadata

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
@@ -39,7 +39,9 @@ class TelemetryV2 {
           mapOf(
               "ideProductCode" to intellijProductCodeMap.getOrDefault(build.productCode, 0L),
               "ideBaselineVersion" to build.baselineVersion.toLong())
-      val newParameters = parameters?.copy(metadata = parameters.metadata?.plus(versionParameters))
+      val baseParameters = parameters ?: TelemetryEventParameters()
+      val newParameters =
+          baseParameters.copy(metadata = baseParameters.metadata?.plus(versionParameters))
 
       CodyAgentService.withAgent(project) { agent ->
         agent.server.recordEvent(

--- a/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/telemetry/TelemetryV2.kt
@@ -6,39 +6,20 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol.BillingMetadata
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol.TelemetryEventParameters
+import com.sourcegraph.config.ConfigUtil
 
 class TelemetryV2 {
   companion object {
-    private val intellijProductCodeMap =
-        mapOf(
-            "IU" to 1L, // IntelliJ IDEA Ultimate
-            "IC" to 2L, // IntelliJ IDEA Community
-            "IE" to 3L, // IntelliJ IDEA Educational
-            "PS" to 4L, // PhpStorm
-            "WS" to 5L, // WebStorm
-            "PY" to 6L, // PyCharm Professional
-            "PC" to 7L, // PyCharm Community
-            "PE" to 8L, // PyCharm Educational
-            "RM" to 9L, // RubyMine
-            "OC" to 10L, // AppCode
-            "CL" to 11L, // CLion
-            "GO" to 12L, // GoLand
-            "DB" to 13L, // DataGrip
-            "RD" to 14L, // Rider
-            "AI" to 15L, // Android Studio
-        )
-
     fun sendTelemetryEvent(
         project: Project,
         feature: String,
         action: String,
         parameters: TelemetryEventParameters? = null
     ) {
-      val build = ApplicationInfo.getInstance().build
       val versionParameters =
           mapOf(
-              "ideProductCode" to intellijProductCodeMap.getOrDefault(build.productCode, 0L),
-              "ideBaselineVersion" to build.baselineVersion.toLong())
+              "ideProductCode" to ConfigUtil.getIntellijProductCode(),
+              "ideBaselineVersion" to ApplicationInfo.getInstance().build.baselineVersion.toLong())
       val baseParameters = parameters ?: TelemetryEventParameters()
       val newParameters =
           baseParameters.copy(metadata = baseParameters.metadata?.plus(versionParameters))

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -2,6 +2,7 @@ package com.sourcegraph.config
 
 import com.google.gson.JsonObject
 import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.extensions.PluginId
@@ -37,6 +38,29 @@ object ConfigUtil {
 
   private val featureFlags: Map<String, Boolean> by lazy {
     parseFeatureFlags(System.getenv(FEATURE_FLAGS_ENV_VAR))
+  }
+
+  fun getIntellijProductCode(): Long {
+    val build = ApplicationInfo.getInstance().build
+    val intellijProductCodeMap =
+        mapOf(
+            "IU" to 1L, // IntelliJ IDEA Ultimate
+            "IC" to 2L, // IntelliJ IDEA Community
+            "IE" to 3L, // IntelliJ IDEA Educational
+            "PS" to 4L, // PhpStorm
+            "WS" to 5L, // WebStorm
+            "PY" to 6L, // PyCharm Professional
+            "PC" to 7L, // PyCharm Community
+            "PE" to 8L, // PyCharm Educational
+            "RM" to 9L, // RubyMine
+            "OC" to 10L, // AppCode
+            "CL" to 11L, // CLion
+            "GO" to 12L, // GoLand
+            "DB" to 13L, // DataGrip
+            "RD" to 14L, // Rider
+            "AI" to 15L, // Android Studio
+        )
+    return intellijProductCodeMap[build.productCode] ?: 0L
   }
 
   @VisibleForTesting
@@ -137,7 +161,10 @@ object ConfigUtil {
     // Needed by Edit commands to trigger smart-selection; without it things break.
     // So it isn't optional in JetBrains clients, which do not offer language-neutral solutions
     // to this problem; instead we hardwire it to use the indentation-based provider.
-    val additionalProperties = mapOf("cody.experimental.foldingRanges" to "indentation-based")
+    val additionalProperties =
+        mapOf(
+            "cody.experimental.foldingRanges" to "indentation-based",
+            "cody.advanced.agent.ide.productCode" to getIntellijProductCode())
 
     return try {
       val text = customConfigContent ?: getSettingsFile(project).readText()


### PR DESCRIPTION
## Changes

Previously telemetry events were including IDE version only when even already has `TelemetryEventParameters`.
That was a bug, it should always be sent.

## Test plan

I verified in the debugger that now all events includes version info.

