### PR TITLE
cherrypick 2588

### DIFF
--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -141,11 +141,13 @@ object ConfigUtil {
 
     return try {
       val text = customConfigContent ?: getSettingsFile(project).readText()
-      val config = ConfigFactory.parseString(text).resolve()
+      var config = ConfigFactory.parseString(text).resolve()
       additionalProperties.forEach { (key, value) ->
-        config.withValue(key, ConfigValueFactory.fromAnyRef(value))
+        config = config.withValue(key, ConfigValueFactory.fromAnyRef(value))
       }
-      config.root().render(ConfigRenderOptions.defaults().setOriginComments(false))
+      config
+          .root()
+          .render(ConfigRenderOptions.defaults().setComments(false).setOriginComments(false))
     } catch (e: Exception) {
       logger.info("No user defined settings file found. Proceeding with empty custom config")
       ""

--- a/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
+++ b/src/test/kotlin/com/sourcegraph/config/ConfigUtilTest.kt
@@ -1,0 +1,66 @@
+import com.google.gson.JsonParser
+import com.intellij.openapi.project.Project
+import com.sourcegraph.config.ConfigUtil
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.mockito.Mockito.mock
+
+class ConfigUtils {
+
+  private val mockProject = mock(Project::class.java)
+
+  @Test
+  fun testGetCustomConfiguration_addsAdditionalProperties() {
+    val input =
+        """
+    {
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    val parsed = JsonParser.parseString(result).asJsonObject
+
+    assertEquals(
+        "indentation-based",
+        parsed
+            .get("cody")
+            .asJsonObject
+            .get("experimental")
+            .asJsonObject
+            .get("foldingRanges")
+            .asString)
+  }
+
+  @Test
+  fun testGetCustomConfiguration_handlesTrailingCommas() {
+    val input =
+        """
+    {
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true,
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    assertNotNull(result)
+    val parsed = JsonParser.parseString(result).asJsonObject
+    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+  }
+
+  @Test
+  fun testGetCustomConfiguration_handlesComments() {
+    val input =
+        """
+    {
+       // This is a comment
+      "cody.debug": true,
+      "cody.autocomplete.enabled": true,
+    }
+    """
+    val result = ConfigUtil.getCustomConfiguration(mockProject, input)
+    assertNotNull(result)
+    val parsed = JsonParser.parseString(result).asJsonObject
+    assertEquals(2 + 1, parsed.size()) // +1 for the additional folding property
+  }
+}


### PR DESCRIPTION
cherry pick #2588 - allowing more flexibility as we didn't inform the team when branch cut was

Fixes
https://linear.app/sourcegraph/issue/CODY-4264/a-comment-in-cody-settingsjson-breaks-cody-initialization-stuck-at.


## Test plan
1. Have the cody_settings.json like this:
```
{
  // other providers...
  "openctx.providers": {
    "https://gist.githubusercontent.com/thenamankumar/3708f084fb2abd57adafe7f14620bdf7/raw/e7c7059cb5b04f6feead002e7b3a90c5b1a4bb96/provider.js": true
  }
}
```
2. Cody should initialize

## Test plan

<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
