### PR TITLE
Fix extensionConfiguration/change type, respect authStatus from cody

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -86,7 +86,7 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("extensionConfiguration/getSettingsSchema")
   fun extensionConfiguration_getSettingsSchema(params: Null?): CompletableFuture<String>
 
-  @JsonNotification("extensionConfiguration/change")
+  @JsonRequest("extensionConfiguration/change")
   fun extensionConfiguration_change(
       params: ExtensionConfiguration
   ): CompletableFuture<ProtocolAuthStatus?>


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/BUGS-670

## Changes

1. Bumped cody commit to match the one from `jb-v7.1.x` branch
2. Fixed `"extensionConfiguration/change"` endpoint type - issue was introduced [there](https://github.com/sourcegraph/jetbrains/commit/8ea63fc50cb91a78900df25ef2d9ceb8860082a2)
3. For the sake of correctness I also added check of returned auth state and if auth fails I set the token as invalid.

## Test plan

1. Run IDE
4. Remove all account in the cody settings
5. Login panel shoul appear
6. Sign in to enterprise account 
7. Make sure chat panel appears and in the account panel enterprise acc is shown
8. Remove all account in the cody settings
9. Login panel should appear
10. Sign in to free dotcom account
11. Make sure chat panel appears and in the account panel free acc is shown