### PR TITLE
Migrate remaining endpoints (with a single exception)

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -59,9 +59,10 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
 
       val recordingsFuture = CompletableFuture<Void>()
       CodyAgentService.withAgent(project) { agent ->
-        val errors = agent.server.testingRequestErrors().get()
+        val errors = agent.server.testing_requestErrors(null).get()
         // We extract polly.js errors to notify users about the missing recordings, if any
-        val missingRecordings = errors.filter { it.error?.contains("`recordIfMissing` is") == true }
+        val missingRecordings =
+            errors.errors.filter { it.error?.contains("`recordIfMissing` is") == true }
         missingRecordings.forEach { missing ->
           logger.error(
               """Recording is missing: ${missing.error}

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -7,14 +7,7 @@ data class WebviewRegisterWebviewViewProviderParams(
     val retainContextWhenHidden: Boolean
 )
 
-data class WebviewResolveWebviewViewParams(val viewId: String, val webviewHandle: String)
-
 data class WebviewPostMessageStringEncodedParams(val id: String, val stringEncodedMessage: String)
-
-data class WebviewReceiveMessageStringEncodedParams(
-    val id: String,
-    val messageStringEncoded: String
-)
 
 data class WebviewSetHtmlParams(val handle: String, val html: String)
 
@@ -28,8 +21,5 @@ data class WebviewRevealParams(val handle: String, val viewColumn: Int, val pres
 
 // When the server initiates dispose, this is sent to the client.
 data class WebviewDisposeParams(val handle: String)
-
-// When the client initiates dispose, this is sent to the server.
-data class WebviewDidDisposeParams(val handle: String)
 
 data class ConfigFeatures(val serverSentModels: Boolean)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -3,8 +3,6 @@
 package com.sourcegraph.cody.agent
 
 import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
-import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
-import com.sourcegraph.cody.agent.protocol.IgnoreTestResponse
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
@@ -31,6 +29,8 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
 import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
 import com.sourcegraph.cody.agent.protocol_generated.FeatureFlags_GetFeatureFlagParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.agent.protocol_generated.Null
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
@@ -129,6 +129,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("chat/web/new")
   fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
 
+  @JsonRequest("ignore/test")
+  fun ignore_test(params: Ignore_TestParams): CompletableFuture<Ignore_TestResult>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -179,9 +182,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("ignore/test")
-  fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
   fun testingIgnoreOverridePolicy(params: IgnorePolicySpec?): CompletableFuture<Unit>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -35,6 +35,9 @@ import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
 import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidFocusParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_DidDisposeNativeParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ReceiveMessageStringEncodedParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ResolveWebviewViewParams
 import com.sourcegraph.cody.agent.protocol_generated.Window_DidChangeFocusParams
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
@@ -114,6 +117,14 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("editCommands/code")
   fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
 
+  @JsonRequest("webview/resolveWebviewView")
+  fun webview_resolveWebviewView(params: Webview_ResolveWebviewViewParams): CompletableFuture<Null?>
+
+  @JsonRequest("webview/receiveMessageStringEncoded")
+  fun webview_receiveMessageStringEncoded(
+      params: Webview_ReceiveMessageStringEncodedParams
+  ): CompletableFuture<Null?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -147,6 +158,9 @@ interface _SubsetGeneratedCodyAgentServer {
 
   @JsonNotification("window/didChangeFocus")
   fun window_didChangeFocus(params: Window_DidChangeFocusParams)
+
+  @JsonNotification("webview/didDisposeNative")
+  fun webview_didDisposeNative(params: Webview_DidDisposeNativeParams)
 }
 
 // TODO: Requests waiting to be migrated & tested for compatibility. Avoid placing new protocol
@@ -163,17 +177,6 @@ interface _LegacyAgentServer {
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
 
   @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
-
-  @JsonRequest("webview/receiveMessageStringEncoded")
-  fun webviewReceiveMessageStringEncoded(
-      params: WebviewReceiveMessageStringEncodedParams
-  ): CompletableFuture<Void?>
-
-  @JsonNotification("webview/didDisposeNative")
-  fun webviewDidDisposeNative(webviewDidDisposeParams: WebviewDidDisposeParams)
-
-  @JsonRequest("webview/resolveWebviewView")
-  fun webviewResolveWebviewView(params: WebviewResolveWebviewViewParams): CompletableFuture<Any>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -2,8 +2,6 @@
 
 package com.sourcegraph.cody.agent
 
-import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
-import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
@@ -16,6 +14,7 @@ import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
 import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
+import com.sourcegraph.cody.agent.protocol_generated.ContextFilters
 import com.sourcegraph.cody.agent.protocol_generated.CurrentUserCodySubscription
 import com.sourcegraph.cody.agent.protocol_generated.CustomCommandResult
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
@@ -35,6 +34,7 @@ import com.sourcegraph.cody.agent.protocol_generated.Null
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
+import com.sourcegraph.cody.agent.protocol_generated.Testing_RequestErrorsResult
 import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidFocusParams
 import com.sourcegraph.cody.agent.protocol_generated.Webview_DidDisposeNativeParams
 import com.sourcegraph.cody.agent.protocol_generated.Webview_ReceiveMessageStringEncodedParams
@@ -132,6 +132,12 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("ignore/test")
   fun ignore_test(params: Ignore_TestParams): CompletableFuture<Ignore_TestResult>
 
+  @JsonRequest("testing/ignore/overridePolicy")
+  fun testing_ignore_overridePolicy(params: ContextFilters?): CompletableFuture<Null?>
+
+  @JsonRequest("testing/requestErrors")
+  fun testing_requestErrors(params: Null?): CompletableFuture<Testing_RequestErrorsResult>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -182,10 +188,4 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("testing/ignore/overridePolicy")
-  fun testingIgnoreOverridePolicy(params: IgnorePolicySpec?): CompletableFuture<Unit>
-
-  @JsonRequest("testing/requestErrors")
-  fun testingRequestErrors(): CompletableFuture<List<NetworkRequest>>
 }

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -12,6 +12,7 @@ import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ImportParams
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsParams
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsResult
+import com.sourcegraph.cody.agent.protocol_generated.Chat_Web_NewResult
 import com.sourcegraph.cody.agent.protocol_generated.ClientInfo
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
@@ -125,6 +126,9 @@ interface _SubsetGeneratedCodyAgentServer {
       params: Webview_ReceiveMessageStringEncodedParams
   ): CompletableFuture<Null?>
 
+  @JsonRequest("chat/web/new")
+  fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -175,8 +179,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -102,6 +102,15 @@ interface _SubsetGeneratedCodyAgentServer {
       params: Null?
   ): CompletableFuture<CurrentUserCodySubscription?>
 
+  @JsonRequest("editTask/accept")
+  fun editTask_accept(params: EditTask_AcceptParams): CompletableFuture<Null?>
+
+  @JsonRequest("editTask/undo")
+  fun editTask_undo(params: EditTask_UndoParams): CompletableFuture<Null?>
+
+  @JsonRequest("editTask/cancel")
+  fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -149,15 +158,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/accept")
-  fun acceptEditTask(params: EditTask_AcceptParams): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/undo")
-  fun undoEditTask(params: EditTask_UndoParams): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/cancel")
-  fun cancelEditTask(params: EditTask_CancelParams): CompletableFuture<Void?>
 
   @JsonRequest("editCommands/code")
   fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -5,7 +5,6 @@ package com.sourcegraph.cody.agent
 import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
 import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
 import com.sourcegraph.cody.agent.protocol.IgnoreTestResponse
-import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
@@ -21,6 +20,7 @@ import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
 import com.sourcegraph.cody.agent.protocol_generated.CurrentUserCodySubscription
 import com.sourcegraph.cody.agent.protocol_generated.CustomCommandResult
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
+import com.sourcegraph.cody.agent.protocol_generated.EditCommands_CodeParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_CancelParams
@@ -111,6 +111,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("editTask/cancel")
   fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null?>
 
+  @JsonRequest("editCommands/code")
+  fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -158,9 +161,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("editCommands/code")
-  fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>
 
   @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,11 +1,5 @@
 package com.sourcegraph.cody.agent.protocol
 
-data class IgnoreTestParams(val uri: String)
-
-data class IgnoreTestResponse(
-    val policy: String // "use" or "ignore"
-)
-
 data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)
 
 data class IgnorePolicySpec(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,8 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)
-
-data class IgnorePolicySpec(
-    val exclude: List<IgnorePolicyPattern>?,
-    val include: List<IgnorePolicyPattern>?,
-)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/InlineEditParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/InlineEditParams.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class InlineEditParams(val instruction: String, val model: String, val mode: String)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/NetworkRequest.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/NetworkRequest.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class NetworkRequest(val url: String?, val body: String?, val error: String?)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -13,12 +13,12 @@ import com.sourcegraph.cody.agent.protocol_extensions.Position
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.agent.protocol_generated.Position
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.cody.agent.protocol_generated.SelectedCompletionInfo
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.cody.statusbar.CodyStatus
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
@@ -81,7 +81,7 @@ object Utils {
     CodyAgentService.withAgent(project) { agent ->
       if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
           IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
-              IgnorePolicy.USE) {
+              Ignore_TestResult.PolicyEnum.Use) {
         ActionInIgnoredFileNotification.maybeNotify(project)
         resetApplication(project)
         resultOuter.cancel(true)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -10,10 +10,10 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.commands.CommandId
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.concurrent.Callable
@@ -38,7 +38,7 @@ abstract class BaseCommandAction : DumbAwareEDTAction() {
           .expireWith(project)
           .finishOnUiThread(ModalityState.nonModal()) {
             when (it) {
-              IgnorePolicy.USE -> {
+              Ignore_TestResult.PolicyEnum.Use -> {
                 CodyAgentService.withAgent(project) { agent ->
                   agent.server.command_execute(
                       ExecuteCommandParams(

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
@@ -8,7 +8,7 @@ import com.sourcegraph.common.ui.DumbAwareEDTAction
 
 class NewChatAction : DumbAwareEDTAction() {
   override fun actionPerformed(event: AnActionEvent) {
-    CodyAgentService.withAgent(event.project ?: return) { agent -> agent.server.chatNew() }
+    CodyAgentService.withAgent(event.project ?: return) { agent -> agent.server.chat_web_new(null) }
   }
 
   override fun update(event: AnActionEvent) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -26,8 +26,8 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.ModelUsage
+import com.sourcegraph.cody.agent.protocol_generated.EditCommands_CodeParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_RetryParams
 import com.sourcegraph.cody.agent.protocol_generated.ModelAvailabilityStatus
@@ -416,7 +416,13 @@ class EditCommandPrompt(
                       previousEdit.selectionRange)
               agent.server.editTask_retry(params).get()
             } else {
-              agent.server.commandsEdit(InlineEditParams(text, currentModel, "edit")).get()
+              agent.server
+                  .editCommands_code(
+                      EditCommands_CodeParams(
+                          instruction = text,
+                          model = currentModel,
+                          mode = EditCommands_CodeParams.ModeEnum.Edit))
+                  .get()
             }
         EditCodeAction.completedEditTasks[result.id] = result
       }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
@@ -6,10 +6,10 @@ import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.autocomplete.action.CodyAction
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.config.ConfigUtil
 
@@ -19,7 +19,8 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
   private fun isBlockedByPolicy(project: Project, event: AnActionEvent): Boolean {
     val editor = event.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
     return editor != null &&
-        IgnoreOracle.getInstance(project).policyForEditor(editor) != IgnorePolicy.USE
+        IgnoreOracle.getInstance(project).policyForEditor(editor) !=
+            Ignore_TestResult.PolicyEnum.Use
   }
 
   private fun isCodyWorking(project: Project): Boolean {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditAcceptAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditAcceptAction.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
 class EditAcceptAction :
     LensEditAction({ project, _, _, taskId ->
       CodyAgentService.withAgent(project) {
-        it.server.acceptEditTask(EditTask_AcceptParams(taskId))
+        it.server.editTask_accept(EditTask_AcceptParams(taskId))
       }
     }) {
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditCancelAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditCancelAction.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_CancelParams
 class EditCancelAction :
     LensEditAction({ project, _, _, taskId ->
       CodyAgentService.withAgent(project) {
-        it.server.cancelEditTask(EditTask_CancelParams(taskId))
+        it.server.editTask_cancel(EditTask_CancelParams(taskId))
       }
     }) {
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditUndoAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditUndoAction.kt
@@ -5,7 +5,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
 
 class EditUndoAction :
     LensEditAction({ project, _, _, taskId ->
-      CodyAgentService.withAgent(project) { it.server.undoEditTask(EditTask_UndoParams(taskId)) }
+      CodyAgentService.withAgent(project) { it.server.editTask_undo(EditTask_UndoParams(taskId)) }
     }) {
   companion object {
     const val ID = "cody.fixup.codelens.undo"

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -11,18 +11,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.containers.SLRUMap
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-
-enum class IgnorePolicy(val value: String) {
-  IGNORE("ignore"),
-  USE("use"),
-}
 
 /**
  * Provides details about whether files and repositories must be ignored as chat context, for
@@ -32,10 +28,10 @@ enum class IgnorePolicy(val value: String) {
 class IgnoreOracle(private val project: Project) {
   private val logger = Logger.getInstance(IgnoreOracle::class.java)
 
-  data class CacheEntry(val policy: IgnorePolicy, val timestampMsec: Long)
+  data class CacheEntry(val policy: Ignore_TestResult.PolicyEnum, val timestampMsec: Long)
 
   private val cache = SLRUMap<String, CacheEntry>(100, 100)
-  @Volatile private var focusedPolicy: IgnorePolicy? = null
+  @Volatile private var focusedPolicy: Ignore_TestResult.PolicyEnum? = null
   @Volatile private var willFocusUri: String? = null
   private val fileListeners: MutableList<FocusedFileIgnorePolicyListener> = mutableListOf()
   private val policyAwaitTimeoutMs = System.getProperty("cody.ignore.policy.timeout", "16").toLong()
@@ -57,7 +53,7 @@ class IgnoreOracle(private val project: Project) {
 
   val isEditingIgnoredFile: Boolean
     get() {
-      return focusedPolicy == IgnorePolicy.IGNORE
+      return focusedPolicy == Ignore_TestResult.PolicyEnum.Ignore
     }
 
   fun focusedFileDidChange(uri: String) {
@@ -81,7 +77,7 @@ class IgnoreOracle(private val project: Project) {
   fun addListener(listener: FocusedFileIgnorePolicyListener) {
     synchronized(fileListeners) { fileListeners.add(listener) }
     // Invoke the listener with the focused file policy to set initial state.
-    listener.focusedFileIgnorePolicyChanged(focusedPolicy ?: IgnorePolicy.USE)
+    listener.focusedFileIgnorePolicyChanged(focusedPolicy ?: Ignore_TestResult.PolicyEnum.Use)
   }
 
   fun removeListener(listener: FocusedFileIgnorePolicyListener) {
@@ -103,8 +99,8 @@ class IgnoreOracle(private val project: Project) {
   }
 
   /** Gets whether `uri` should be ignored for autocomplete, context, etc. */
-  fun policyForUri(uri: String): CompletableFuture<IgnorePolicy> {
-    val completable = CompletableFuture<IgnorePolicy>()
+  fun policyForUri(uri: String): CompletableFuture<Ignore_TestResult.PolicyEnum> {
+    val completable = CompletableFuture<Ignore_TestResult.PolicyEnum>()
     val result = synchronized(cache) { cache[uri] }
     val cacheMaxAgeMsec = 60 * 1000
     if (result != null && result.timestampMsec > System.currentTimeMillis() - cacheMaxAgeMsec) {
@@ -118,23 +114,17 @@ class IgnoreOracle(private val project: Project) {
   }
 
   /** Like `policyForUri(String)` but reuses the current thread and supplied Agent handle. */
-  fun policyForUri(uri: String, agent: CodyAgent): CompletableFuture<IgnorePolicy> {
-    return agent.server.ignoreTest(IgnoreTestParams(uri)).thenApply {
-      val newPolicy =
-          when (it.policy) {
-            "ignore" -> IgnorePolicy.IGNORE
-            "use" -> IgnorePolicy.USE
-            else -> throw IllegalStateException("invalid ignore policy value")
-          }
+  fun policyForUri(uri: String, agent: CodyAgent): CompletableFuture<Ignore_TestResult.PolicyEnum> {
+    return agent.server.ignore_test(Ignore_TestParams(uri)).thenApply {
       synchronized(cache) {
-        cache.put(uri, CacheEntry(policy = newPolicy, timestampMsec = System.currentTimeMillis()))
+        cache.put(uri, CacheEntry(policy = it.policy, timestampMsec = System.currentTimeMillis()))
       }
-      newPolicy
+      it.policy
     }
   }
 
   /** Like `policyForUri(String)` but fetches the uri from the passed Editor's Document. */
-  fun policyForEditor(editor: Editor): IgnorePolicy? {
+  fun policyForEditor(editor: Editor): Ignore_TestResult.PolicyEnum? {
     val url = FileDocumentManager.getInstance().getFile(editor.document)?.url ?: return null
     val completable = policyForUri(url)
     return try {
@@ -146,7 +136,7 @@ class IgnoreOracle(private val project: Project) {
   }
 
   interface FocusedFileIgnorePolicyListener {
-    fun focusedFileIgnorePolicyChanged(policy: IgnorePolicy)
+    fun focusedFileIgnorePolicyChanged(policy: Ignore_TestResult.PolicyEnum)
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -16,7 +16,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.rows
 import com.intellij.ui.dsl.builder.selected
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
+import com.sourcegraph.cody.agent.protocol_generated.ContextFilters
 import javax.swing.JComponent
 
 data object IgnoreOverrideModel {
@@ -50,7 +50,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
             .bindText(IgnoreOverrideModel::policy)
             .validationInfo { textArea ->
               try {
-                Gson().fromJson(textArea.text, IgnorePolicySpec::class.java)
+                Gson().fromJson(textArea.text, ContextFilters::class.java)
                 null
               } catch (e: JsonSyntaxException) {
                 ValidationInfo("JSON error: ${e.message}", textArea)
@@ -63,9 +63,9 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
 
   override fun doOKAction() {
     CodyAgentService.withAgent(project) { agent ->
-      agent.server.testingIgnoreOverridePolicy(
+      agent.server.testing_ignore_overridePolicy(
           if (IgnoreOverrideModel.enabled) {
-            Gson().fromJson(IgnoreOverrideModel.policy, IgnorePolicySpec::class.java)
+            Gson().fromJson(IgnoreOverrideModel.policy, ContextFilters::class.java)
           } else {
             null
           })

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -12,9 +12,9 @@ import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
 import java.awt.Font
@@ -38,7 +38,8 @@ class CodySelectionInlayManager(val project: Project) {
         !ConfigUtil.isCodyUIHintsEnabled() ||
         !CodyEditorUtil.isEditorValidForAutocomplete(editor) ||
         CodyAuthenticationManager.getInstance().hasNoActiveAccount() ||
-        IgnoreOracle.getInstance(project).policyForEditor(editor) != IgnorePolicy.USE) {
+        IgnoreOracle.getInstance(project).policyForEditor(editor) !=
+            Ignore_TestResult.PolicyEnum.Use) {
       return
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
@@ -11,10 +11,10 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.WebviewDidDisposeParams
-import com.sourcegraph.cody.agent.WebviewReceiveMessageStringEncodedParams
 import com.sourcegraph.cody.agent.protocol.WebviewOptions
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_DidDisposeNativeParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ReceiveMessageStringEncodedParams
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ui.AccountConfigurable
 import com.sourcegraph.cody.config.ui.CodyConfigurable
@@ -98,8 +98,8 @@ internal class WebUIHostImpl(
       }
     } else {
       CodyAgentService.withAgent(project) {
-        it.server.webviewReceiveMessageStringEncoded(
-            WebviewReceiveMessageStringEncodedParams(handle, stringEncodedJsonMessage))
+        it.server.webview_receiveMessageStringEncoded(
+            Webview_ReceiveMessageStringEncodedParams(handle, stringEncodedJsonMessage))
       }
     }
   }
@@ -144,7 +144,7 @@ internal class WebUIHostImpl(
   override fun dispose() {
     // TODO: Consider cleaning up the view.
     CodyAgentService.withAgent(project) {
-      it.server.webviewDidDisposeNative(WebviewDidDisposeParams(handle))
+      it.server.webview_didDisposeNative(Webview_DidDisposeNativeParams(handle))
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.WebviewResolveWebviewViewParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ResolveWebviewViewParams
 
 /// A view that can host a browser component.
 private interface WebviewHost {
@@ -113,8 +113,8 @@ internal class WebviewViewManager(private val project: Project) {
 
     CodyAgentService.withAgent(project) {
       // TODO: https://code.visualstudio.com/api/references/vscode-api#WebviewViewProvider
-      it.server.webviewResolveWebviewView(
-          WebviewResolveWebviewViewParams(viewId = provider.id, webviewHandle = handle))
+      it.server.webview_resolveWebviewView(
+          Webview_ResolveWebviewViewParams(viewId = provider.id, webviewHandle = handle))
     }
   }
 }


### PR DESCRIPTION
This PR is a part of the protocol migration. Some endpoints are written by hand. We are switching to the protocol generated from Cody. In this PR:
- [Migrate editTask/*](https://github.com/sourcegraph/jetbrains/pull/2634/commits/8a164fab31f632299f5e6a660fccc0085a2291a8)
- [Migrate editCommands/code](https://github.com/sourcegraph/jetbrains/pull/2634/commits/c17f8e264be79bc498e8e5a80a56aaa9f9bb4ad0)
- [Migrate webview/*](https://github.com/sourcegraph/jetbrains/pull/2634/commits/a9e17a93106a43bd3bf54b007bc80496bc3589af)
- [Migrate chat/web/new](https://github.com/sourcegraph/jetbrains/pull/2634/commits/0fc6cf9fa69ccfeddb668bdccc50df62b0b06fd7)
- [Migrate ignore/test](https://github.com/sourcegraph/jetbrains/pull/2634/commits/a53943305b4188dc5f9bce8920ccd890cb85f366)
- [Migrate testing/*](https://github.com/sourcegraph/jetbrains/pull/2634/commits/dde28c8be104134621b3856f5ba0c26088757ca2)

<!-- start git-machete generated -->

# Based on PR #2633

## Full chain of PRs as of 2024-11-13

* PR #2634:
  `mkondratek/chore/migrate-api-part-3` ➔ `mkondratek/chore/migrate-api-part-2`
* PR #2633:
  `mkondratek/chore/migrate-api-part-2` ➔ `mkondratek/chore/migrate-api-part-1`
* PR #2632:
  `mkondratek/chore/migrate-api-part-1` ➔ `main`

<!-- end git-machete generated -->



## Test plan
- All migrated endpoints have been verified with debugger (and reviewed in the trace log).
- New chat action executed 🟢 
- Autocomplete tested 🟢 
- Inline Edits (including cancel, undo, retry, accept) tested 🟢 
- Chat tested 🟢 
- Closing/Opening the project, closing/opening files, closing/opening new chats tested 🟢 
- Swtiching account (dotcom -> enterprsise) tested 🟢
- Cody Ignore (with `CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true`) 🟢 
