### PR TITLE
Migrate editTask/*, editCommands/code, webview/*, chat/web/new

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,7 @@ dependencies {
 
   implementation("com.typesafe:config:1.4.3")
   implementation("org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.23.1")
+  testImplementation("net.java.dev.jna:jna:5.10.0") // it is needed for integration tests
   testImplementation("org.awaitility:awaitility-kotlin:4.2.2")
   testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.0.21")

--- a/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
+++ b/src/main/java/com/sourcegraph/cody/agent/WebviewPostMessageParams.kt
@@ -7,14 +7,7 @@ data class WebviewRegisterWebviewViewProviderParams(
     val retainContextWhenHidden: Boolean
 )
 
-data class WebviewResolveWebviewViewParams(val viewId: String, val webviewHandle: String)
-
 data class WebviewPostMessageStringEncodedParams(val id: String, val stringEncodedMessage: String)
-
-data class WebviewReceiveMessageStringEncodedParams(
-    val id: String,
-    val messageStringEncoded: String
-)
 
 data class WebviewSetHtmlParams(val handle: String, val html: String)
 
@@ -28,8 +21,5 @@ data class WebviewRevealParams(val handle: String, val viewColumn: Int, val pres
 
 // When the server initiates dispose, this is sent to the client.
 data class WebviewDisposeParams(val handle: String)
-
-// When the client initiates dispose, this is sent to the server.
-data class WebviewDidDisposeParams(val handle: String)
 
 data class ConfigFeatures(val serverSentModels: Boolean)

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -35,6 +35,9 @@ import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol_generated.ServerInfo
 import com.sourcegraph.cody.agent.protocol_generated.TextDocument_DidFocusParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_DidDisposeNativeParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ReceiveMessageStringEncodedParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ResolveWebviewViewParams
 import com.sourcegraph.cody.agent.protocol_generated.Window_DidChangeFocusParams
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
@@ -114,6 +117,14 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("editCommands/code")
   fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
 
+  @JsonRequest("webview/resolveWebviewView")
+  fun webview_resolveWebviewView(params: Webview_ResolveWebviewViewParams): CompletableFuture<Null?>
+
+  @JsonRequest("webview/receiveMessageStringEncoded")
+  fun webview_receiveMessageStringEncoded(
+      params: Webview_ReceiveMessageStringEncodedParams
+  ): CompletableFuture<Null?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -147,6 +158,9 @@ interface _SubsetGeneratedCodyAgentServer {
 
   @JsonNotification("window/didChangeFocus")
   fun window_didChangeFocus(params: Window_DidChangeFocusParams)
+
+  @JsonNotification("webview/didDisposeNative")
+  fun webview_didDisposeNative(params: Webview_DidDisposeNativeParams)
 }
 
 // TODO: Requests waiting to be migrated & tested for compatibility. Avoid placing new protocol
@@ -163,17 +177,6 @@ interface _LegacyAgentServer {
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
 
   @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
-
-  @JsonRequest("webview/receiveMessageStringEncoded")
-  fun webviewReceiveMessageStringEncoded(
-      params: WebviewReceiveMessageStringEncodedParams
-  ): CompletableFuture<Void?>
-
-  @JsonNotification("webview/didDisposeNative")
-  fun webviewDidDisposeNative(webviewDidDisposeParams: WebviewDidDisposeParams)
-
-  @JsonRequest("webview/resolveWebviewView")
-  fun webviewResolveWebviewView(params: WebviewResolveWebviewViewParams): CompletableFuture<Any>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -12,6 +12,7 @@ import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ImportParams
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsParams
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsResult
+import com.sourcegraph.cody.agent.protocol_generated.Chat_Web_NewResult
 import com.sourcegraph.cody.agent.protocol_generated.ClientInfo
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
@@ -125,6 +126,9 @@ interface _SubsetGeneratedCodyAgentServer {
       params: Webview_ReceiveMessageStringEncodedParams
   ): CompletableFuture<Null?>
 
+  @JsonRequest("chat/web/new")
+  fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -175,8 +179,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
 
   @JsonRequest("ignore/test")
   fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -102,6 +102,15 @@ interface _SubsetGeneratedCodyAgentServer {
       params: Null?
   ): CompletableFuture<CurrentUserCodySubscription?>
 
+  @JsonRequest("editTask/accept")
+  fun editTask_accept(params: EditTask_AcceptParams): CompletableFuture<Null?>
+
+  @JsonRequest("editTask/undo")
+  fun editTask_undo(params: EditTask_UndoParams): CompletableFuture<Null?>
+
+  @JsonRequest("editTask/cancel")
+  fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -149,15 +158,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/accept")
-  fun acceptEditTask(params: EditTask_AcceptParams): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/undo")
-  fun undoEditTask(params: EditTask_UndoParams): CompletableFuture<Void?>
-
-  @JsonRequest("editTask/cancel")
-  fun cancelEditTask(params: EditTask_CancelParams): CompletableFuture<Void?>
 
   @JsonRequest("editCommands/code")
   fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -5,7 +5,6 @@ package com.sourcegraph.cody.agent
 import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
 import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
 import com.sourcegraph.cody.agent.protocol.IgnoreTestResponse
-import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
@@ -21,6 +20,7 @@ import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
 import com.sourcegraph.cody.agent.protocol_generated.CurrentUserCodySubscription
 import com.sourcegraph.cody.agent.protocol_generated.CustomCommandResult
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
+import com.sourcegraph.cody.agent.protocol_generated.EditCommands_CodeParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_CancelParams
@@ -111,6 +111,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("editTask/cancel")
   fun editTask_cancel(params: EditTask_CancelParams): CompletableFuture<Null?>
 
+  @JsonRequest("editCommands/code")
+  fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -158,9 +161,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("editCommands/code")
-  fun commandsEdit(params: InlineEditParams): CompletableFuture<EditTask>
 
   @JsonRequest("chat/web/new") fun chatNew(): CompletableFuture<Any>
 

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/InlineEditParams.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/InlineEditParams.kt
@@ -1,3 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class InlineEditParams(val instruction: String, val model: String, val mode: String)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
@@ -8,7 +8,7 @@ import com.sourcegraph.common.ui.DumbAwareEDTAction
 
 class NewChatAction : DumbAwareEDTAction() {
   override fun actionPerformed(event: AnActionEvent) {
-    CodyAgentService.withAgent(event.project ?: return) { agent -> agent.server.chatNew() }
+    CodyAgentService.withAgent(event.project ?: return) { agent -> agent.server.chat_web_new(null) }
   }
 
   override fun update(event: AnActionEvent) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/EditCommandPrompt.kt
@@ -26,8 +26,8 @@ import com.intellij.util.concurrency.annotations.RequiresEdt
 import com.intellij.util.messages.MessageBusConnection
 import com.intellij.util.ui.JBUI
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.InlineEditParams
 import com.sourcegraph.cody.agent.protocol.ModelUsage
+import com.sourcegraph.cody.agent.protocol_generated.EditCommands_CodeParams
 import com.sourcegraph.cody.agent.protocol_generated.EditTask
 import com.sourcegraph.cody.agent.protocol_generated.EditTask_RetryParams
 import com.sourcegraph.cody.agent.protocol_generated.ModelAvailabilityStatus
@@ -416,7 +416,13 @@ class EditCommandPrompt(
                       previousEdit.selectionRange)
               agent.server.editTask_retry(params).get()
             } else {
-              agent.server.commandsEdit(InlineEditParams(text, currentModel, "edit")).get()
+              agent.server
+                  .editCommands_code(
+                      EditCommands_CodeParams(
+                          instruction = text,
+                          model = currentModel,
+                          mode = EditCommands_CodeParams.ModeEnum.Edit))
+                  .get()
             }
         EditCodeAction.completedEditTasks[result.id] = result
       }

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditAcceptAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditAcceptAction.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_AcceptParams
 class EditAcceptAction :
     LensEditAction({ project, _, _, taskId ->
       CodyAgentService.withAgent(project) {
-        it.server.acceptEditTask(EditTask_AcceptParams(taskId))
+        it.server.editTask_accept(EditTask_AcceptParams(taskId))
       }
     }) {
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditCancelAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditCancelAction.kt
@@ -6,7 +6,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_CancelParams
 class EditCancelAction :
     LensEditAction({ project, _, _, taskId ->
       CodyAgentService.withAgent(project) {
-        it.server.cancelEditTask(EditTask_CancelParams(taskId))
+        it.server.editTask_cancel(EditTask_CancelParams(taskId))
       }
     }) {
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditUndoAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/EditUndoAction.kt
@@ -5,7 +5,7 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
 
 class EditUndoAction :
     LensEditAction({ project, _, _, taskId ->
-      CodyAgentService.withAgent(project) { it.server.undoEditTask(EditTask_UndoParams(taskId)) }
+      CodyAgentService.withAgent(project) { it.server.editTask_undo(EditTask_UndoParams(taskId)) }
     }) {
   companion object {
     const val ID = "cody.fixup.codelens.undo"

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -48,7 +48,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
             .columns(40)
             .rows(15)
             .bindText(IgnoreOverrideModel::policy)
-            .validationInfo { textArea ->
+            .validationOnInput { textArea ->
               try {
                 Gson().fromJson(textArea.text, IgnorePolicySpec::class.java)
                 null
@@ -62,6 +62,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
   }
 
   override fun doOKAction() {
+    super.doOKAction()
     CodyAgentService.withAgent(project) { agent ->
       agent.server.testingIgnoreOverridePolicy(
           if (IgnoreOverrideModel.enabled) {
@@ -70,7 +71,6 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
             null
           })
     }
-    super.doOKAction()
   }
 }
 

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIHost.kt
@@ -11,10 +11,10 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.WebviewDidDisposeParams
-import com.sourcegraph.cody.agent.WebviewReceiveMessageStringEncodedParams
 import com.sourcegraph.cody.agent.protocol.WebviewOptions
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_DidDisposeNativeParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ReceiveMessageStringEncodedParams
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.config.ui.AccountConfigurable
 import com.sourcegraph.cody.config.ui.CodyConfigurable
@@ -98,8 +98,8 @@ internal class WebUIHostImpl(
       }
     } else {
       CodyAgentService.withAgent(project) {
-        it.server.webviewReceiveMessageStringEncoded(
-            WebviewReceiveMessageStringEncodedParams(handle, stringEncodedJsonMessage))
+        it.server.webview_receiveMessageStringEncoded(
+            Webview_ReceiveMessageStringEncodedParams(handle, stringEncodedJsonMessage))
       }
     }
   }
@@ -144,7 +144,7 @@ internal class WebUIHostImpl(
   override fun dispose() {
     // TODO: Consider cleaning up the view.
     CodyAgentService.withAgent(project) {
-      it.server.webviewDidDisposeNative(WebviewDidDisposeParams(handle))
+      it.server.webview_didDisposeNative(Webview_DidDisposeNativeParams(handle))
     }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebviewView.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.WebviewResolveWebviewViewParams
+import com.sourcegraph.cody.agent.protocol_generated.Webview_ResolveWebviewViewParams
 
 /// A view that can host a browser component.
 private interface WebviewHost {
@@ -113,8 +113,8 @@ internal class WebviewViewManager(private val project: Project) {
 
     CodyAgentService.withAgent(project) {
       // TODO: https://code.visualstudio.com/api/references/vscode-api#WebviewViewProvider
-      it.server.webviewResolveWebviewView(
-          WebviewResolveWebviewViewParams(viewId = provider.id, webviewHandle = handle))
+      it.server.webview_resolveWebviewView(
+          Webview_ResolveWebviewViewParams(viewId = provider.id, webviewHandle = handle))
     }
   }
 }


### PR DESCRIPTION
This PR is a part of the protocol migration. Some endpoints are written by hand. We are switching to the protocol generated from Cody. In this PR:
- [Migrate editTask/*](https://github.com/sourcegraph/jetbrains/pull/2637/commits/d897fc7cf2a6b4bf1c2025d7a72d20b23fa94a76)
- [Migrate editCommands/code](https://github.com/sourcegraph/jetbrains/pull/2637/commits/98bb04fb6f0497a09b0b670de645b91aa77e6fbb)
- [Migrate webview/*](https://github.com/sourcegraph/jetbrains/pull/2637/commits/2701d2d19260b3cacee3a0a51340b6a9d29566c6)
- [Migrate chat/web/new](https://github.com/sourcegraph/jetbrains/pull/2637/commits/521f21e99680ffedb5ca789e5a183a737af7c2cf)

## Test plan
- All migrated endpoints have been verified with debugger (and reviewed in the trace log).
- New chat action executed 🟢 
- Autocomplete tested 🟢 
- Inline Edits (including cancel, undo, retry, accept) tested 🟢 
- Chat tested 🟢 
- Closing/Opening the project, closing/opening files, closing/opening new chats tested 🟢 
- Swtiching account (dotcom -> enterprsise) tested 🟢
