### PR TITLE
Migrate ignore/test

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -3,8 +3,6 @@
 package com.sourcegraph.cody.agent
 
 import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
-import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
-import com.sourcegraph.cody.agent.protocol.IgnoreTestResponse
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
@@ -31,6 +29,8 @@ import com.sourcegraph.cody.agent.protocol_generated.EditTask_UndoParams
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
 import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
 import com.sourcegraph.cody.agent.protocol_generated.FeatureFlags_GetFeatureFlagParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.agent.protocol_generated.Null
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolAuthStatus
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
@@ -129,6 +129,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("chat/web/new")
   fun chat_web_new(params: Null?): CompletableFuture<Chat_Web_NewResult>
 
+  @JsonRequest("ignore/test")
+  fun ignore_test(params: Ignore_TestParams): CompletableFuture<Ignore_TestResult>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -179,9 +182,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("ignore/test")
-  fun ignoreTest(params: IgnoreTestParams): CompletableFuture<IgnoreTestResponse>
 
   @JsonRequest("testing/ignore/overridePolicy")
   fun testingIgnoreOverridePolicy(params: IgnorePolicySpec?): CompletableFuture<Unit>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -2,7 +2,6 @@
 
 package com.sourcegraph.cody.agent
 
-import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
 import com.sourcegraph.cody.agent.protocol.NetworkRequest
 import com.sourcegraph.cody.agent.protocol.TelemetryEvent
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
@@ -16,6 +15,7 @@ import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideParams
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_ProvideResult
 import com.sourcegraph.cody.agent.protocol_generated.CodeActions_TriggerParams
 import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
+import com.sourcegraph.cody.agent.protocol_generated.ContextFilters
 import com.sourcegraph.cody.agent.protocol_generated.CurrentUserCodySubscription
 import com.sourcegraph.cody.agent.protocol_generated.CustomCommandResult
 import com.sourcegraph.cody.agent.protocol_generated.Diagnostics_PublishParams
@@ -132,6 +132,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("ignore/test")
   fun ignore_test(params: Ignore_TestParams): CompletableFuture<Ignore_TestResult>
 
+  @JsonRequest("testing/ignore/overridePolicy")
+  fun testing_ignore_overridePolicy(params: ContextFilters?): CompletableFuture<Null?>
+
   //  // =============
   //  // Notifications
   //  // =============
@@ -182,9 +185,6 @@ interface _LegacyAgentServer {
 
   @JsonRequest("telemetry/recordEvent")
   fun recordEvent(event: TelemetryEvent): CompletableFuture<Void?>
-
-  @JsonRequest("testing/ignore/overridePolicy")
-  fun testingIgnoreOverridePolicy(params: IgnorePolicySpec?): CompletableFuture<Unit>
 
   @JsonRequest("testing/requestErrors")
   fun testingRequestErrors(): CompletableFuture<List<NetworkRequest>>

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,11 +1,5 @@
 package com.sourcegraph.cody.agent.protocol
 
-data class IgnoreTestParams(val uri: String)
-
-data class IgnoreTestResponse(
-    val policy: String // "use" or "ignore"
-)
-
 data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)
 
 data class IgnorePolicySpec(

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol/Ignore.kt
@@ -1,8 +1,0 @@
-package com.sourcegraph.cody.agent.protocol
-
-data class IgnorePolicyPattern(val repoNamePattern: String, val filePathPatterns: List<String>?)
-
-data class IgnorePolicySpec(
-    val exclude: List<IgnorePolicyPattern>?,
-    val include: List<IgnorePolicyPattern>?,
-)

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/Utils.kt
@@ -13,12 +13,12 @@ import com.sourcegraph.cody.agent.protocol_extensions.Position
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteParams
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.agent.protocol_generated.Position
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.cody.agent.protocol_generated.SelectedCompletionInfo
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.cody.statusbar.CodyStatus
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.notifyApplication
 import com.sourcegraph.cody.statusbar.CodyStatusService.Companion.resetApplication
@@ -81,7 +81,7 @@ object Utils {
     CodyAgentService.withAgent(project) { agent ->
       if (triggerKind == InlineCompletionTriggerKind.INVOKE &&
           IgnoreOracle.getInstance(project).policyForUri(virtualFile.url, agent).get() !=
-              IgnorePolicy.USE) {
+              Ignore_TestResult.PolicyEnum.Use) {
         ActionInIgnoredFileNotification.maybeNotify(project)
         resetApplication(project)
         resultOuter.cancel(true)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -10,10 +10,10 @@ import com.intellij.util.concurrency.AppExecutorUtil
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.commands.CommandId
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.concurrent.Callable
@@ -38,7 +38,7 @@ abstract class BaseCommandAction : DumbAwareEDTAction() {
           .expireWith(project)
           .finishOnUiThread(ModalityState.nonModal()) {
             when (it) {
-              IgnorePolicy.USE -> {
+              Ignore_TestResult.PolicyEnum.Use -> {
                 CodyAgentService.withAgent(project) { agent ->
                   agent.server.command_execute(
                       ExecuteCommandParams(

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
@@ -6,10 +6,10 @@ import com.intellij.openapi.editor.actionSystem.EditorAction
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.autocomplete.action.CodyAction
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.config.ConfigUtil
 
@@ -19,7 +19,8 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
   private fun isBlockedByPolicy(project: Project, event: AnActionEvent): Boolean {
     val editor = event.getData(com.intellij.openapi.actionSystem.CommonDataKeys.EDITOR)
     return editor != null &&
-        IgnoreOracle.getInstance(project).policyForEditor(editor) != IgnorePolicy.USE
+        IgnoreOracle.getInstance(project).policyForEditor(editor) !=
+            Ignore_TestResult.PolicyEnum.Use
   }
 
   private fun isCodyWorking(project: Project): Boolean {

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/IgnoreOracle.kt
@@ -11,18 +11,14 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.containers.SLRUMap
 import com.sourcegraph.cody.agent.CodyAgent
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.IgnoreTestParams
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestParams
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.utils.CodyEditorUtil
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
-
-enum class IgnorePolicy(val value: String) {
-  IGNORE("ignore"),
-  USE("use"),
-}
 
 /**
  * Provides details about whether files and repositories must be ignored as chat context, for
@@ -32,10 +28,10 @@ enum class IgnorePolicy(val value: String) {
 class IgnoreOracle(private val project: Project) {
   private val logger = Logger.getInstance(IgnoreOracle::class.java)
 
-  data class CacheEntry(val policy: IgnorePolicy, val timestampMsec: Long)
+  data class CacheEntry(val policy: Ignore_TestResult.PolicyEnum, val timestampMsec: Long)
 
   private val cache = SLRUMap<String, CacheEntry>(100, 100)
-  @Volatile private var focusedPolicy: IgnorePolicy? = null
+  @Volatile private var focusedPolicy: Ignore_TestResult.PolicyEnum? = null
   @Volatile private var willFocusUri: String? = null
   private val fileListeners: MutableList<FocusedFileIgnorePolicyListener> = mutableListOf()
   private val policyAwaitTimeoutMs = System.getProperty("cody.ignore.policy.timeout", "16").toLong()
@@ -57,7 +53,7 @@ class IgnoreOracle(private val project: Project) {
 
   val isEditingIgnoredFile: Boolean
     get() {
-      return focusedPolicy == IgnorePolicy.IGNORE
+      return focusedPolicy == Ignore_TestResult.PolicyEnum.Ignore
     }
 
   fun focusedFileDidChange(uri: String) {
@@ -81,7 +77,7 @@ class IgnoreOracle(private val project: Project) {
   fun addListener(listener: FocusedFileIgnorePolicyListener) {
     synchronized(fileListeners) { fileListeners.add(listener) }
     // Invoke the listener with the focused file policy to set initial state.
-    listener.focusedFileIgnorePolicyChanged(focusedPolicy ?: IgnorePolicy.USE)
+    listener.focusedFileIgnorePolicyChanged(focusedPolicy ?: Ignore_TestResult.PolicyEnum.Use)
   }
 
   fun removeListener(listener: FocusedFileIgnorePolicyListener) {
@@ -103,8 +99,8 @@ class IgnoreOracle(private val project: Project) {
   }
 
   /** Gets whether `uri` should be ignored for autocomplete, context, etc. */
-  fun policyForUri(uri: String): CompletableFuture<IgnorePolicy> {
-    val completable = CompletableFuture<IgnorePolicy>()
+  fun policyForUri(uri: String): CompletableFuture<Ignore_TestResult.PolicyEnum> {
+    val completable = CompletableFuture<Ignore_TestResult.PolicyEnum>()
     val result = synchronized(cache) { cache[uri] }
     val cacheMaxAgeMsec = 60 * 1000
     if (result != null && result.timestampMsec > System.currentTimeMillis() - cacheMaxAgeMsec) {
@@ -118,23 +114,17 @@ class IgnoreOracle(private val project: Project) {
   }
 
   /** Like `policyForUri(String)` but reuses the current thread and supplied Agent handle. */
-  fun policyForUri(uri: String, agent: CodyAgent): CompletableFuture<IgnorePolicy> {
-    return agent.server.ignoreTest(IgnoreTestParams(uri)).thenApply {
-      val newPolicy =
-          when (it.policy) {
-            "ignore" -> IgnorePolicy.IGNORE
-            "use" -> IgnorePolicy.USE
-            else -> throw IllegalStateException("invalid ignore policy value")
-          }
+  fun policyForUri(uri: String, agent: CodyAgent): CompletableFuture<Ignore_TestResult.PolicyEnum> {
+    return agent.server.ignore_test(Ignore_TestParams(uri)).thenApply {
       synchronized(cache) {
-        cache.put(uri, CacheEntry(policy = newPolicy, timestampMsec = System.currentTimeMillis()))
+        cache.put(uri, CacheEntry(policy = it.policy, timestampMsec = System.currentTimeMillis()))
       }
-      newPolicy
+      it.policy
     }
   }
 
   /** Like `policyForUri(String)` but fetches the uri from the passed Editor's Document. */
-  fun policyForEditor(editor: Editor): IgnorePolicy? {
+  fun policyForEditor(editor: Editor): Ignore_TestResult.PolicyEnum? {
     val url = FileDocumentManager.getInstance().getFile(editor.document)?.url ?: return null
     val completable = policyForUri(url)
     return try {
@@ -146,7 +136,7 @@ class IgnoreOracle(private val project: Project) {
   }
 
   interface FocusedFileIgnorePolicyListener {
-    fun focusedFileIgnorePolicyChanged(policy: IgnorePolicy)
+    fun focusedFileIgnorePolicyChanged(policy: Ignore_TestResult.PolicyEnum)
   }
 
   companion object {

--- a/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/internals/IgnoreOverrideAction.kt
@@ -16,7 +16,7 @@ import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.builder.rows
 import com.intellij.ui.dsl.builder.selected
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol.IgnorePolicySpec
+import com.sourcegraph.cody.agent.protocol_generated.ContextFilters
 import javax.swing.JComponent
 
 data object IgnoreOverrideModel {
@@ -50,7 +50,7 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
             .bindText(IgnoreOverrideModel::policy)
             .validationOnInput { textArea ->
               try {
-                Gson().fromJson(textArea.text, IgnorePolicySpec::class.java)
+                Gson().fromJson(textArea.text, ContextFilters::class.java)
                 null
               } catch (e: JsonSyntaxException) {
                 ValidationInfo("JSON error: ${e.message}", textArea)
@@ -64,9 +64,9 @@ class IgnoreOverrideDialog(val project: Project) : DialogWrapper(project) {
   override fun doOKAction() {
     super.doOKAction()
     CodyAgentService.withAgent(project) { agent ->
-      agent.server.testingIgnoreOverridePolicy(
+      agent.server.testing_ignore_overridePolicy(
           if (IgnoreOverrideModel.enabled) {
-            Gson().fromJson(IgnoreOverrideModel.policy, IgnorePolicySpec::class.java)
+            Gson().fromJson(IgnoreOverrideModel.policy, ContextFilters::class.java)
           } else {
             null
           })

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -12,9 +12,9 @@ import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.sourcegraph.cody.agent.CodyAgentService
+import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
 import com.sourcegraph.cody.config.CodyAuthenticationManager
 import com.sourcegraph.cody.ignore.IgnoreOracle
-import com.sourcegraph.cody.ignore.IgnorePolicy
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
 import java.awt.Font
@@ -38,7 +38,8 @@ class CodySelectionInlayManager(val project: Project) {
         !ConfigUtil.isCodyUIHintsEnabled() ||
         !CodyEditorUtil.isEditorValidForAutocomplete(editor) ||
         CodyAuthenticationManager.getInstance().hasNoActiveAccount() ||
-        IgnoreOracle.getInstance(project).policyForEditor(editor) != IgnorePolicy.USE) {
+        IgnoreOracle.getInstance(project).policyForEditor(editor) !=
+            Ignore_TestResult.PolicyEnum.Use) {
       return
     }
 


### PR DESCRIPTION
This PR is a part of the protocol migration. Some endpoints are written by hand. We are switching to the protocol generated from Cody. In this PR:
- [Migrate ignore/test](https://github.com/sourcegraph/jetbrains/pull/2638/commits/03a93bfb709f35500059445ea2a526829dce610b)


<!-- start git-machete generated -->

# Based on PR #2637

## Full chain of PRs as of 2024-11-13

* PR #2638:
  `mkondratek/chore/migrate-api-part-4` ➔ `mkondratek/chore/migrate-api-part-3x`
* PR #2637:
  `mkondratek/chore/migrate-api-part-3x` ➔ `main`

<!-- end git-machete generated -->



## Test plan
- All migrated endpoints have been verified with debugger (and reviewed in the trace log).
- Cody Ignore (with `CODY_JETBRAINS_FEATURES=cody.feature.internals-menu=true`) 🟢 
