### PR TITLE
chore/build: Roll Cody commit to 6ac4a8c1831ad3945fc16f20b8f21947897d3d14

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx4g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=c1923cdd292baf6cef0d8eb7af118b2afe3dda4b
+cody.commit=6ac4a8c1831ad3945fc16f20b8f21947897d3d14


### PR DESCRIPTION
Rolls the Cody commit to sourcegraph/cody@6ac4a8c1831ad3945fc16f20b8f21947897d3d14 which is the start of the vscode-v1.44.x release branch.

This commit will be the start of the jb-v7.2.x release branch.

## Test plan

CI