### PR TITLE
feat(rel): add backport GHA to Jetbrains

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,27 @@
+name: Backport
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    name: Backport
+    runs-on: ubuntu-latest
+    # Only react to merged PRs for security reasons.
+    # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
+    steps:
+      - uses: sourcegraph/backport@v2
+        with:
+          github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
+          label_pattern: '^backport (?<base>jetbrains-v\d+\.\d+\.x)$'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -24,4 +24,4 @@ jobs:
       - uses: sourcegraph/backport@v2
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
-          label_pattern: '^backport (?<base>jetbrains-v\d+\.\d+\.x)$'
+          label_pattern: '^backport (?<base>jb-v\d+\.\d+\.x)$'


### PR DESCRIPTION
Having tested backport functionality in the [Cody repo](https://github.com/sourcegraph/cody/pull/6119) I'm now adding it here too.

This PR adds a backport github action based our backport tooling in sourcegraph/backport
It uses the almost the same label as the Cody one, but with a slightly different base branch (backport jetbrains-v<version-number>). Notably, the `jetbrains-v<version-number>` branch doesn't appear to be the standard here, but I think we should adopt the same convention that is used in Cody.

## Test plan
CI
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->

