### PR TITLE
Propagate font settings from JetBrains to webview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx4g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=6ac4a8c1831ad3945fc16f20b8f21947897d3d14
+cody.commit=05cdd34e7dc7e7e7652e71140729dcbf2cb33a14

--- a/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ui/web/WebUIService.kt
@@ -1,6 +1,7 @@
 package com.sourcegraph.cody.ui.web
 
 import com.google.gson.JsonParser
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
@@ -31,7 +32,7 @@ internal data class WebUIProxyCreationGate(
 // - Pushes theme updates into Webviews.
 // - Routes postMessage from host to Webviews.
 @Service(Service.Level.PROJECT)
-class WebUIService(private val project: Project) {
+class WebUIService(private val project: Project) : Disposable {
   companion object {
     @JvmStatic fun getInstance(project: Project): WebUIService = project.service<WebUIService>()
   }
@@ -78,8 +79,8 @@ class WebUIService(private val project: Project) {
         }
       }
 
-  private var themeController =
-      WebThemeController().apply { setThemeChangeListener { updateTheme(it) } }
+  private val themeController =
+      WebThemeController(this).apply { setThemeChangeListener { updateTheme(it) } }
 
   private fun updateTheme(theme: WebTheme) {
     synchronized(proxies) {
@@ -164,4 +165,6 @@ class WebUIService(private val project: Project) {
   internal fun setTitle(handle: String, title: String) {
     withProxy(handle) { it.title = title }
   }
+
+  override fun dispose() {}
 }


### PR DESCRIPTION
Fixes:
https://linear.app/sourcegraph/issue/BUGS-462
https://linear.app/sourcegraph/issue/BUGS-342
https://linear.app/sourcegraph/issue/BUGS-220

## Test plan

1. Run this branch with https://github.com/sourcegraph/cody/pull/6134
2. Open Settings > Appearance
3. Tick `Use custom font` and change font size
4. Apply changes
5. You should notice that both editor and webview font size changed

![image](https://github.com/user-attachments/assets/d3411dcc-5b85-4e6b-a438-ad25dc099ea8)
