### PR TITLE
fix: don't add release team as reviewer for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -25,3 +25,4 @@ jobs:
         with:
           github_token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
           label_pattern: '^backport (?<base>jb-v\d+\.\d+\.x)$'
+          team_reviews: ''


### PR DESCRIPTION
Clone of the Cody PR #6136, so that we don't have failing backports

## Test plan
Tested on the [Cody repo](https://github.com/sourcegraph/cody/pull/6136)
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
