### PR TITLE
Fix incorrect cross-project event propagation

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/CodySettingsFileChangeListener.kt
@@ -1,16 +1,21 @@
 package com.sourcegraph.cody.config
 
 import com.intellij.openapi.editor.Document
-import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.fileEditor.FileDocumentManagerListener
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.config.ConfigUtil
+import com.sourcegraph.utils.CodyEditorUtil
 
 class CodySettingsFileChangeListener(private val project: Project) : FileDocumentManagerListener {
   override fun beforeDocumentSaving(document: Document) {
-    val currentFile = FileDocumentManager.getInstance().getFile(document)
+    val editor = CodyEditorUtil.getEditorForDocument(document) ?: return
+    if (editor.project != project) {
+      return
+    }
+
+    val currentFile = editor.virtualFile
     val configFile =
         LocalFileSystem.getInstance()
             .refreshAndFindFileByNioFile(ConfigUtil.getSettingsFile(project))

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/PostStartupActivity.kt
@@ -47,8 +47,11 @@ class PostStartupActivity : ProjectActivity {
 
     CodyStatusService.resetApplication(project)
 
-    val multicaster = EditorFactory.getInstance().eventMulticaster as EditorEventMulticasterEx
     val disposable = CodyAgentService.getInstance(project)
+
+    // WARNING: All listeners should check if an event they are receiving is matching project
+    // they were created for. Otherwise, we risk propagating events to the wrong agent instance.
+    val multicaster = EditorFactory.getInstance().eventMulticaster as EditorEventMulticasterEx
     multicaster.addFocusChangeListener(CodyFocusChangeListener(project), disposable)
     multicaster.addCaretListener(CodyCaretListener(project), disposable)
     multicaster.addSelectionListener(CodySelectionListener(project), disposable)

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyCaretListener.kt
@@ -15,7 +15,9 @@ import com.sourcegraph.utils.CodyEditorUtil
 
 class CodyCaretListener(val project: Project) : CaretListener {
   override fun caretPositionChanged(e: CaretEvent) {
-    if (!ConfigUtil.isCodyEnabled() || e.editor.editorKind != EditorKind.MAIN_EDITOR) {
+    if (!ConfigUtil.isCodyEnabled() ||
+        e.editor.editorKind != EditorKind.MAIN_EDITOR ||
+        e.editor.project != project) {
       return
     }
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyDocumentListener.kt
@@ -46,6 +46,10 @@ class CodyDocumentListener(val project: Project) : BulkAwareDocumentListener {
   private fun handleDocumentEvent(event: DocumentEvent) {
     val editor = CodyEditorUtil.getEditorForDocument(event.document) ?: return
 
+    if (editor.project != project) {
+      return
+    }
+
     logCodeCopyPastedFromChat(event)
     CodyAutocompleteManager.instance.clearAutocompleteSuggestions(editor)
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodyFocusChangeListener.kt
@@ -12,6 +12,10 @@ import com.sourcegraph.cody.ignore.IgnoreOracle
 class CodyFocusChangeListener(val project: Project) : FocusChangeListener {
 
   override fun focusGained(editor: Editor) {
+    if (editor.project != project) {
+      return
+    }
+
     ProtocolTextDocumentExt.fromEditor(editor)?.let { textDocument ->
       EditorChangesBus.documentChanged(project, textDocument)
       CodyAgentService.withAgent(project) { agent: CodyAgent ->


### PR DESCRIPTION
## Changes

Due to incorrect implementation of event listeners, if more than one project was open, events like caret change were propagated between editors. This PR fixes it.

## Test plan

Test separately with four different options ([opened file | active file | caret position |  selected text]):

1. Open two projects in IntelliJ.
2. Change [opened file | active file | caret position |  selected text] for the first project
3. Change [opened file | active file | caret position |  selected text] for the second project
4. Files set as context in the Cody chat should be different and match files activated on the previous steps.