### PR TITLE
bump commit to vscode-v1.46.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx4g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=5223b41852341d2c262db88d3b7ec11163c75092
+cody.commit=a36c585e66498747289bc87e551441c50cdd46c8


### PR DESCRIPTION
Uses the same commit as `jb-v7.3.x`, targets the [vscode-v1.46.x](https://github.com/sourcegraph/cody/commits/vscode-v1.46.x/) release branch

I probably did this in the wrong order, I should've bumped the commit on main and then cut the release branch 

## Test plan
N/A
<!-- All pull requests REQUIRE a test plan: https://sourcegraph.com/docs/dev/background-information/testing_principles

Why does it matter?

These test plans are there to demonstrate that are following industry standards which are important or critical for our customers.
They might be read by customers or an auditor. There are meant be simple and easy to read. Simply explain what you did to ensure
your changes are correct!

Here are a non exhaustive list of test plan examples to help you:

- Making changes on a given feature or component:
  - "Covered by existing tests" or "CI" for the shortest possible plan if there is zero ambiguity
  - "Added new tests"
  - "Manually tested" (if non trivial, share some output, logs, or screenshot)
- Updating docs:
  - "previewed locally"
  - share a screenshot if you want to be thorough
- Updating deps, that would typically fail immediately in CI if incorrect
  - "CI"
  - "locally tested"
-->
