### PR TITLE
Use `editCommands/document` instead of custom command

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/CodyAgentServer.kt
@@ -117,6 +117,9 @@ interface _SubsetGeneratedCodyAgentServer {
   @JsonRequest("editCommands/code")
   fun editCommands_code(params: EditCommands_CodeParams): CompletableFuture<EditTask>
 
+  @JsonRequest("editCommands/document")
+  fun editCommands_document(params: Null?): CompletableFuture<EditTask>
+
   @JsonRequest("webview/resolveWebviewView")
   fun webview_resolveWebviewView(params: Webview_ResolveWebviewViewParams): CompletableFuture<Null?>
 

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/DocumentCodeAction.kt
@@ -1,16 +1,13 @@
 package com.sourcegraph.cody.edit.actions
 
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.agent.protocol_generated.Commands_CustomParams
-import com.sourcegraph.cody.agent.protocol_generated.CustomEditCommandResult
 
 class DocumentCodeAction :
     BaseEditCodeAction({ editor ->
       editor.project?.let { project ->
         CodyAgentService.withAgent(project) { agent ->
-          val customCommandResult = agent.server.commands_custom(Commands_CustomParams("doc")).get()
-          val result = customCommandResult as? CustomEditCommandResult ?: return@withAgent
-          EditCodeAction.completedEditTasks[result.editResult.id] = result.editResult
+          val result = agent.server.editCommands_document(null).get()
+          EditCodeAction.completedEditTasks[result.id] = result
         }
       }
     }) {


### PR DESCRIPTION
By mistake I moved document code to custom commands API while moving test command. Most likely, we want to stick to the dedicated endpoint.

## Test plan
1. Document Code works
