### PR TITLE
Show cody console only in dev mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -476,8 +476,7 @@ tasks {
               "${layout.buildDirectory.asFile.get()}/sourcegraph/cody-agent-trace.json",
           "cody-agent.directory" to buildCodyDir.parent,
           "sourcegraph.verbose-logging" to "true",
-          "cody-agent.panic-when-out-of-sync" to
-              (System.getProperty("cody-agent.panic-when-out-of-sync") ?: "true"),
+          "cody-agent.is-dev-mode" to (System.getProperty("cody-agent.is-dev-mode") ?: "true"),
           "cody-agent.fullDocumentSyncEnabled" to
               (System.getProperty("cody-agent.fullDocumentSyncEnabled") ?: "false"),
           "cody.autocomplete.enableFormatting" to

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/ProtocolTextDocument.kt
@@ -15,6 +15,7 @@ import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocument
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolTextDocumentContentChangeEvent
 import com.sourcegraph.cody.agent.protocol_generated.Range
 import com.sourcegraph.cody.agent.protocol_generated.TestingParams
+import com.sourcegraph.config.ConfigUtil
 import java.awt.Point
 import java.nio.file.FileSystems
 import java.util.Locale
@@ -28,17 +29,18 @@ object ProtocolTextDocumentExt {
       selection: Range? = null,
       selectedText: String? = null
   ): TestingParams? {
-    if (!TestingParamsExt.doIncludeTestingParam) {
-      return null
+    if (ConfigUtil.isDevMode()) {
+      return TestingParams(
+          selectedText = selectedText,
+          sourceOfTruthDocument =
+              ProtocolTextDocument(
+                  uri = uri,
+                  content = content,
+                  selection = selection,
+              ))
     }
-    return TestingParams(
-        selectedText = selectedText,
-        sourceOfTruthDocument =
-            ProtocolTextDocument(
-                uri = uri,
-                content = content,
-                selection = selection,
-            ))
+
+    return null
   }
 
   @RequiresEdt

--- a/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/TestingParamsExt.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/agent/protocol_extensions/TestingParamsExt.kt
@@ -1,6 +1,0 @@
-package com.sourcegraph.cody.agent.protocol_extensions
-
-object TestingParamsExt {
-  val doIncludeTestingParam =
-      "true" == System.getProperty("cody-agent.panic-when-out-of-sync", "false")
-}

--- a/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/error/CodyConsole.kt
@@ -31,8 +31,12 @@ class CodyConsole(project: Project) {
         logger.info(messageText)
       }
 
-      if (ConfigUtil.isCodyDebugEnabled()) {
-        toolWindow?.contentManager?.getReady(this)?.doWhenDone { toolWindow.show() }
+      if (ConfigUtil.isCodyDebugEnabled() && ConfigUtil.isDevMode()) {
+        toolWindow?.contentManager?.getReady(this)?.doWhenDone {
+          if (!toolWindow.isVisible) {
+            toolWindow.show()
+          }
+        }
       }
     }
   }

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -178,6 +178,8 @@ object ConfigUtil {
 
   @JvmStatic fun isCodyDebugEnabled(): Boolean = CodyApplicationSettings.instance.isCodyDebugEnabled
 
+  @JvmStatic fun isDevMode(): Boolean = System.getProperty("cody-agent.is-dev-mode") == "true"
+
   @JvmStatic
   fun isCodyUIHintsEnabled(): Boolean = CodyApplicationSettings.instance.isCodyUIHintsEnabled
 


### PR DESCRIPTION
## Test plan

**Scenario 1**

Run new IJ instance using `:customRunIde` and make sure that:

a) When debug logging is disabled cody console does not show up during normal operations
b) When debug logging is enabled cody console show up after some time

**Scenario 2**

Build plugin and instal it by choosing zip package form disk. Make sure that:

a) When debug logging is disabled cody console does not show up during normal operations
b) When debug logging is enabled cody console **also does not show up**

