### PR TITLE
Fix cody autocomplete suggestions

### DIFF
--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -150,7 +150,7 @@ class CodyAutocompleteManager {
         isCommandExcluded(currentCommand)) {
       return
     }
-    if (CodyAccount.hasActiveAccount()) {
+    if (!CodyAccount.hasActiveAccount()) {
       if (isTriggeredExplicitly) {
         HintManager.getInstance().showErrorHint(editor, "Cody: Sign in to use autocomplete")
         CodyToolWindowContent.show(project)


### PR DESCRIPTION

Fixes https://linear.app/sourcegraph/issue/QA-182/jetbrains-autocomplete-is-not-working

## Test plan

With autocomplete enabled:

1. Open code file in IntelliJ
2. Start typing
3. Autocomplete suggestion should appear
4. Click Esc to dismiss it
5. Hit ⌥ Option + ⌘ Command + P to trigger autocomplete again
6. Autocomplete suggestion should appear


With autocomplete disabled:

1. Open code file in IntelliJ
2. Start typing
3. Autocomplete suggestion should NOT appear
4. 5. Hit ⌥ Option + ⌘ Command + P to trigger autocomplete
6. Autocomplete suggestion should NOT appear

