### PR TITLE
bump commit to vscode-v1.48.x

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ org.gradle.jvmargs=-Xmx4g -Xms500m
 nodeBinaries.commit=8755ae4c05fd476cd23f2972049111ba436c86d4
 nodeBinaries.version=v20.12.2
 cody.autocomplete.enableFormatting=true
-cody.commit=d5f24bc80a7685a39873ee3f41a54a6bf3e29295
+cody.commit=bb818530bd1200f6a1b26977d9f51ca38c04b3c1


### PR DESCRIPTION
Bump commit to [vscode-v1.48.x](https://github.com/sourcegraph/cody/commits/vscode-v1.48.x/)

## Test plan

N/A
