### PR TITLE
Store active account settings per project

### DIFF
--- a/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
+++ b/src/integrationTest/kotlin/com/sourcegraph/cody/util/CodyIntegrationTextFixture.kt
@@ -22,6 +22,7 @@ import com.intellij.testFramework.runInEdtAndWait
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.ProtocolCodeLens
 import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.auth.SourcegraphServerPath
 import com.sourcegraph.cody.edit.lenses.LensListener
 import com.sourcegraph.cody.edit.lenses.LensesService
@@ -94,11 +95,10 @@ open class CodyIntegrationTextFixture : BasePlatformTestCase(), LensListener {
   // change anything.
   private fun initCredentialsAndAgent() {
     val credentials = TestingCredentials.dotcom
-    val account = CodyAccount(SourcegraphServerPath.from(credentials.serverEndpoint, ""))
-    account.storeToken(
-        credentials.token ?: credentials.redactedToken,
-    )
-    CodyAccount.setActiveAccount(account)
+    val serverPath = SourcegraphServerPath.from(credentials.serverEndpoint, "")
+    val token = credentials.token ?: credentials.redactedToken
+    val account = CodyAccount(serverPath, token)
+    CodyAccountService.getInstance(project).setActiveAccount(account)
 
     assertNotNull(
         "Unable to start agent in a timely fashion!",

--- a/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
+++ b/src/main/java/com/sourcegraph/cody/CodyActionGroup.java
@@ -3,7 +3,8 @@ package com.sourcegraph.cody;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
-import com.sourcegraph.cody.auth.CodyAccount;
+import com.intellij.openapi.project.Project;
+import com.sourcegraph.cody.auth.CodyAccountService;
 import com.sourcegraph.config.ConfigUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,7 +23,12 @@ public class CodyActionGroup extends DefaultActionGroup {
   @Override
   public void update(@NotNull AnActionEvent e) {
     super.update(e);
+
+    Project project = e.getProject();
     e.getPresentation()
-        .setVisible(ConfigUtil.isCodyEnabled() && CodyAccount.Companion.hasActiveAccount());
+        .setVisible(
+            ConfigUtil.isCodyEnabled()
+                && project != null
+                && CodyAccountService.getInstance(project).isActivated());
   }
 }

--- a/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
+++ b/src/main/java/com/sourcegraph/config/CodyAuthNotificationActivity.java
@@ -10,7 +10,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.sourcegraph.Icons;
 import com.sourcegraph.cody.CodyToolWindowFactory;
-import com.sourcegraph.cody.auth.CodyAccount;
+import com.sourcegraph.cody.auth.CodyAccountService;
 import com.sourcegraph.cody.config.CodyApplicationSettings;
 import com.sourcegraph.cody.initialization.Activity;
 import com.sourcegraph.common.NotificationGroups;
@@ -22,7 +22,7 @@ public class CodyAuthNotificationActivity implements Activity {
   @Override
   public void runActivity(@NotNull Project project) {
     if (!CodyApplicationSettings.getInstance().isGetStartedNotificationDismissed()
-        && !CodyAccount.Companion.hasActiveAccount()) {
+        && !CodyAccountService.getInstance(project).isActivated()) {
       showOpenCodySidebarNotification(project);
     }
   }

--- a/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
+++ b/src/main/java/com/sourcegraph/find/browser/JSToJavaBridgeRequestHandler.java
@@ -42,7 +42,7 @@ public class JSToJavaBridgeRequestHandler {
     try {
       switch (action) {
         case "getConfig":
-          return createSuccessResponse(ConfigUtil.getConfigAsJson());
+          return createSuccessResponse(ConfigUtil.getConfigAsJson(project));
         case "getTheme":
           JsonObject currentThemeAsJson = ThemeUtil.getCurrentThemeAsJson();
           return createSuccessResponse(currentThemeAsJson);

--- a/src/main/java/com/sourcegraph/website/FileActionBase.java
+++ b/src/main/java/com/sourcegraph/website/FileActionBase.java
@@ -40,11 +40,13 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
     LogicalPosition selectionStartPosition = getSelectionStartPosition(editor);
     LogicalPosition selectionEndPosition = getSelectionEndPosition(editor);
 
+    URLBuilder urlBuilder = new URLBuilder(project);
+
     if (currentFile instanceof SourcegraphVirtualFile) {
       SourcegraphVirtualFile sourcegraphFile = (SourcegraphVirtualFile) currentFile;
       handleFileUri(
           project,
-          URLBuilder.buildSourcegraphBlobUrl(
+          urlBuilder.buildSourcegraphBlobUrl(
               sourcegraphFile.getRepoUrl(),
               sourcegraphFile.getCommit(),
               sourcegraphFile.getRelativePath(),
@@ -68,7 +70,7 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
                   // Our "editor" backend doesn't support Perforce, but we have all the info we
                   // need, so we'll go to the final URL directly.
                   url =
-                      URLBuilder.buildSourcegraphBlobUrl(
+                      urlBuilder.buildSourcegraphBlobUrl(
                           repoInfo.getCodeHostUrl() + "/" + repoInfo.getRepoName(),
                           null,
                           repoInfo.relativePath,
@@ -76,7 +78,7 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
                           selectionEndPosition);
                 } else {
                   url =
-                      URLBuilder.buildEditorFileUrl(
+                      urlBuilder.buildEditorFileUrl(
                           repoInfo.remoteUrl,
                           repoInfo.remoteBranchName,
                           repoInfo.relativePath,
@@ -102,12 +104,13 @@ public abstract class FileActionBase extends DumbAwareEDTAction {
 
     handleFileUri(
         project,
-        URLBuilder.buildSourcegraphBlobUrl(
-            previewContent.getRepoUrl(),
-            previewContent.getCommit(),
-            previewContent.getPath(),
-            start,
-            end));
+        new URLBuilder(project)
+            .buildSourcegraphBlobUrl(
+                previewContent.getRepoUrl(),
+                previewContent.getCommit(),
+                previewContent.getPath(),
+                start,
+                end));
   }
 
   @Nullable

--- a/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
+++ b/src/main/java/com/sourcegraph/website/OpenRevisionAction.java
@@ -89,7 +89,7 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
               try {
                 url =
                     URLBuilder.buildCommitUrl(
-                        ConfigUtil.getServerPath().getUrl(),
+                        ConfigUtil.getServerPath(project).getUrl(),
                         context.getRevisionNumber(),
                         remoteUrl,
                         productName,
@@ -97,7 +97,7 @@ public class OpenRevisionAction extends DumbAwareEDTAction {
               } catch (IllegalArgumentException e) {
                 logger.warn(
                     "Unable to build commit view URI for url "
-                        + ConfigUtil.getServerPath().getUrl()
+                        + ConfigUtil.getServerPath(project).getUrl()
                         + ", revision "
                         + context.getRevisionNumber()
                         + ", product "

--- a/src/main/java/com/sourcegraph/website/SearchActionBase.java
+++ b/src/main/java/com/sourcegraph/website/SearchActionBase.java
@@ -40,11 +40,12 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
     VirtualFile currentFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
     assert currentFile != null; // selectedText != null, so this can't be null.
 
+    URLBuilder urlBuilder = new URLBuilder(project);
     if (currentFile instanceof SourcegraphVirtualFile) {
       String url;
       SourcegraphVirtualFile sourcegraphFile = (SourcegraphVirtualFile) currentFile;
       String repoUrl = (scope == Scope.REPOSITORY) ? sourcegraphFile.getRepoUrl() : null;
-      url = URLBuilder.buildEditorSearchUrl(selectedText, repoUrl, null);
+      url = urlBuilder.buildEditorSearchUrl(selectedText, repoUrl, null);
       BrowserOpener.INSTANCE.openInBrowser(project, url);
     } else {
       // This cannot run on EDT (Event Dispatch Thread) because it may block for a long time.
@@ -62,9 +63,9 @@ public abstract class SearchActionBase extends DumbAwareEDTAction {
                   String codeHostUrl =
                       (scope == Scope.REPOSITORY) ? repoInfo.getCodeHostUrl() : null;
                   String repoName = (scope == Scope.REPOSITORY) ? repoInfo.getRepoName() : null;
-                  url = URLBuilder.buildDirectSearchUrl(selectedText, codeHostUrl, repoName);
+                  url = urlBuilder.buildDirectSearchUrl(selectedText, codeHostUrl, repoName);
                 } else {
-                  url = URLBuilder.buildEditorSearchUrl(selectedText, remoteUrl, remoteBranchName);
+                  url = urlBuilder.buildEditorSearchUrl(selectedText, remoteUrl, remoteBranchName);
                 }
                 BrowserOpener.INSTANCE.openInBrowser(project, url);
               });

--- a/src/main/java/com/sourcegraph/website/URLBuilder.java
+++ b/src/main/java/com/sourcegraph/website/URLBuilder.java
@@ -1,6 +1,7 @@
 package com.sourcegraph.website;
 
 import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.project.Project;
 import com.sourcegraph.common.RegexEscaper;
 import com.sourcegraph.config.ConfigUtil;
 import java.net.URI;
@@ -10,14 +11,20 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class URLBuilder {
+  Project project;
+
+  public URLBuilder(Project project) {
+    this.project = project;
+  }
+
   @NotNull
-  public static String buildEditorFileUrl(
+  public String buildEditorFileUrl(
       @NotNull String remoteUrl,
       @NotNull String branchName,
       @NotNull String relativePath,
       @Nullable LogicalPosition start,
       @Nullable LogicalPosition end) {
-    return ConfigUtil.getServerPath().getUrl()
+    return ConfigUtil.getServerPath(project).getUrl()
         + "-/editor"
         + "?remote_url="
         + URLEncoder.encode(remoteUrl, StandardCharsets.UTF_8)
@@ -42,10 +49,10 @@ public class URLBuilder {
   }
 
   @NotNull
-  public static String buildEditorSearchUrl(
+  public String buildEditorSearchUrl(
       @NotNull String search, @Nullable String remoteUrl, @Nullable String remoteBranchName) {
     String url =
-        ConfigUtil.getServerPath().getUrl()
+        ConfigUtil.getServerPath(project).getUrl()
             + "-/editor"
             + "?"
             + buildVersionParams()
@@ -63,13 +70,13 @@ public class URLBuilder {
   }
 
   @NotNull
-  public static String buildDirectSearchUrl(
+  public String buildDirectSearchUrl(
       @NotNull String search, @Nullable String codeHost, @Nullable String repoName) {
     String repoFilter =
         (codeHost != null && repoName != null)
             ? "repo:^" + RegexEscaper.INSTANCE.escapeRegexChars(codeHost + "/" + repoName) + "$"
             : null;
-    return ConfigUtil.getServerPath().getUrl()
+    return ConfigUtil.getServerPath(project).getUrl()
         + "/search"
         + "?patternType=literal"
         + "&q="
@@ -117,13 +124,13 @@ public class URLBuilder {
 
   @NotNull
   // repoUrl should be like "github.com/sourcegraph/sourcegraph"
-  public static String buildSourcegraphBlobUrl(
+  public String buildSourcegraphBlobUrl(
       @NotNull String repoUrl,
       @Nullable String commit,
       @NotNull String path,
       @Nullable LogicalPosition start,
       @Nullable LogicalPosition end) {
-    return ConfigUtil.getServerPath().getUrl()
+    return ConfigUtil.getServerPath(project).getUrl()
         + repoUrl
         + (commit != null ? "@" + commit : "")
         + "/-/blob/"

--- a/src/main/kotlin/com/sourcegraph/cody/auth/CodyAccount.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/CodyAccount.kt
@@ -1,50 +1,7 @@
 package com.sourcegraph.cody.auth
 
-import com.intellij.credentialStore.CredentialAttributes
-import com.intellij.credentialStore.Credentials
-import com.intellij.credentialStore.generateServiceName
-import com.intellij.ide.passwordSafe.PasswordSafe
 import com.sourcegraph.config.ConfigUtil
 
-data class CodyAccount(val server: SourcegraphServerPath) {
-
+data class CodyAccount(val server: SourcegraphServerPath, val token: String?) {
   fun isDotcomAccount(): Boolean = server.url.lowercase().startsWith(ConfigUtil.DOTCOM_URL)
-
-  fun getToken(): String? {
-    return PasswordSafe.instance.get(credentialAttributes(server.url))?.getPasswordAsString()
-  }
-
-  fun storeToken(token: String?) {
-    PasswordSafe.instance.set(credentialAttributes(server.url), Credentials(user = "", token))
-  }
-
-  companion object {
-    private const val ACTIVE_ACCOUNT_MARKER = "active_cody_account"
-
-    @Volatile private var isActivated: Boolean = false
-
-    private fun credentialAttributes(key: String): CredentialAttributes =
-        CredentialAttributes(generateServiceName("Sourcegraph", key))
-
-    fun hasActiveAccount(): Boolean {
-      return isActivated && getActiveAccount() != null
-    }
-
-    fun setActivated(isActivated: Boolean) {
-      this.isActivated = isActivated
-    }
-
-    fun getActiveAccount(): CodyAccount? {
-      val serverUrl =
-          PasswordSafe.instance
-              .get(credentialAttributes(ACTIVE_ACCOUNT_MARKER))
-              ?.getPasswordAsString()
-      return if (serverUrl == null) null else CodyAccount(SourcegraphServerPath(serverUrl))
-    }
-
-    fun setActiveAccount(account: CodyAccount?) {
-      PasswordSafe.instance.set(
-          credentialAttributes(ACTIVE_ACCOUNT_MARKER), Credentials(user = "", account?.server?.url))
-    }
-  }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/auth/CodyAccountService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/CodyAccountService.kt
@@ -1,0 +1,56 @@
+package com.sourcegraph.cody.auth
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import com.sourcegraph.cody.auth.CodySecureStore.getFromSecureStore
+import com.sourcegraph.cody.auth.CodySecureStore.writeToSecureStore
+
+@Service(Service.Level.PROJECT)
+class CodyAccountService(val project: Project) {
+  private val activeAccountMarker = "active_cody_account"
+  private val projectActiveAccountMarker = project.locationHash
+  private var activeAccount: CodyAccount? = null
+
+  @Volatile private var isActivated: Boolean = false
+
+  fun isActivated(): Boolean {
+    return isActivated
+  }
+
+  fun setActivated(isActivated: Boolean) {
+    this.isActivated = isActivated
+  }
+
+  fun loadAccount(serverUrl: String): CodyAccount {
+    val token = serverUrl.let { getFromSecureStore(it) }
+    return CodyAccount(SourcegraphServerPath(serverUrl), token)
+  }
+
+  fun storeAccount(account: CodyAccount) {
+    writeToSecureStore(account.server.url, account.token)
+  }
+
+  fun getActiveAccount(): CodyAccount? {
+    if (activeAccount == null) {
+      val serverUrl =
+          getFromSecureStore(projectActiveAccountMarker) ?: getFromSecureStore(activeAccountMarker)
+      activeAccount = if (serverUrl == null) null else loadAccount(serverUrl)
+    }
+
+    return activeAccount
+  }
+
+  fun setActiveAccount(account: CodyAccount) {
+    storeAccount(account)
+    writeToSecureStore(activeAccountMarker, account.server.url)
+    writeToSecureStore(projectActiveAccountMarker, account.server.url)
+  }
+
+  companion object {
+    @JvmStatic
+    fun getInstance(project: Project): CodyAccountService {
+      return project.service<CodyAccountService>()
+    }
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/auth/CodySecureStore.kt
@@ -1,0 +1,19 @@
+package com.sourcegraph.cody.auth
+
+import com.intellij.credentialStore.CredentialAttributes
+import com.intellij.credentialStore.Credentials
+import com.intellij.credentialStore.generateServiceName
+import com.intellij.ide.passwordSafe.PasswordSafe
+
+object CodySecureStore {
+  private fun credentialAttributes(key: String): CredentialAttributes =
+      CredentialAttributes(generateServiceName("Sourcegraph", key))
+
+  fun getFromSecureStore(key: String): String? {
+    return PasswordSafe.instance.get(credentialAttributes(key))?.getPasswordAsString()
+  }
+
+  fun writeToSecureStore(key: String, value: String?) {
+    PasswordSafe.instance.set(credentialAttributes(key), Credentials(user = "", value))
+  }
+}

--- a/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/autocomplete/CodyAutocompleteManager.kt
@@ -27,7 +27,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteItem
 import com.sourcegraph.cody.agent.protocol_generated.AutocompleteResult
 import com.sourcegraph.cody.agent.protocol_generated.CompletionItemParams
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.autocomplete.Utils.triggerAutocompleteAsync
 import com.sourcegraph.cody.autocomplete.render.AutocompleteRendererType
 import com.sourcegraph.cody.autocomplete.render.CodyAutocompleteBlockElementRenderer
@@ -150,7 +150,7 @@ class CodyAutocompleteManager {
         isCommandExcluded(currentCommand)) {
       return
     }
-    if (!CodyAccount.hasActiveAccount()) {
+    if (!CodyAccountService.getInstance(project).isActivated()) {
       if (isTriggeredExplicitly) {
         HintManager.getInstance().showErrorHint(editor, "Cody: Sign in to use autocomplete")
         CodyToolWindowContent.show(project)

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/BaseCommandAction.kt
@@ -11,7 +11,7 @@ import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_extensions.ProtocolTextDocumentExt
 import com.sourcegraph.cody.agent.protocol_generated.ExecuteCommandParams
 import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
-import com.sourcegraph.cody.auth.CodyAccount.Companion.hasActiveAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.commands.CommandId
 import com.sourcegraph.cody.ignore.ActionInIgnoredFileNotification
 import com.sourcegraph.cody.ignore.IgnoreOracle
@@ -30,7 +30,9 @@ abstract class BaseCommandAction : DumbAwareEDTAction() {
 
   override fun update(e: AnActionEvent) {
     super.update(e)
-    e.presentation.isVisible = isCodyEnabled() && hasActiveAccount()
+    val project = e.project
+    e.presentation.isVisible =
+        isCodyEnabled() && project != null && CodyAccountService.getInstance(project).isActivated()
   }
 
   open fun doAction(project: Project) {

--- a/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/actions/NewChatAction.kt
@@ -2,7 +2,7 @@ package com.sourcegraph.cody.chat.actions
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.common.CodyBundle
 import com.sourcegraph.common.ui.DumbAwareEDTAction
 
@@ -12,7 +12,9 @@ class NewChatAction : DumbAwareEDTAction() {
   }
 
   override fun update(event: AnActionEvent) {
-    event.presentation.isEnabled = CodyAccount.hasActiveAccount()
+    val project = event.project
+    event.presentation.isEnabled =
+        project != null && CodyAccountService.getInstance(project).isActivated()
     if (!event.presentation.isEnabled) {
       event.presentation.description =
           CodyBundle.getString("action.sourcegraph.disabled.description")

--- a/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/chat/ui/LlmDropdown.kt
@@ -14,7 +14,7 @@ import com.sourcegraph.cody.agent.protocol_extensions.isDeprecated
 import com.sourcegraph.cody.agent.protocol_generated.Chat_ModelsParams
 import com.sourcegraph.cody.agent.protocol_generated.Model
 import com.sourcegraph.cody.agent.protocol_generated.ModelAvailabilityStatus
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.auth.SourcegraphServerPath
 import com.sourcegraph.cody.edit.EditCommandPrompt
 import com.sourcegraph.cody.ui.LlmComboBoxRenderer
@@ -69,7 +69,8 @@ class LlmDropdown(
     val availableModels = models.map { it }.filterNot { it.model.isDeprecated() }
     availableModels.sortedBy { it.model.isCodyProOnly() }.forEach { addItem(it) }
 
-    val defaultLlm = serverToRecentModel[CodyAccount.getActiveAccount()?.server]
+    val account = CodyAccountService.getInstance(project).getActiveAccount()
+    val defaultLlm = serverToRecentModel[account?.server]
 
     selectedItem =
         availableModels.find { it.model.id == fixedModel || it.model.id == defaultLlm?.id }
@@ -96,7 +97,8 @@ class LlmDropdown(
         return
       }
 
-      CodyAccount.getActiveAccount()?.server?.also { serverToRecentModel[it] = modelProvider.model }
+      val account = CodyAccountService.getInstance(project).getActiveAccount()
+      account?.server?.also { serverToRecentModel[it] = modelProvider.model }
 
       super.setSelectedItem(anObject)
       onSetSelectedItem(modelProvider.model)

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/AccountsMigration.kt
@@ -1,18 +1,24 @@
 package com.sourcegraph.cody.config.migration
 
+import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.auth.deprecated.DeprecatedCodyAccountManager
 
 object AccountsMigration {
-  fun migrate() {
+  fun migrate(project: Project) {
     val codyAccountManager = DeprecatedCodyAccountManager.getInstance()
     codyAccountManager.getAccounts().forEach { oldAccount ->
       val token = codyAccountManager.getTokenForAccount(oldAccount)
       if (token != null) {
-        CodyAccount(oldAccount.server).storeToken(token)
+        val account = CodyAccount(oldAccount.server, token)
+        CodyAccountService.getInstance(project).setActiveAccount(account)
       }
     }
 
-    codyAccountManager.account?.server?.let { CodyAccount.setActiveAccount(CodyAccount(it)) }
+    codyAccountManager.account?.server?.let {
+      val account = CodyAccountService.getInstance(project).loadAccount(it.url)
+      CodyAccountService.getInstance(project).setActiveAccount(account)
+    }
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/migration/SettingsMigration.kt
@@ -70,7 +70,7 @@ class SettingsMigration : Activity {
       ChatHistoryMigration.migrate(project)
     }
     RunOnceUtil.runOnceForProject(project, "AccountsToCodyMigration") {
-      AccountsMigration.migrate()
+      AccountsMigration.migrate(project)
     }
   }
 

--- a/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/config/notification/CodySettingChangeListener.kt
@@ -20,7 +20,7 @@ class CodySettingChangeListener(project: Project) : ChangeListener(project) {
         object : CodySettingChangeActionNotifier {
           override fun afterAction(context: CodySettingChangeContext) {
             // Notify JCEF about the config changes
-            javaToJSBridge?.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson())
+            javaToJSBridge?.callJS("pluginSettingsChanged", ConfigUtil.getConfigAsJson(project))
 
             if (context.oldCodyEnabled != context.newCodyEnabled) {
               if (context.newCodyEnabled) {

--- a/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/actions/BaseEditCodeAction.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.project.Project
 import com.sourcegraph.cody.CodyToolWindowContent
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.autocomplete.action.CodyAction
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.common.CodyBundle
@@ -39,7 +39,7 @@ open class BaseEditCodeAction(runAction: (Editor) -> Unit) :
           false to CodyBundle.getString("action.cody.not-working")
         } else if (isBlockedByPolicy(project, event)) {
           false to CodyBundle.getString("filter.action-in-ignored-file.detail")
-        } else if (!CodyAccount.hasActiveAccount()) {
+        } else if (!CodyAccountService.getInstance(project).isActivated()) {
           false to CodyBundle.getString("action.sourcegraph.disabled.description")
         } else {
           true to ""

--- a/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/LensEditAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/edit/lenses/actions/LensEditAction.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.edit.lenses.LensesService
 import com.sourcegraph.common.CodyBundle
 
@@ -22,7 +22,9 @@ abstract class LensEditAction(val editAction: (Project, AnActionEvent, Editor, S
   }
 
   override fun update(event: AnActionEvent) {
-    event.presentation.isEnabled = CodyAccount.hasActiveAccount()
+    val project = event.project
+    event.presentation.isEnabled =
+        project != null && CodyAccountService.getInstance(project).isActivated()
     if (!event.presentation.isEnabled) {
       event.presentation.description =
           CodyBundle.getString("action.sourcegraph.disabled.description")

--- a/src/main/kotlin/com/sourcegraph/cody/ignore/ActionInIgnoredFileNotification.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/ignore/ActionInIgnoredFileNotification.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.sourcegraph.Icons
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.statusbar.CodyStatus
 import com.sourcegraph.cody.statusbar.CodyStatusService
 import com.sourcegraph.common.CodyBundle
@@ -31,7 +31,7 @@ class ActionInIgnoredFileNotification :
 
     fun maybeNotify(project: Project) {
       val status = CodyStatusService.getCurrentStatus(project)
-      val account = CodyAccount.getActiveAccount()
+      val account = CodyAccountService.getInstance(project).getActiveAccount()
       when {
         status == CodyStatus.CodyUninit ||
             status == CodyStatus.CodyDisabled ||

--- a/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/initialization/EndOfTrialNotificationScheduler.kt
@@ -9,7 +9,7 @@ import com.sourcegraph.cody.agent.protocol.GetFeatureFlag
 import com.sourcegraph.cody.agent.protocol_extensions.isPendingStatus
 import com.sourcegraph.cody.agent.protocol_extensions.isProPlan
 import com.sourcegraph.cody.agent.protocol_generated.CurrentUserCodySubscription
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.config.ConfigUtil
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -31,7 +31,8 @@ class EndOfTrialNotificationScheduler private constructor(val project: Project) 
             this.dispose()
           }
 
-          if (CodyAccount.getActiveAccount()?.isDotcomAccount() != true) {
+          if (CodyAccountService.getInstance(project).getActiveAccount()?.isDotcomAccount() !=
+              true) {
             return@scheduleAtFixedRate
           }
 

--- a/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/listeners/CodySelectionInlayManager.kt
@@ -13,7 +13,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.sourcegraph.cody.agent.CodyAgentService
 import com.sourcegraph.cody.agent.protocol_generated.Ignore_TestResult
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.config.ConfigUtil
 import com.sourcegraph.utils.CodyEditorUtil
@@ -37,7 +37,7 @@ class CodySelectionInlayManager(val project: Project) {
         !CodyAgentService.isConnected(project) ||
         !ConfigUtil.isCodyUIHintsEnabled() ||
         !CodyEditorUtil.isEditorValidForAutocomplete(editor) ||
-        !CodyAccount.hasActiveAccount() ||
+        !CodyAccountService.getInstance(project).isActivated() ||
         IgnoreOracle.getInstance(project).policyForEditor(editor) !=
             Ignore_TestResult.PolicyEnum.Use) {
       return

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableAutocompleteAction.kt
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
@@ -15,9 +15,11 @@ class CodyDisableAutocompleteAction : DumbAwareEDTAction("Disable Cody Autocompl
 
   override fun update(e: AnActionEvent) {
     super.update(e)
+    val project = e.project
     e.presentation.isEnabledAndVisible =
         ConfigUtil.isCodyEnabled() &&
+            project != null &&
             ConfigUtil.isCodyAutocompleteEnabled() &&
-            CodyAccount.hasActiveAccount()
+            CodyAccountService.getInstance(project).isActivated()
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyDisableLanguageForAutocompleteAction.kt
@@ -1,7 +1,7 @@
 package com.sourcegraph.cody.statusbar
 
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.autocomplete.CodyAutocompleteManager
 import com.sourcegraph.cody.config.CodyApplicationSettings
 import com.sourcegraph.common.ui.DumbAwareEDTAction
@@ -25,12 +25,14 @@ class CodyDisableLanguageForAutocompleteAction : DumbAwareEDTAction() {
     val isLanguageBlacklisted =
         languageForFocusedEditor?.let { CodyLanguageUtil.isLanguageBlacklisted(it) } ?: false
     val languageName = languageForFocusedEditor?.displayName ?: ""
+    val project = e.project
     e.presentation.isEnabledAndVisible =
         languageForFocusedEditor != null &&
             ConfigUtil.isCodyEnabled() &&
             ConfigUtil.isCodyAutocompleteEnabled() &&
+            project != null &&
             !isLanguageBlacklisted &&
-            CodyAccount.hasActiveAccount()
+            CodyAccountService.getInstance(project).isActivated()
     e.presentation.text = "Disable Cody Autocomplete for $languageName"
   }
 }

--- a/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusService.kt
+++ b/src/main/kotlin/com/sourcegraph/cody/statusbar/CodyStatusService.kt
@@ -8,7 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.util.ui.UIUtil
 import com.sourcegraph.cody.agent.CodyAgentService
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.ignore.IgnoreOracle
 import com.sourcegraph.common.UpgradeToCodyProNotification
 import com.sourcegraph.config.ConfigUtil
@@ -55,7 +55,7 @@ class CodyStatusService(val project: Project) : Disposable {
             CodyStatus.AgentError
           } else if (!CodyAgentService.isConnected(project)) {
             CodyStatus.CodyAgentNotRunning
-          } else if (!CodyAccount.hasActiveAccount()) {
+          } else if (!CodyAccountService.getInstance(project).isActivated()) {
             CodyStatus.CodyNotSignedIn
           } else if (UpgradeToCodyProNotification.autocompleteRateLimitError.get() != null ||
               UpgradeToCodyProNotification.chatRateLimitError.get() != null) {

--- a/src/main/kotlin/com/sourcegraph/common/BrowserOpener.kt
+++ b/src/main/kotlin/com/sourcegraph/common/BrowserOpener.kt
@@ -12,7 +12,7 @@ import java.net.URISyntaxException
 
 object BrowserOpener {
   fun openRelativeUrlInBrowser(project: Project, relativeUrl: String) {
-    openInBrowser(project, getServerPath().url + "/" + relativeUrl)
+    openInBrowser(project, getServerPath(project).url + "/" + relativeUrl)
   }
 
   fun openInBrowser(project: Project?, absoluteUrl: String) {

--- a/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
+++ b/src/main/kotlin/com/sourcegraph/config/ConfigUtil.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.sourcegraph.cody.agent.protocol_generated.ExtensionConfiguration
-import com.sourcegraph.cody.auth.CodyAccount
+import com.sourcegraph.cody.auth.CodyAccountService
 import com.sourcegraph.cody.auth.SourcegraphServerPath
 import com.sourcegraph.cody.auth.SourcegraphServerPath.Companion.from
 import com.sourcegraph.cody.config.CodyApplicationSettings
@@ -92,12 +92,12 @@ object ConfigUtil {
       project: Project,
       customConfigContent: String? = null
   ): ExtensionConfiguration {
-    val account = CodyAccount.getActiveAccount()
+    val account = CodyAccountService.getInstance(project).getActiveAccount()
 
     return ExtensionConfiguration(
         anonymousUserID = CodyApplicationSettings.instance.anonymousUserId,
         serverEndpoint = account?.server?.url ?: "",
-        accessToken = account?.getToken() ?: "",
+        accessToken = account?.token ?: "",
         customHeaders = emptyMap(),
         proxy = UserLevelConfig.getProxy(),
         autocompleteAdvancedProvider =
@@ -109,11 +109,11 @@ object ConfigUtil {
   }
 
   @JvmStatic
-  fun getConfigAsJson(): JsonObject {
-    val account = CodyAccount.getActiveAccount()
+  fun getConfigAsJson(project: Project): JsonObject {
+    val account = CodyAccountService.getInstance(project).getActiveAccount()
     return JsonObject().apply {
       addProperty("instanceURL", account?.server?.url)
-      addProperty("accessToken", account?.getToken())
+      addProperty("accessToken", account?.token)
       addProperty("customRequestHeadersAsString", "")
       addProperty("pluginVersion", getPluginVersion())
       addProperty("anonymousUserId", CodyApplicationSettings.instance.anonymousUserId)
@@ -121,8 +121,8 @@ object ConfigUtil {
   }
 
   @JvmStatic
-  fun getServerPath(): SourcegraphServerPath {
-    val activeAccount = CodyAccount.getActiveAccount()
+  fun getServerPath(project: Project): SourcegraphServerPath {
+    val activeAccount = CodyAccountService.getInstance(project).getActiveAccount()
     return activeAccount?.server ?: from(DOTCOM_URL, "")
   }
 


### PR DESCRIPTION
Fixes https://linear.app/sourcegraph/issue/QA-188/jetbrains-adding-password-in-keychain-will-logout-user-when-same

## Changes

There is a lot of cosmetic changes due to slightly different interfaces but main changes are there:
https://github.com/sourcegraph/jetbrains/pull/2817/files#diff-56b9b0d56648edfc3a3154ee5357aeaa891fb834b049e5eb0fb1da4a2eff5c2f

This PR changes the way account settings are stored.
Instead of having one settings shared by all cody clients we keep them separated per project.
This simplifies synchronisation between instance (as it is not needed) and is more in-line with model where each agent is separate being. I believe it is also more intuitive to the users.

## Test plan

TBD